### PR TITLE
[FEATURE] #314: Autodetect binary (0,1) columns

### DIFF
--- a/ehrapy/anndata/anndata_ext.py
+++ b/ehrapy/anndata/anndata_ext.py
@@ -470,15 +470,14 @@ def _update_uns(
 
 
 def _detect_binary_columns(df: pd.DataFrame, numerical_columns: list[str]) -> list[str]:
-    """
-    Detect all columns that contain only 0 and 1 (besides NaNs)
+    """Detect all columns that contain only 0 and 1 (besides NaNs).
 
     Args:
-        df: The dataframe to check
-        numerical_columns: All numerical columns of df
+        df: The dataframe to check.
+        numerical_columns: All numerical columns of the dataframe.
 
     Returns:
-            List of column names that are binary (contiain only 0 and 1 (+NaNs))
+            List of column names that are binary (containing only 0 and 1 (+NaNs))
     """
     binary_columns = []
     for column in numerical_columns:
@@ -486,6 +485,7 @@ def _detect_binary_columns(df: pd.DataFrame, numerical_columns: list[str]) -> li
         # only columns that contain at least one 0 and one 1 are counted as binary (or 0.0/1.0)
         if df[column].isin([0.0, 1.0, np.NaN, 0, 1]).all() and df[column].nunique() == 2:
             binary_columns.append(column)
+
     return binary_columns
 
 

--- a/ehrapy/anndata/anndata_ext.py
+++ b/ehrapy/anndata/anndata_ext.py
@@ -44,7 +44,9 @@ def df_to_anndata(
     # see: https://stackoverflow.com/questions/25480089/right-way-to-initialize-an-ordereddict-using-its-constructor-such-that-it-retain/25480206
     uns = OrderedDict()
     # store all numerical/non-numerical columns that are not obs only
-    uns["numerical_columns"] = list(dataframes.df.select_dtypes("number").columns)
+    numerical_columns = list(dataframes.df.select_dtypes("number").columns)
+    binary_columns = _detect_binary_columns(df, numerical_columns)
+    uns["numerical_columns"] = list(set(numerical_columns) ^ set(binary_columns))
     uns["non_numerical_columns"] = list(set(dataframes.df.columns) ^ set(uns["numerical_columns"]))
     return AnnData(
         X=X,
@@ -465,6 +467,26 @@ def _update_uns(
         all_moved_non_num_columns = moved_columns_set ^ set(adata.obs.select_dtypes("number").columns)
         all_moved_num_columns = list(moved_columns_set ^ all_moved_non_num_columns)
         return all_moved_num_columns, list(all_moved_non_num_columns), None
+
+
+def _detect_binary_columns(df: pd.DataFrame, numerical_columns: list[str]) -> list[str]:
+    """
+    Detect all columns that contain only 0 and 1 (besides NaNs)
+
+    Args:
+        df: The dataframe to check
+        numerical_columns: All numerical columns of df
+
+    Returns:
+            List of column names that are binary (contiain only 0 and 1 (+NaNs))
+    """
+    binary_columns = []
+    for column in numerical_columns:
+        # checking for float and int as well as NaNs (this is safe since checked columns are numericals only)
+        # only columns that contain at least one 0 and one 1 are counted as binary (or 0.0/1.0)
+        if df[column].isin([0.0, 1.0, np.NaN, 0, 1]).all() and df[column].nunique() == 2:
+            binary_columns.append(column)
+    return binary_columns
 
 
 def generate_anndata(

--- a/ehrapy/preprocessing/encoding/_encode.py
+++ b/ehrapy/preprocessing/encoding/_encode.py
@@ -41,7 +41,7 @@ def encode(
 
     Args:
         data: The initial :class:`~anndata.AnnData` or :class:`~mudata.MuData` object
-        autodetect: Autodetection of categorical values
+        autodetect: Autodetection of categorical values. Also detects binary values such as only 0 and 1 in columns.
         encodings: Only needed if autodetect set to False (or False for some columns in case of a :class:`~mudata.MuData` object).
         A dict containing the encoding mode and categorical name for the respective column (for each AnnData object in case of MuData object).
 

--- a/tests/anndata/test_anndata_ext.py
+++ b/tests/anndata/test_anndata_ext.py
@@ -149,6 +149,18 @@ class TestAnndataExt:
         with pytest.raises(ObsEmptyError):
             _ = anndata_to_df(adata, add_from_obs=["some_missing_column"])
 
+    def test_detect_binary_columns(self):
+        binary_df = TestAnndataExt._setup_binary_df_to_anndata()
+        adata = df_to_anndata(binary_df)
+        assert set(adata.uns["non_numerical_columns"]) == {
+            "col1",
+            "col2",
+            "col7_binary_int",
+            "col8_binary_float",
+            "col9_binary_missing_values",
+        }
+        assert set(adata.uns["numerical_columns"]) == {f"col{idx}" for idx in range(3, 7)}
+
     @staticmethod
     def _setup_df_to_anndata() -> Tuple[DataFrame, list, list, list]:
         col1_val = ["str" + str(idx) for idx in range(100)]
@@ -157,6 +169,33 @@ class TestAnndataExt:
         df = DataFrame({"col1": col1_val, "col2": col2_val, "col3": col3_val})
 
         return df, col1_val, col2_val, col3_val
+
+    @staticmethod
+    def _setup_binary_df_to_anndata() -> DataFrame:
+        col1_val = ["str" + str(idx) for idx in range(100)]
+        col2_val = ["another_str" + str(idx) for idx in range(100)]
+        col3_val = [0 for _ in range(100)]
+        col4_val = [1.0 for _ in range(100)]
+        col5_val = [np.NaN for _ in range(100)]
+        col6_val = [0.0 if idx % 2 == 0 else np.NaN for idx in range(100)]
+        col7_val = [idx % 2 for idx in range(100)]
+        col8_val = [float(idx % 2) for idx in range(100)]
+        col9_val = [idx % 3 if idx % 3 in {0, 1} else np.NaN for idx in range(100)]
+        df = DataFrame(
+            {
+                "col1": col1_val,
+                "col2": col2_val,
+                "col3": col3_val,
+                "col4": col4_val,
+                "col5": col5_val,
+                "col6": col6_val,
+                "col7_binary_int": col7_val,
+                "col8_binary_float": col8_val,
+                "col9_binary_missing_values": col9_val,
+            }
+        )
+
+        return df
 
     @staticmethod
     def _setup_anndata_to_df() -> Tuple[list, list, list]:


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [x] This comment contains a description of changes (with reason)
-   [x] Referenced issue is linked
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the user. -->
- autodetect now detects numerical columns that are binary
--> only contain 0 and 1 (or 0.0 and 1.0) and maybe some missing values

- columns count as binary when they have at least one 0 (or 0.0) and one 1 (or 1.0) and an arbitrary number (also 0) of missing values