### PR TITLE
Fix #174 and #173

### DIFF
--- a/ehrapy/api/anndata_ext.py
+++ b/ehrapy/api/anndata_ext.py
@@ -37,8 +37,8 @@ def df_to_anndata(
     # see: https://stackoverflow.com/questions/25480089/right-way-to-initialize-an-ordereddict-using-its-constructor-such-that-it-retain/25480206
     uns = OrderedDict()
     # store all numerical/non-numerical columns that are not obs only
-    uns["numerical_columns"] = list(df.select_dtypes("number").columns)
-    uns["non_numerical_columns"] = list(set(df.columns) ^ set(uns["numerical_columns"]))
+    uns["numerical_columns"] = list(dataframes.df.select_dtypes("number").columns)
+    uns["non_numerical_columns"] = list(set(dataframes.df.columns) ^ set(uns["numerical_columns"]))
     return AnnData(
         X=X,
         obs=dataframes.obs,
@@ -138,7 +138,7 @@ def get_column_values(adata: AnnData, indices: int | list[int]) -> np.ndarray:
 
 def assert_encoded(adata: AnnData):
     try:
-        assert any(enc_flag in adata.uns_keys() for enc_flag in ["categoricals", "encoding_to_var"])
+        assert np.issubdtype(adata.X.dtype, np.number)
     except AssertionError:
         raise NotEncodedError("The AnnData object has not yet been encoded.") from AssertionError
 


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [x] This comment contains a description of changes (with reason)
-   [x] Referenced issue is linked

**Description of changes**

<!-- Please state what you've changed and how it might affect the user. -->

- fixed an issue that stored vars in uns["non_numerical_columns"] or uns["numerical_columns"] that where obs only

- fixed an issue that caused assert_encode to raise an error when an adata object has not been encoded yet (and does not need to be)