### PR TITLE
[FIX] Write .h5ad files

### DIFF
--- a/ehrapy/anndata/anndata_ext.py
+++ b/ehrapy/anndata/anndata_ext.py
@@ -39,14 +39,14 @@ def df_to_anndata(
     non_numerical_columns = list(df[columns_obs_only].select_dtypes(exclude="number").columns)
     # move columns from the input dataframe to later obs
     dataframes = _move_columns_to_obs(df, columns_obs_only)
+    numerical_columns = list(dataframes.df.select_dtypes("number").columns)
     # if data is numerical only, short-circuit AnnData creation to have float dtype instead of object
-    all_num = True if not non_numerical_columns else False
+    all_num = True if len(numerical_columns) == len(list(dataframes.df.columns)) else False
     X = dataframes.df.to_numpy(copy=True)
     # initializing an OrderedDict with a non-empty dict might not be intended,
     # see: https://stackoverflow.com/questions/25480089/right-way-to-initialize-an-ordereddict-using-its-constructor-such-that-it-retain/25480206
     uns = OrderedDict()
     # store all numerical/non-numerical columns that are not obs only
-    numerical_columns = list(dataframes.df.select_dtypes("number").columns)
     binary_columns = _detect_binary_columns(df, numerical_columns)
     uns["numerical_columns"] = list(set(numerical_columns) ^ set(binary_columns))
     uns["non_numerical_columns"] = list(set(dataframes.df.columns) ^ set(uns["numerical_columns"]))

--- a/ehrapy/io/_read.py
+++ b/ehrapy/io/_read.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from typing import Iterator
 
 import camelot
-import pandas as pd
 import numpy as np
+import pandas as pd
 from _collections import OrderedDict
 from anndata import AnnData
 from anndata import read as read_h5ad

--- a/ehrapy/io/_read.py
+++ b/ehrapy/io/_read.py
@@ -569,6 +569,7 @@ def _decode_cached_adata(adata: AnnData, column_obs_only: list[str]) -> AnnData:
     numerical_columns = adata.uns["numerical_columns"]
     adata.uns = OrderedDict()
     adata.uns["numerical_columns"] = numerical_columns
+    adata.uns["non_numerical_columns"] = list(set(adata.var_names) ^ set(numerical_columns))
 
     return adata
 

--- a/ehrapy/io/_write.py
+++ b/ehrapy/io/_write.py
@@ -18,12 +18,15 @@ def write(
     compression: Literal["gzip", "lzf"] | None = "gzip",
     compression_opts: int | None = None,
 ) -> None:
-    """Write :class:`~anndata.AnnData` objects to file.
+    """Write :class:`~anndata.AnnData` objects to file. It is possbile to either write an :class:`~anndata.AnnData` object to
+    a .csv file or a .h5ad file.
+    The .h5ad file can be used as a cache to save the current state of the object and to retrieve it faster once needed. This preserves
+    the object state at the time of writing. It is possible to write both, encoded and unencoded objects.
 
     Args:
         filename: File name or path to write the file to
         adata: Annotated data matrix.
-        extension: File extension. One of h5, csv, txt
+        extension: File extension. One of h5ad, csv
         compression: Optional file compression. One of gzip, lzf
         compression_opts: See http://docs.h5py.org/en/latest/high/dataset.html.
 
@@ -45,7 +48,7 @@ def write(
             raise ValueError(
                 "It suffices to provide the file type by "
                 "providing a proper extension to the filename."
-                'One of "txt", "csv", "h5".'
+                'One of "csv", "h5".'
             )
     else:
         key = filename
@@ -54,6 +57,7 @@ def write(
     if extension == "csv":
         adata.write_csvs(filename)
     else:
+        # dummy encoding when there is non numerical data in X
         if not np.issubdtype(adata.X.dtype, np.number) and extension == "h5ad":
             # flag to indicate an Anndata object has been dummy encoded to write it to .h5ad file
             # this could be the case when writing to cache file or when writing an unencoded non numerical AnnData object

--- a/ehrapy/preprocessing/encoding/_encode.py
+++ b/ehrapy/preprocessing/encoding/_encode.py
@@ -844,9 +844,13 @@ def _add_categoricals_to_obs(ann_data: AnnData, categorical_names: list[str]) ->
             continue
         elif var_name in categorical_names:
             ann_data.obs[var_name] = ann_data.X[::, idx : idx + 1]
+            # note: this will count binary columns (0 and 1 only) as well
+            # needed for writing to .h5ad files
+            if set(pd.unique(ann_data.obs[var_name])).issubset({False,True,np.NaN}):
+                ann_data.obs[var_name] = ann_data.obs[var_name].astype("bool")
+    # get all non bool object columns and cast the to category dtype
     object_columns = list(ann_data.obs.select_dtypes(include="object").columns)
     ann_data.obs[object_columns] = ann_data.obs[object_columns].astype("category")
-
 
 
 def _add_categoricals_to_uns(ann_data: AnnData, categorical_names: list[str]) -> None:

--- a/ehrapy/preprocessing/encoding/_encode.py
+++ b/ehrapy/preprocessing/encoding/_encode.py
@@ -844,6 +844,9 @@ def _add_categoricals_to_obs(ann_data: AnnData, categorical_names: list[str]) ->
             continue
         elif var_name in categorical_names:
             ann_data.obs[var_name] = ann_data.X[::, idx : idx + 1]
+    object_columns = list(ann_data.obs.select_dtypes(include="object").columns)
+    ann_data.obs[object_columns] = ann_data.obs[object_columns].astype("category")
+
 
 
 def _add_categoricals_to_uns(ann_data: AnnData, categorical_names: list[str]) -> None:
@@ -862,7 +865,7 @@ def _add_categoricals_to_uns(ann_data: AnnData, categorical_names: list[str]) ->
         if is_initial and var_name in ann_data.uns["original_values_categoricals"]:
             continue
         elif var_name in categorical_names:
-            ann_data.uns["original_values_categoricals"][var_name] = ann_data.X[::, idx : idx + 1]
+            ann_data.uns["original_values_categoricals"][var_name] = ann_data.X[::, idx : idx + 1].astype("str")
 
 
 def _get_mudata_autodetect_options_and_encoding_modes(

--- a/ehrapy/preprocessing/encoding/_encode.py
+++ b/ehrapy/preprocessing/encoding/_encode.py
@@ -846,7 +846,7 @@ def _add_categoricals_to_obs(ann_data: AnnData, categorical_names: list[str]) ->
             ann_data.obs[var_name] = ann_data.X[::, idx : idx + 1]
             # note: this will count binary columns (0 and 1 only) as well
             # needed for writing to .h5ad files
-            if set(pd.unique(ann_data.obs[var_name])).issubset({False,True,np.NaN}):
+            if set(pd.unique(ann_data.obs[var_name])).issubset({False, True, np.NaN}):
                 ann_data.obs[var_name] = ann_data.obs[var_name].astype("bool")
     # get all non bool object columns and cast the to category dtype
     object_columns = list(ann_data.obs.select_dtypes(include="object").columns)

--- a/poetry.lock
+++ b/poetry.lock
@@ -181,7 +181,7 @@ python-versions = ">=3.6.0"
 name = "bandit"
 version = "1.7.4"
 description = "Security oriented static analyser for python code."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -654,7 +654,7 @@ testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-co
 name = "flake8"
 version = "4.0.1"
 description = "the modular source code checker: pep8 pyflakes and co"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -667,7 +667,7 @@ pyflakes = ">=2.4.0,<2.5.0"
 name = "flake8-bandit"
 version = "3.0.0"
 description = "Automated security testing with bandit and flake8."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -708,7 +708,7 @@ pydocstyle = ">=2.1"
 name = "flake8-polyfill"
 version = "1.0.2"
 description = "Polyfill package for Flake8 plugins"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -822,7 +822,7 @@ python-versions = "*"
 name = "gitdb"
 version = "4.0.9"
 description = "Git Object Database"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -833,7 +833,7 @@ smmap = ">=3.0.1,<6"
 name = "gitpython"
 version = "3.1.27"
 description = "GitPython is a python library used to interact with Git repositories"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -1264,7 +1264,7 @@ traitlets = "*"
 name = "mccabe"
 version = "0.6.1"
 description = "McCabe checker, plugin for flake8"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -1315,14 +1315,14 @@ python-versions = "*"
 
 [[package]]
 name = "mudata"
-version = "0.1.0"
+version = "0.1.1"
 description = "Multimodal omics analysis framework"
 category = "main"
 optional = false
 python-versions = ">= 3.6"
 
 [package.dependencies]
-anndata = "*"
+anndata = "<0.8"
 h5py = "*"
 numpy = "*"
 pandas = "*"
@@ -1415,7 +1415,7 @@ test = ["ipython (<8.0.0)", "ipykernel", "ipywidgets (<8.0.0)", "pytest (>=4.1)"
 
 [[package]]
 name = "nbconvert"
-version = "6.4.2"
+version = "6.4.3"
 description = "Converting Jupyter Notebooks"
 category = "main"
 optional = false
@@ -1716,7 +1716,7 @@ test = ["pytest", "pytest-cov", "scipy"]
 name = "pbr"
 version = "5.8.1"
 description = "Python Build Reasonableness"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.6"
 
@@ -1974,7 +1974,7 @@ pybtex = ">=0.16"
 name = "pycodestyle"
 version = "2.8.0"
 description = "Python style guide checker"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -2046,7 +2046,7 @@ python-versions = ">=3.5"
 name = "pyflakes"
 version = "2.4.0"
 description = "passive checker of Python programs"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -2519,7 +2519,7 @@ webhdfs = ["requests"]
 name = "smmap"
 version = "5.0.0"
 description = "A pure Python implementation of a sliding window memory map manager"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -2902,7 +2902,7 @@ develop = ["sphinx"]
 name = "stevedore"
 version = "3.5.0"
 description = "Manage dynamic plugins for Python applications"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -3389,7 +3389,7 @@ scikit-learn-intelex = ["scikit-learn-intelex"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8.0,<4"
-content-hash = "797cc1c5264bbcdd0695afbcfd30a6ec402fe5d75aaccd821eedcaeda6f6372d"
+content-hash = "5e839a2d4dbb32b98c50691cee9e070f473963cc9111bd95afe5bbbaf20c693f"
 
 [metadata.files]
 aiofiles = [
@@ -3758,7 +3758,7 @@ cycler = [
     {file = "cycler-0.11.0.tar.gz", hash = "sha256:9c87405839a19696e837b3b818fed3f5f69f16f1eec1a1ad77e043dcea9c772f"},
 ]
 cymem = [
-    {file = "cymem-2.0.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2b4e27e739f09f16c7c0190f962ffe60dab39cb6a229d5c13e274d16f46a17e8"},
+    {file = "cymem-2.0.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:700540b68e96a7056d0691d467df2bbaaf0934a3e6fe2383669998cbee19580a"},
     {file = "cymem-2.0.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:971cf0a8437dfb4185c3049c086e463612fe849efadc0f5cc153fc81c501da7d"},
     {file = "cymem-2.0.6-cp310-cp310-win_amd64.whl", hash = "sha256:6b0d1a6b0a1296f31fa9e4b7ae5ea49394084ecc883b1ae6fec4844403c43468"},
     {file = "cymem-2.0.6-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b8e1c18bb00800425576710468299153caad20c64ddb6819d40a6a34e21ee21c"},
@@ -4334,8 +4334,8 @@ monotonic = [
     {file = "monotonic-1.6.tar.gz", hash = "sha256:3a55207bcfed53ddd5c5bae174524062935efed17792e9de2ad0205ce9ad63f7"},
 ]
 mudata = [
-    {file = "mudata-0.1.0-py3-none-any.whl", hash = "sha256:0709f09f19de1c81359f69b164eda3b7b7ad9fb7cecf97e1e84980a3be355260"},
-    {file = "mudata-0.1.0.tar.gz", hash = "sha256:85d46902e877ddb02b0fe5c70384930ddffa4c07da04371da88d6bb8d58f456c"},
+    {file = "mudata-0.1.1-py3-none-any.whl", hash = "sha256:a6b545954e93d0c84386993c0ec05076441239fa227acd47dea204a45ebafc50"},
+    {file = "mudata-0.1.1.tar.gz", hash = "sha256:8f4e695ed8e7787c3928c8726049a4a3f2e9e07d8ca57ade0e08ee790b673e9b"},
 ]
 multidict = [
     {file = "multidict-6.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0b9e95a740109c6047602f4db4da9949e6c5945cefbad34a1299775ddc9a62e2"},
@@ -4414,7 +4414,7 @@ multiprocess = [
     {file = "multiprocess-0.70.12.2.zip", hash = "sha256:206bb9b97b73f87fec1ed15a19f8762950256aa84225450abc7150d02855a083"},
 ]
 murmurhash = [
-    {file = "murmurhash-1.0.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a814d559afe2a97ad40accf21ce96e8b04a3ff5a08f80c02b7acd427dbb7d567"},
+    {file = "murmurhash-1.0.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1431d817e1fff1ed35f8dc54dd5b4d70165ec98076de8aca351805f8037293f3"},
     {file = "murmurhash-1.0.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c7b8cc4a8db1c821b80f8ca70a25c3166b14d68ecef8693a117c6a0b1d74ace"},
     {file = "murmurhash-1.0.6-cp310-cp310-win_amd64.whl", hash = "sha256:e40790fdaf65213d70da4ed9229f16f6d6376310dc8fc23eacc98e6151c6ae7e"},
     {file = "murmurhash-1.0.6-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:a78d53f047c3410ce4c589d9b47090f628f844ed5694418144e63cfe7f3da7e9"},
@@ -4469,8 +4469,8 @@ nbclient = [
     {file = "nbclient-0.5.13.tar.gz", hash = "sha256:40c52c9b5e3c31faecaee69f202b3f53e38d7c1c563de0fadde9d7eda0fdafe8"},
 ]
 nbconvert = [
-    {file = "nbconvert-6.4.2-py3-none-any.whl", hash = "sha256:7b006ae9979af56200e7fa3db39d9d12c99e811e8843b05dbe518e5b754bcb2e"},
-    {file = "nbconvert-6.4.2.tar.gz", hash = "sha256:eb2803db18f6facce6bf3b01b684fe47907994bd156d15eaccdf011e3d7f8164"},
+    {file = "nbconvert-6.4.3-py3-none-any.whl", hash = "sha256:5a8eea76af7870d5dfa0197f52d1af85da23d5ad57e5f61d0e2fd1572761ad4e"},
+    {file = "nbconvert-6.4.3.tar.gz", hash = "sha256:b7cfb62d4e9cfcb7d2485c78ca06acc5d9bbb271f2f7e968526bbc430e822e8f"},
 ]
 nbformat = [
     {file = "nbformat-5.2.0-py3-none-any.whl", hash = "sha256:3e30424e8291b2188347f5c3ba5273ed3766f12f8c5137c2e456a0815f36e785"},
@@ -4673,6 +4673,9 @@ pickleshare = [
     {file = "pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca"},
 ]
 pillow = [
+    {file = "Pillow-9.0.1-1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a5d24e1d674dd9d72c66ad3ea9131322819ff86250b30dc5821cbafcfa0b96b4"},
+    {file = "Pillow-9.0.1-1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2632d0f846b7c7600edf53c48f8f9f1e13e62f66a6dbc15191029d950bfed976"},
+    {file = "Pillow-9.0.1-1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b9618823bd237c0d2575283f2939655f54d51b4527ec3972907a927acbcc5bfc"},
     {file = "Pillow-9.0.1-cp310-cp310-macosx_10_10_universal2.whl", hash = "sha256:9bfdb82cdfeccec50aad441afc332faf8606dfa5e8efd18a6692b5d6e79f00fd"},
     {file = "Pillow-9.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5100b45a4638e3c00e4d2320d3193bdabb2d75e79793af7c3eb139e4f569f16f"},
     {file = "Pillow-9.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:528a2a692c65dd5cafc130de286030af251d2ee0483a5bf50c9348aefe834e8a"},
@@ -4723,7 +4726,7 @@ pre-commit-hooks = [
     {file = "pre_commit_hooks-4.1.0.tar.gz", hash = "sha256:b6361865d1877c5da5ac3a944aab19ce6bd749a534d2ede28e683d07194a57e1"},
 ]
 preshed = [
-    {file = "preshed-3.0.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a9683730127658b531120b4ed5cff1f2a567318ab75e9ab0f22cc84ae1486c23"},
+    {file = "preshed-3.0.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:66a71ced487516cf81fd0431a3a843514262ae2f33e9a7688b87562258fa75d5"},
     {file = "preshed-3.0.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c98f725d8478f3ade4ab1ea00f50a92d2d9406d37276bc46fd8bab1d47452c4"},
     {file = "preshed-3.0.6-cp310-cp310-win_amd64.whl", hash = "sha256:ea8aa9610837e907e8442e79300df0a861bfdb4dcaf026a5d9642a688ad04815"},
     {file = "preshed-3.0.6-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e03ae3eee961106a517fcd827b5a7c51f7317236b3e665c989054ab8dc381d28"},
@@ -5011,32 +5014,24 @@ pyzmq = [
     {file = "pyzmq-22.3.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f89468059ebc519a7acde1ee50b779019535db8dcf9b8c162ef669257fef7a93"},
     {file = "pyzmq-22.3.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ea12133df25e3a6918718fbb9a510c6ee5d3fdd5a346320421aac3882f4feeea"},
     {file = "pyzmq-22.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76c532fd68b93998aab92356be280deec5de8f8fe59cd28763d2cc8a58747b7f"},
-    {file = "pyzmq-22.3.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:f907c7359ce8bf7f7e63c82f75ad0223384105f5126f313400b7e8004d9b33c3"},
-    {file = "pyzmq-22.3.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:902319cfe23366595d3fa769b5b751e6ee6750a0a64c5d9f757d624b2ac3519e"},
     {file = "pyzmq-22.3.0-cp310-cp310-win32.whl", hash = "sha256:67db33bea0a29d03e6eeec55a8190e033318cee3cbc732ba8fd939617cbf762d"},
     {file = "pyzmq-22.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:7661fc1d5cb73481cf710a1418a4e1e301ed7d5d924f91c67ba84b2a1b89defd"},
     {file = "pyzmq-22.3.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:79244b9e97948eaf38695f4b8e6fc63b14b78cc37f403c6642ba555517ac1268"},
     {file = "pyzmq-22.3.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab888624ed68930442a3f3b0b921ad7439c51ba122dbc8c386e6487a658e4a4e"},
     {file = "pyzmq-22.3.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:18cd854b423fce44951c3a4d3e686bac8f1243d954f579e120a1714096637cc0"},
     {file = "pyzmq-22.3.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:de8df0684398bd74ad160afdc2a118ca28384ac6f5e234eb0508858d8d2d9364"},
-    {file = "pyzmq-22.3.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:62bcade20813796c426409a3e7423862d50ff0639f5a2a95be4b85b09a618666"},
-    {file = "pyzmq-22.3.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:ea5a79e808baef98c48c884effce05c31a0698c1057de8fc1c688891043c1ce1"},
     {file = "pyzmq-22.3.0-cp36-cp36m-win32.whl", hash = "sha256:3c1895c95be92600233e476fe283f042e71cf8f0b938aabf21b7aafa62a8dac9"},
     {file = "pyzmq-22.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:851977788b9caa8ed011f5f643d3ee8653af02c5fc723fa350db5125abf2be7b"},
     {file = "pyzmq-22.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b4ebed0977f92320f6686c96e9e8dd29eed199eb8d066936bac991afc37cbb70"},
     {file = "pyzmq-22.3.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42abddebe2c6a35180ca549fadc7228d23c1e1f76167c5ebc8a936b5804ea2df"},
     {file = "pyzmq-22.3.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1e41b32d6f7f9c26bc731a8b529ff592f31fc8b6ef2be9fa74abd05c8a342d7"},
     {file = "pyzmq-22.3.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:be4e0f229cf3a71f9ecd633566bd6f80d9fa6afaaff5489492be63fe459ef98c"},
-    {file = "pyzmq-22.3.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:08c4e315a76ef26eb833511ebf3fa87d182152adf43dedee8d79f998a2162a0b"},
-    {file = "pyzmq-22.3.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:badb868fff14cfd0e200eaa845887b1011146a7d26d579aaa7f966c203736b92"},
     {file = "pyzmq-22.3.0-cp37-cp37m-win32.whl", hash = "sha256:7c58f598d9fcc52772b89a92d72bf8829c12d09746a6d2c724c5b30076c1f11d"},
     {file = "pyzmq-22.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2b97502c16a5ec611cd52410bdfaab264997c627a46b0f98d3f666227fd1ea2d"},
     {file = "pyzmq-22.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d728b08448e5ac3e4d886b165385a262883c34b84a7fe1166277fe675e1c197a"},
     {file = "pyzmq-22.3.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:480b9931bfb08bf8b094edd4836271d4d6b44150da051547d8c7113bf947a8b0"},
     {file = "pyzmq-22.3.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7dc09198e4073e6015d9a8ea093fc348d4e59de49382476940c3dd9ae156fba8"},
     {file = "pyzmq-22.3.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ca6cd58f62a2751728016d40082008d3b3412a7f28ddfb4a2f0d3c130f69e74"},
-    {file = "pyzmq-22.3.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:468bd59a588e276961a918a3060948ae68f6ff5a7fa10bb2f9160c18fe341067"},
-    {file = "pyzmq-22.3.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c88fa7410e9fc471e0858638f403739ee869924dd8e4ae26748496466e27ac59"},
     {file = "pyzmq-22.3.0-cp38-cp38-win32.whl", hash = "sha256:c0f84360dcca3481e8674393bdf931f9f10470988f87311b19d23cda869bb6b7"},
     {file = "pyzmq-22.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:f762442bab706fd874064ca218b33a1d8e40d4938e96c24dafd9b12e28017f45"},
     {file = "pyzmq-22.3.0-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:954e73c9cd4d6ae319f1c936ad159072b6d356a92dcbbabfd6e6204b9a79d356"},
@@ -5044,8 +5039,6 @@ pyzmq = [
     {file = "pyzmq-22.3.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:acebba1a23fb9d72b42471c3771b6f2f18dcd46df77482612054bd45c07dfa36"},
     {file = "pyzmq-22.3.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cf98fd7a6c8aaa08dbc699ffae33fd71175696d78028281bc7b832b26f00ca57"},
     {file = "pyzmq-22.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d072f7dfbdb184f0786d63bda26e8a0882041b1e393fbe98940395f7fab4c5e2"},
-    {file = "pyzmq-22.3.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:53f4fd13976789ffafedd4d46f954c7bb01146121812b72b4ddca286034df966"},
-    {file = "pyzmq-22.3.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d1b5d457acbadcf8b27561deeaa386b0217f47626b29672fa7bd31deb6e91e1b"},
     {file = "pyzmq-22.3.0-cp39-cp39-win32.whl", hash = "sha256:e6a02cf7271ee94674a44f4e62aa061d2d049001c844657740e156596298b70b"},
     {file = "pyzmq-22.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:d3dcb5548ead4f1123851a5ced467791f6986d68c656bc63bfff1bf9e36671e2"},
     {file = "pyzmq-22.3.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3a4c9886d61d386b2b493377d980f502186cd71d501fffdba52bd2a0880cef4f"},
@@ -5369,7 +5362,7 @@ sphinxcontrib-serializinghtml = [
     {file = "sphinxcontrib_serializinghtml-1.1.5-py2.py3-none-any.whl", hash = "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd"},
 ]
 srsly = [
-    {file = "srsly-2.4.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:834229df7377386e9990fd245e1ae12a72152997fd159a782a798b638721a7b2"},
+    {file = "srsly-2.4.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5e22bbc1a20abf749fa53adf101c36bc369ec63f496c7a44bf4f5f287d724900"},
     {file = "srsly-2.4.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:004d29a5abc0fe632434359c0be170490a69c4dce2c3de8a769944c37da7bb4b"},
     {file = "srsly-2.4.2-cp310-cp310-win_amd64.whl", hash = "sha256:7ced7ec4993b4d4ad73cc442f8f7a518368348054d510864b1aa149e8d71654d"},
     {file = "srsly-2.4.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:801c7e6e32c6a4721ab78ab7dafd01074fdb144f4876c09b25305c98f95c470f"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -485,13 +485,13 @@ xxhash = "*"
 apache-beam = ["apache-beam (>=2.26.0)"]
 audio = ["librosa"]
 benchmarks = ["numpy (==1.18.5)", "tensorflow (==2.3.0)", "torch (==1.6.0)", "transformers (==3.0.2)"]
-dev = ["absl-py", "pytest", "pytest-datadir", "pytest-xdist", "apache-beam (>=2.26.0)", "elasticsearch", "aiobotocore", "boto3", "botocore", "fsspec", "moto[server,s3] (==2.0.4)", "rarfile (>=4.0)", "s3fs (==2021.08.1)", "tensorflow (>=2.3)", "torch", "torchaudio", "transformers", "bs4", "conllu", "langdetect", "lxml", "mwparserfromhell", "nltk", "openpyxl", "py7zr", "tldextract", "zstandard", "bert-score (>=0.3.6)", "rouge-score", "sacrebleu", "scipy", "seqeval", "scikit-learn", "jiwer", "sentencepiece", "toml (>=0.10.1)", "requests-file (>=1.5.1)", "tldextract (>=3.1.0)", "texttable (>=1.6.3)", "Werkzeug (>=1.0.1)", "six (>=1.15.0,<1.16.0)", "black (==21.4b0)", "flake8 (==3.7.9)", "isort", "pyyaml (>=5.3.1)", "importlib-resources"]
+dev = ["absl-py", "pytest", "pytest-datadir", "pytest-xdist", "apache-beam (>=2.26.0)", "elasticsearch", "aiobotocore", "boto3", "botocore", "fsspec", "moto[s3,server] (==2.0.4)", "rarfile (>=4.0)", "s3fs (==2021.08.1)", "tensorflow (>=2.3)", "torch", "torchaudio", "transformers", "bs4", "conllu", "langdetect", "lxml", "mwparserfromhell", "nltk", "openpyxl", "py7zr", "tldextract", "zstandard", "bert-score (>=0.3.6)", "rouge-score", "sacrebleu", "scipy", "seqeval", "scikit-learn", "jiwer", "sentencepiece", "toml (>=0.10.1)", "requests-file (>=1.5.1)", "tldextract (>=3.1.0)", "texttable (>=1.6.3)", "Werkzeug (>=1.0.1)", "six (>=1.15.0,<1.16.0)", "black (==21.4b0)", "flake8 (==3.7.9)", "isort", "pyyaml (>=5.3.1)", "importlib-resources"]
 docs = ["docutils (==0.16.0)", "recommonmark", "sphinx (==3.1.2)", "sphinx-markdown-tables", "sphinx-rtd-theme (==0.4.3)", "sphinxext-opengraph (==0.4.1)", "sphinx-copybutton", "fsspec (<2021.9.0)", "s3fs", "sphinx-panels", "sphinx-inline-tabs", "myst-parser"]
 quality = ["black (==21.4b0)", "flake8 (==3.7.9)", "isort", "pyyaml (>=5.3.1)"]
 s3 = ["fsspec", "boto3", "botocore", "s3fs"]
 tensorflow = ["tensorflow (>=2.2.0)"]
 tensorflow_gpu = ["tensorflow-gpu (>=2.2.0)"]
-tests = ["absl-py", "pytest", "pytest-datadir", "pytest-xdist", "apache-beam (>=2.26.0)", "elasticsearch", "aiobotocore", "boto3", "botocore", "fsspec", "moto[server,s3] (==2.0.4)", "rarfile (>=4.0)", "s3fs (==2021.08.1)", "tensorflow (>=2.3)", "torch", "torchaudio", "transformers", "bs4", "conllu", "langdetect", "lxml", "mwparserfromhell", "nltk", "openpyxl", "py7zr", "tldextract", "zstandard", "bert-score (>=0.3.6)", "rouge-score", "sacrebleu", "scipy", "seqeval", "scikit-learn", "jiwer", "sentencepiece", "toml (>=0.10.1)", "requests-file (>=1.5.1)", "tldextract (>=3.1.0)", "texttable (>=1.6.3)", "Werkzeug (>=1.0.1)", "six (>=1.15.0,<1.16.0)", "importlib-resources"]
+tests = ["absl-py", "pytest", "pytest-datadir", "pytest-xdist", "apache-beam (>=2.26.0)", "elasticsearch", "aiobotocore", "boto3", "botocore", "fsspec", "moto[s3,server] (==2.0.4)", "rarfile (>=4.0)", "s3fs (==2021.08.1)", "tensorflow (>=2.3)", "torch", "torchaudio", "transformers", "bs4", "conllu", "langdetect", "lxml", "mwparserfromhell", "nltk", "openpyxl", "py7zr", "tldextract", "zstandard", "bert-score (>=0.3.6)", "rouge-score", "sacrebleu", "scipy", "seqeval", "scikit-learn", "jiwer", "sentencepiece", "toml (>=0.10.1)", "requests-file (>=1.5.1)", "tldextract (>=3.1.0)", "texttable (>=1.6.3)", "Werkzeug (>=1.0.1)", "six (>=1.15.0,<1.16.0)", "importlib-resources"]
 torch = ["torch"]
 
 [[package]]
@@ -1315,14 +1315,14 @@ python-versions = "*"
 
 [[package]]
 name = "mudata"
-version = "0.1.1"
+version = "0.1.0"
 description = "Multimodal omics analysis framework"
 category = "main"
 optional = false
 python-versions = ">= 3.6"
 
 [package.dependencies]
-anndata = "<0.8"
+anndata = "*"
 h5py = "*"
 numpy = "*"
 pandas = "*"
@@ -3390,7 +3390,7 @@ scikit-learn-intelex = ["scikit-learn-intelex"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8.0,<4"
-content-hash = "dd8d9afe236b6cbc45c153d1abf41da906329d5c0854a0834d477b4b3f00a5fe"
+content-hash = "fdbbbaf39f079964d179f318b69de7891f72d3284063b40c71c3619db34ebc2c"
 
 [metadata.files]
 aiofiles = [
@@ -4334,8 +4334,8 @@ monotonic = [
     {file = "monotonic-1.6.tar.gz", hash = "sha256:3a55207bcfed53ddd5c5bae174524062935efed17792e9de2ad0205ce9ad63f7"},
 ]
 mudata = [
-    {file = "mudata-0.1.1-py3-none-any.whl", hash = "sha256:a6b545954e93d0c84386993c0ec05076441239fa227acd47dea204a45ebafc50"},
-    {file = "mudata-0.1.1.tar.gz", hash = "sha256:8f4e695ed8e7787c3928c8726049a4a3f2e9e07d8ca57ade0e08ee790b673e9b"},
+    {file = "mudata-0.1.0-py3-none-any.whl", hash = "sha256:0709f09f19de1c81359f69b164eda3b7b7ad9fb7cecf97e1e84980a3be355260"},
+    {file = "mudata-0.1.0.tar.gz", hash = "sha256:85d46902e877ddb02b0fe5c70384930ddffa4c07da04371da88d6bb8d58f456c"},
 ]
 multidict = [
     {file = "multidict-6.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0b9e95a740109c6047602f4db4da9949e6c5945cefbad34a1299775ddc9a62e2"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -181,7 +181,7 @@ python-versions = ">=3.6.0"
 name = "bandit"
 version = "1.7.4"
 description = "Security oriented static analyser for python code."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -485,13 +485,13 @@ xxhash = "*"
 apache-beam = ["apache-beam (>=2.26.0)"]
 audio = ["librosa"]
 benchmarks = ["numpy (==1.18.5)", "tensorflow (==2.3.0)", "torch (==1.6.0)", "transformers (==3.0.2)"]
-dev = ["absl-py", "pytest", "pytest-datadir", "pytest-xdist", "apache-beam (>=2.26.0)", "elasticsearch", "aiobotocore", "boto3", "botocore", "fsspec", "moto[s3,server] (==2.0.4)", "rarfile (>=4.0)", "s3fs (==2021.08.1)", "tensorflow (>=2.3)", "torch", "torchaudio", "transformers", "bs4", "conllu", "langdetect", "lxml", "mwparserfromhell", "nltk", "openpyxl", "py7zr", "tldextract", "zstandard", "bert-score (>=0.3.6)", "rouge-score", "sacrebleu", "scipy", "seqeval", "scikit-learn", "jiwer", "sentencepiece", "toml (>=0.10.1)", "requests-file (>=1.5.1)", "tldextract (>=3.1.0)", "texttable (>=1.6.3)", "Werkzeug (>=1.0.1)", "six (>=1.15.0,<1.16.0)", "black (==21.4b0)", "flake8 (==3.7.9)", "isort", "pyyaml (>=5.3.1)", "importlib-resources"]
+dev = ["absl-py", "pytest", "pytest-datadir", "pytest-xdist", "apache-beam (>=2.26.0)", "elasticsearch", "aiobotocore", "boto3", "botocore", "fsspec", "moto[server,s3] (==2.0.4)", "rarfile (>=4.0)", "s3fs (==2021.08.1)", "tensorflow (>=2.3)", "torch", "torchaudio", "transformers", "bs4", "conllu", "langdetect", "lxml", "mwparserfromhell", "nltk", "openpyxl", "py7zr", "tldextract", "zstandard", "bert-score (>=0.3.6)", "rouge-score", "sacrebleu", "scipy", "seqeval", "scikit-learn", "jiwer", "sentencepiece", "toml (>=0.10.1)", "requests-file (>=1.5.1)", "tldextract (>=3.1.0)", "texttable (>=1.6.3)", "Werkzeug (>=1.0.1)", "six (>=1.15.0,<1.16.0)", "black (==21.4b0)", "flake8 (==3.7.9)", "isort", "pyyaml (>=5.3.1)", "importlib-resources"]
 docs = ["docutils (==0.16.0)", "recommonmark", "sphinx (==3.1.2)", "sphinx-markdown-tables", "sphinx-rtd-theme (==0.4.3)", "sphinxext-opengraph (==0.4.1)", "sphinx-copybutton", "fsspec (<2021.9.0)", "s3fs", "sphinx-panels", "sphinx-inline-tabs", "myst-parser"]
 quality = ["black (==21.4b0)", "flake8 (==3.7.9)", "isort", "pyyaml (>=5.3.1)"]
 s3 = ["fsspec", "boto3", "botocore", "s3fs"]
 tensorflow = ["tensorflow (>=2.2.0)"]
 tensorflow_gpu = ["tensorflow-gpu (>=2.2.0)"]
-tests = ["absl-py", "pytest", "pytest-datadir", "pytest-xdist", "apache-beam (>=2.26.0)", "elasticsearch", "aiobotocore", "boto3", "botocore", "fsspec", "moto[s3,server] (==2.0.4)", "rarfile (>=4.0)", "s3fs (==2021.08.1)", "tensorflow (>=2.3)", "torch", "torchaudio", "transformers", "bs4", "conllu", "langdetect", "lxml", "mwparserfromhell", "nltk", "openpyxl", "py7zr", "tldextract", "zstandard", "bert-score (>=0.3.6)", "rouge-score", "sacrebleu", "scipy", "seqeval", "scikit-learn", "jiwer", "sentencepiece", "toml (>=0.10.1)", "requests-file (>=1.5.1)", "tldextract (>=3.1.0)", "texttable (>=1.6.3)", "Werkzeug (>=1.0.1)", "six (>=1.15.0,<1.16.0)", "importlib-resources"]
+tests = ["absl-py", "pytest", "pytest-datadir", "pytest-xdist", "apache-beam (>=2.26.0)", "elasticsearch", "aiobotocore", "boto3", "botocore", "fsspec", "moto[server,s3] (==2.0.4)", "rarfile (>=4.0)", "s3fs (==2021.08.1)", "tensorflow (>=2.3)", "torch", "torchaudio", "transformers", "bs4", "conllu", "langdetect", "lxml", "mwparserfromhell", "nltk", "openpyxl", "py7zr", "tldextract", "zstandard", "bert-score (>=0.3.6)", "rouge-score", "sacrebleu", "scipy", "seqeval", "scikit-learn", "jiwer", "sentencepiece", "toml (>=0.10.1)", "requests-file (>=1.5.1)", "tldextract (>=3.1.0)", "texttable (>=1.6.3)", "Werkzeug (>=1.0.1)", "six (>=1.15.0,<1.16.0)", "importlib-resources"]
 torch = ["torch"]
 
 [[package]]
@@ -654,7 +654,7 @@ testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-co
 name = "flake8"
 version = "4.0.1"
 description = "the modular source code checker: pep8 pyflakes and co"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -665,14 +665,14 @@ pyflakes = ">=2.4.0,<2.5.0"
 
 [[package]]
 name = "flake8-bandit"
-version = "2.1.2"
+version = "3.0.0"
 description = "Automated security testing with bandit and flake8."
-category = "dev"
+category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [package.dependencies]
-bandit = "*"
+bandit = ">=1.7.3"
 flake8 = "*"
 flake8-polyfill = "*"
 pycodestyle = "*"
@@ -708,7 +708,7 @@ pydocstyle = ">=2.1"
 name = "flake8-polyfill"
 version = "1.0.2"
 description = "Polyfill package for Flake8 plugins"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -822,7 +822,7 @@ python-versions = "*"
 name = "gitdb"
 version = "4.0.9"
 description = "Git Object Database"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -833,7 +833,7 @@ smmap = ">=3.0.1,<6"
 name = "gitpython"
 version = "3.1.27"
 description = "GitPython is a python library used to interact with Git repositories"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -1264,7 +1264,7 @@ traitlets = "*"
 name = "mccabe"
 version = "0.6.1"
 description = "McCabe checker, plugin for flake8"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -1716,7 +1716,7 @@ test = ["pytest", "pytest-cov", "scipy"]
 name = "pbr"
 version = "5.8.1"
 description = "Python Build Reasonableness"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.6"
 
@@ -1974,7 +1974,7 @@ pybtex = ">=0.16"
 name = "pycodestyle"
 version = "2.8.0"
 description = "Python style guide checker"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -2046,7 +2046,7 @@ python-versions = ">=3.5"
 name = "pyflakes"
 version = "2.4.0"
 description = "passive checker of Python programs"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -2520,7 +2520,7 @@ webhdfs = ["requests"]
 name = "smmap"
 version = "5.0.0"
 description = "A pure Python implementation of a sliding window memory map manager"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -2903,7 +2903,7 @@ develop = ["sphinx"]
 name = "stevedore"
 version = "3.5.0"
 description = "Manage dynamic plugins for Python applications"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -3390,7 +3390,7 @@ scikit-learn-intelex = ["scikit-learn-intelex"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8.0,<4"
-content-hash = "fdbbbaf39f079964d179f318b69de7891f72d3284063b40c71c3619db34ebc2c"
+content-hash = "797cc1c5264bbcdd0695afbcfd30a6ec402fe5d75aaccd821eedcaeda6f6372d"
 
 [metadata.files]
 aiofiles = [
@@ -3873,7 +3873,8 @@ flake8 = [
     {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
 ]
 flake8-bandit = [
-    {file = "flake8_bandit-2.1.2.tar.gz", hash = "sha256:687fc8da2e4a239b206af2e54a90093572a60d0954f3054e23690739b0b0de3b"},
+    {file = "flake8_bandit-3.0.0-py2.py3-none-any.whl", hash = "sha256:61b617f4f7cdaa0e2b1e6bf7b68afb2b619a227bb3e3ae00dd36c213bd17900a"},
+    {file = "flake8_bandit-3.0.0.tar.gz", hash = "sha256:54d19427e6a8d50322a7b02e1841c0a7c22d856975f3459803320e0e18e2d6a1"},
 ]
 flake8-bugbear = [
     {file = "flake8-bugbear-22.1.11.tar.gz", hash = "sha256:4c2a4136bd4ecb8bf02d5159af302ffc067642784c9d0488b33ce4610da825ee"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ deep-translator = ">=1.6.1"
 scikit-learn-intelex = {version = ">=2021.5.3", optional = true}
 medcat = {version = ">=1.2.6", optional = true}
 anndata = "^0.7.8"
+flake8-bandit = ">=3.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = ">=6.2.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,10 @@ Jinja2 = ">=3.0.1"
 questionary = ">=1.10.0"
 requests = ">=2.26.0"
 pandas = "^1.3.3"
-anndata = ">=0.7.6"
+mudata = ">=^0.1.1"
 pypi-latest = ">=0.1.1"
 scikit-learn = ">=1.0"
 category_encoders = ">=2.2.2"
-mudata = ">=0.1.1"
 leidenalg = ">=0.8.7"
 deepl = ">=1.2.0"
 pynndescent = ">=0.5.4"
@@ -41,6 +40,7 @@ camelot-py = {extras = ["base"], version = ">=0.10.1"}
 deep-translator = ">=1.6.1"
 scikit-learn-intelex = {version = ">=2021.5.3", optional = true}
 medcat = {version = ">=1.2.6", optional = true}
+anndata = "^0.7.8"
 
 [tool.poetry.dev-dependencies]
 pytest = ">=6.2.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,7 @@ camelot-py = {extras = ["base"], version = ">=0.10.1"}
 deep-translator = ">=1.6.1"
 scikit-learn-intelex = {version = ">=2021.5.3", optional = true}
 medcat = {version = ">=1.2.6", optional = true}
-anndata = "^0.7.8"
-flake8-bandit = ">=3.0.0"
+anndata = ">=0.7.8"
 
 [tool.poetry.dev-dependencies]
 pytest = ">=6.2.5"

--- a/tests/anndata/test_anndata_ext.py
+++ b/tests/anndata/test_anndata_ext.py
@@ -44,13 +44,13 @@ class TestAnndataExt:
         adata = ep.io.read(CUR_DIR / "../io/test_data_io/dataset4.csv")
         move_to_obs(adata, ["name", "clinic_id"])
         assert set(adata.obs.columns) == {"name", "clinic_id"}
-        assert {str(col) for col in adata.obs.dtypes} == {"float32", "object"}
+        assert {str(col) for col in adata.obs.dtypes} == {"float32", "category"}
         assert_frame_equal(
             adata.obs,
             DataFrame(
                 {"clinic_id": [i for i in range(1, 6)], "name": ["foo", "bar", "baz", "buz", "ber"]},
                 index=[str(idx) for idx in range(5)],
-            ).astype({"clinic_id": "float32"}),
+            ).astype({"clinic_id": "float32", "name": "category"}),
         )
 
     def test_move_to_obs_copy(self):
@@ -58,15 +58,15 @@ class TestAnndataExt:
         cp_adata = move_to_obs(adata, ["name", "clinic_id"], copy=True)
         assert id(cp_adata) != id(adata)
         assert set(cp_adata.obs.columns) == {"name", "clinic_id"}
-        assert {str(col) for col in cp_adata.obs.dtypes} == {"float32", "object"}
+        assert {str(col) for col in cp_adata.obs.dtypes} == {"float32", "category"}
         assert not set(adata.obs.columns) == {"name", "clinic_id"}
-        assert not {str(col) for col in adata.obs.dtypes} == {"float32", "object"}
+        assert not {str(col) for col in adata.obs.dtypes} == {"float32", "category"}
         assert_frame_equal(
             cp_adata.obs,
             DataFrame(
                 {"clinic_id": [i for i in range(1, 6)], "name": ["foo", "bar", "baz", "buz", "ber"]},
                 index=[str(idx) for idx in range(5)],
-            ).astype({"clinic_id": "float32"}),
+            ).astype({"clinic_id": "float32", "name": "category"}),
         )
 
     def test_df_to_anndata_simple(self):
@@ -94,7 +94,8 @@ class TestAnndataExt:
         assert adata.X.dtype == "float32"
         assert adata.X.shape == (100, 1)
         assert_frame_equal(
-            adata.obs, DataFrame({"col1": col1_val, "col2": col2_val}, index=[str(idx) for idx in range(100)])
+            adata.obs,
+            DataFrame({"col1": col1_val, "col2": col2_val}, index=[str(idx) for idx in range(100)]).astype("category"),
         )
 
     def test_df_to_anndata_all_num(self):

--- a/tests/io/test_data_io/dataset6.csv
+++ b/tests/io/test_data_io/dataset6.csv
@@ -1,0 +1,6 @@
+clinic_id,los_days,b12_values,name,survival
+1,14,500,foo,False
+2,7,330,bar,True
+3,10,800,baz,false
+4,11,765,buz,True
+5,3,800,ber,True

--- a/tests/io/test_read.py
+++ b/tests/io/test_read.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from ehrapy._util import shell_command_accessible
@@ -52,6 +53,31 @@ class TestRead:
         assert (adata.layers["original"] == matrix).all()
         assert id(adata.layers["original"]) != id(adata.X)
         assert list(adata.obs.index) == ["0", "1", "2", "3", "4"]
+
+    def test_read_csv_with_bools_obs_only(self):
+        adata = read(dataset_path=f"{_TEST_PATH}/dataset1.csv", columns_obs_only=["survival", "b12_values"])
+        matrix = np.array([[12, 14], [13, 7], [14, 10], [15, 11], [16, 3]])
+        assert adata.X.shape == (5, 2)
+        assert (adata.X == matrix).all()
+        assert adata.var_names.to_list() == ["patient_id", "los_days"]
+        assert (adata.layers["original"] == matrix).all()
+        assert id(adata.layers["original"]) != id(adata.X)
+        assert set(adata.obs.columns) == {"b12_values", "survival"}
+        assert pd.api.types.is_bool_dtype(adata.obs["survival"].dtype)
+        assert pd.api.types.is_numeric_dtype(adata.obs["b12_values"].dtype)
+
+    def test_read_csv_with_bools_and_cats_obs_only(self):
+        adata = read(dataset_path=f"{_TEST_PATH}/dataset6.csv", columns_obs_only=["b12_values", "name", "survival"])
+        matrix = np.array([[1, 14], [2, 7], [3, 10], [4, 11], [5, 3]])
+        assert adata.X.shape == (5, 2)
+        assert (adata.X == matrix).all()
+        assert adata.var_names.to_list() == ["clinic_id", "los_days"]
+        assert (adata.layers["original"] == matrix).all()
+        assert id(adata.layers["original"]) != id(adata.X)
+        assert set(adata.obs.columns) == {"b12_values", "survival", "name"}
+        assert pd.api.types.is_bool_dtype(adata.obs["survival"].dtype)
+        assert pd.api.types.is_numeric_dtype(adata.obs["b12_values"].dtype)
+        assert pd.api.types.is_categorical_dtype(adata.obs["name"].dtype)
 
     @pytest.mark.skipif(
         (os.name != "nt" and not shell_command_accessible(["gs", "-h"]))

--- a/tests/preprocessing/test_encode.py
+++ b/tests/preprocessing/test_encode.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
 from ehrapy.io._read import read
@@ -41,6 +42,8 @@ class TestEncode:
             "clinic_day": "label_encoding",
         }
         assert id(encoded_ann_data.X) != id(encoded_ann_data.layers["original"])
+        assert pd.api.types.is_bool_dtype(encoded_ann_data.obs["survival"].dtype)
+        assert pd.api.types.is_categorical_dtype(encoded_ann_data.obs["clinic_day"].dtype)
 
     def test_autodetect_num_only(self, capfd):
         adata = read(dataset_path=f"{_TEST_PATH}/dataset2.csv")
@@ -65,6 +68,8 @@ class TestEncode:
             "clinic_day": "count_encoding",
         }
         assert id(encoded_ann_data.X) != id(encoded_ann_data.layers["original"])
+        assert pd.api.types.is_bool_dtype(encoded_ann_data.obs["survival"].dtype)
+        assert pd.api.types.is_categorical_dtype(encoded_ann_data.obs["clinic_day"].dtype)
 
     def test_autodetect_encode_again(self):
         adata = read(dataset_path=f"{_TEST_PATH}/dataset1.csv")
@@ -96,6 +101,8 @@ class TestEncode:
             "clinic_day": "one_hot_encoding",
         }
         assert id(encoded_ann_data.X) != id(encoded_ann_data.layers["original"])
+        assert pd.api.types.is_bool_dtype(encoded_ann_data.obs["survival"].dtype)
+        assert pd.api.types.is_categorical_dtype(encoded_ann_data.obs["clinic_day"].dtype)
 
     def test_custom_encode_again_single_columns_encoding(self):
         adata = read(dataset_path=f"{_TEST_PATH}/dataset1.csv")
@@ -125,6 +132,8 @@ class TestEncode:
             "clinic_day": "label_encoding",
         }
         assert id(encoded_ann_data_again.X) != id(encoded_ann_data_again.layers["original"])
+        assert pd.api.types.is_bool_dtype(encoded_ann_data.obs["survival"].dtype)
+        assert pd.api.types.is_categorical_dtype(encoded_ann_data.obs["clinic_day"].dtype)
 
     def test_custom_encode_again_multiple_columns_encoding(self):
         adata = read(dataset_path=f"{_TEST_PATH}/dataset1.csv")
@@ -156,6 +165,8 @@ class TestEncode:
             "clinic_day": "count_encoding",
         }
         assert id(encoded_ann_data_again.X) != id(encoded_ann_data_again.layers["original"])
+        assert pd.api.types.is_bool_dtype(encoded_ann_data.obs["survival"].dtype)
+        assert pd.api.types.is_categorical_dtype(encoded_ann_data.obs["clinic_day"].dtype)
 
     def test_update_encoding_scheme_1(self):
         # just a dummy adata object that won't be used actually


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [x] This comment contains a description of changes (with reason)
-   [x] Referenced issue is linked
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [x] Documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the user. -->
Fix #337 and #333
Issue: Cannot write `dtype object` to .`h5ad` files.

Fix:
- convert any non numerical and non bool column to dtype `category`.
- booleans gotta be treated as dtype `boolean` though (see https://github.com/theislab/anndata/issues/724)
- fixed for move_to_obs, encoding and caching
- fixed an issue that caused numerical only data in X to be flagged as `object` dtype while reading from cache

New feature:
- It's now possible to write unencoded AnnData objects to `.h5ad` files. (relates to #333)

Current Issues:
- writing nullable booleans is currently not supported by AnnData 0.7.8 
--> but this got added in 0.8.0 which should be released in the next few days