### PR TITLE
#321: Add X_only option for reading

### DIFF
--- a/ehrapy/io/_read.py
+++ b/ehrapy/io/_read.py
@@ -41,7 +41,7 @@ def read_csv(
         columns_obs_only: These columns will be added to obs only and not X.
         columns_x_only: These columns will be added to X only and all remaining columns to obs. Note that datetime columns will always be added to .obs though.
         return_mudata: Whether to create and return a MuData object. This is primarily used for complex datasets which require several AnnData files.
-        cache: Whether to write to cache when reading or not.
+        cache: Whether to write to cache when reading or not. (default: False)
         download_dataset_name: Name of the file or directory in case the dataset is downloaded
         backup_url: URL to download the data file(s) from if not yet existing.
 

--- a/ehrapy/io/_utility_io.py
+++ b/ehrapy/io/_utility_io.py
@@ -28,3 +28,13 @@ def _get_file_extension(file_path: Path) -> str:
         {supported_extensions}
         """
     )
+
+
+def _convert_x_only_to_obs_only(x_only: dict[str, list[str]] | list[str]) -> dict[str, list[str]] | list[str]:
+    """Convert X only feature names to obs only names by adding all columns to obs only that are not in x_only.
+    X only is later on never used in reading or writing, but its counterpart obs_only is.
+    """
+    if isinstance(x_only, list):
+        pass
+    else:
+        pass

--- a/ehrapy/io/_utility_io.py
+++ b/ehrapy/io/_utility_io.py
@@ -28,31 +28,3 @@ def _get_file_extension(file_path: Path) -> str:
         {supported_extensions}
         """
     )
-
-
-def _check_columns_only_params(
-    obs_only: dict[str, list[str]] | list[str] | None, x_only: dict[str, list[str]] | list[str] | None
-) -> None:
-    """Check whether columns_obs_only and columns_x_only can be used as passed. For a single anndata object (thus
-    parameters being a list of strings) it's not possible to pass both, obs_only and x_only.
-    For multiple anndata objects (thus the parameters being dicts of string keys with a list value), it is possible to pass both. But the keys
-    (unique identifiers of the anndata objects, basically its names) should share no common identifier, thus a single anndata object is either in x_only OR
-    obs_only, but not in both.
-    """
-    # at least one parameter is None
-    if not obs_only or not x_only:
-        return
-    # cannot use both for a single anndata object
-    if obs_only and x_only and isinstance(obs_only, list):
-        raise ValueError(
-            "Can not use columns_obs_only together with columns_x_only with a single AnnData object. At least one has to be None!"
-        )
-    # check for duplicates in the two dicts for multiple AnnData objects
-    else:
-        common_keys = obs_only.keys() & x_only.keys()  # type: ignore
-        # at least one duplicated key has been found
-        if common_keys:
-            raise ValueError(
-                "Can not use columns_obs_only together with columns_x_only for a single AnnData object. The following anndata identifiers where found"
-                f"in both: {','.join(key for key in common_keys)}!"
-            )

--- a/ehrapy/io/_utility_io.py
+++ b/ehrapy/io/_utility_io.py
@@ -30,11 +30,29 @@ def _get_file_extension(file_path: Path) -> str:
     )
 
 
-def _convert_x_only_to_obs_only(x_only: dict[str, list[str]] | list[str]) -> dict[str, list[str]] | list[str]:
-    """Convert X only feature names to obs only names by adding all columns to obs only that are not in x_only.
-    X only is later on never used in reading or writing, but its counterpart obs_only is.
+def _check_columns_only_params(
+    obs_only: dict[str, list[str]] | list[str] | None, x_only: dict[str, list[str]] | list[str] | None
+) -> None:
+    """Check whether columns_obs_only and columns_x_only can be used as passed. For a single anndata object (thus
+    parameters being a list of strings) it's not possible to pass both, obs_only and x_only.
+    For multiple anndata objects (thus the parameters being dicts of string keys with a list value), it is possible to pass both. But the keys
+    (unique identifiers of the anndata objects, basically its names) should share no common identifier, thus a single anndata object is either in x_only OR
+    obs_only, but not in both.
     """
-    if isinstance(x_only, list):
-        pass
+    # at least one parameter is None
+    if not obs_only or not x_only:
+        return
+    # cannot use both for a single anndata object
+    if obs_only and x_only and isinstance(obs_only, list):
+        raise ValueError(
+            "Can not use columns_obs_only together with columns_x_only with a single AnnData object. At least one has to be None!"
+        )
+    # check for duplicates in the two dicts for multiple AnnData objects
     else:
-        pass
+        common_keys = obs_only.keys() & x_only.keys()  # type: ignore
+        # at least one duplicated key has been found
+        if common_keys:
+            raise ValueError(
+                "Can not use columns_obs_only together with columns_x_only for a single AnnData object. The following anndata identifiers where found"
+                f"in both: {','.join(key for key in common_keys)}!"
+            )

--- a/tests/io/test_read.py
+++ b/tests/io/test_read.py
@@ -199,3 +199,88 @@ class TestRead:
         assert adata.X.shape == (5, 2)
         assert list(adata.obs.columns) == ["b12_values", "survival"]
         assert "b12_values" not in list(adata.var_names.values) and "survival" not in list(adata.var_names.values)
+
+    def test_read_raises_error_with_duplicates_columns_only_single_1(self):
+        with pytest.raises(ValueError):
+            _ = read_csv(
+                dataset_path=f"{_TEST_PATH}/dataset_basic.csv",
+                columns_obs_only=["survival", "b12_values"],
+                columns_x_only=["survival", "b12_values"],
+            )
+
+    def test_read_raises_error_with_duplicates_columns_only_single_2(self):
+        with pytest.raises(ValueError):
+            _ = read_csv(
+                dataset_path=f"{_TEST_PATH}/dataset_basic.csv",
+                columns_obs_only=["survival"],
+                columns_x_only=["survival", "b12_values"],
+            )
+
+    def test_read_raises_error_with_duplicates_columns_only_multiple_1(self):
+        with pytest.raises(ValueError):
+            _ = read_csv(
+                dataset_path=f"{_TEST_PATH_MULTIPLE}",
+                columns_obs_only={
+                    "dataset_non_num_with_missing": ["intcol"],
+                    "dataset_num_with_missing": ["col1", "col2"],
+                },
+                columns_x_only={"dataset_non_num_with_missing": ["intcol"]},
+            )
+
+    def test_read_raises_error_with_duplicates_columns_only_multiple_2(self):
+        with pytest.raises(ValueError):
+            _ = read_csv(
+                dataset_path=f"{_TEST_PATH_MULTIPLE}",
+                columns_obs_only={
+                    "dataset_non_num_with_missing": ["intcol"],
+                    "dataset_num_with_missing": ["col1", "col2"],
+                },
+                columns_x_only={"dataset_non_num_with_missing": ["indexcol"], "dataset_num_with_missing": ["col3"]},
+            )
+
+    def test_move_single_column_to_x(self):
+        adata = read_csv(dataset_path=f"{_TEST_PATH}/dataset_basic.csv", columns_x_only=["b12_values"])
+        assert adata.X.shape == (5, 1)
+        assert list(adata.var_names) == ["b12_values"]
+        assert "b12_values" not in list(adata.obs.columns)
+        assert all(obs_names in list(adata.obs.columns) for obs_names in ["los_days", "patient_id", "survival"])
+
+    def test_move_multiple_columns_to_x(self):
+        adata = read_csv(dataset_path=f"{_TEST_PATH}/dataset_basic.csv", columns_x_only=["b12_values", "survival"])
+        assert adata.X.shape == (5, 2)
+        assert all(var_names in list(adata.var_names) for var_names in ["b12_values", "survival"])
+        assert all(obs_names in list(adata.obs.columns) for obs_names in ["los_days", "patient_id"])
+        assert all(var_names not in list(adata.obs.columns) for var_names in ["b12_values", "survival"])
+
+    def test_read_multiple_csv_with_x_only(self):
+        adatas = read_csv(
+            dataset_path=f"{_TEST_PATH_MULTIPLE}",
+            columns_x_only={"dataset_non_num_with_missing": ["strcol"], "dataset_num_with_missing": ["col1"]},
+        )
+        adata_ids = set(adatas.keys())
+        assert all(adata_id in adata_ids for adata_id in {"dataset_non_num_with_missing", "dataset_num_with_missing"})
+        assert set(adatas["dataset_non_num_with_missing"].obs.columns) == {
+            "indexcol",
+            "intcol",
+            "boolcol",
+            "binary_col",
+            "datetime",
+        }
+        assert set(adatas["dataset_num_with_missing"].obs.columns) == {"col" + str(i) for i in range(2, 4)}
+        assert set(adatas["dataset_non_num_with_missing"].var_names) == {"strcol"}
+        assert set(adatas["dataset_num_with_missing"].var_names) == {"col1"}
+
+    def test_read_multiple_csv_with_x_only_2(self):
+        adatas = read_csv(
+            dataset_path=f"{_TEST_PATH_MULTIPLE}",
+            columns_x_only={
+                "dataset_non_num_with_missing": ["strcol", "intcol", "boolcol"],
+                "dataset_num_with_missing": ["col1", "col3"],
+            },
+        )
+        adata_ids = set(adatas.keys())
+        assert all(adata_id in adata_ids for adata_id in {"dataset_non_num_with_missing", "dataset_num_with_missing"})
+        assert set(adatas["dataset_non_num_with_missing"].obs.columns) == {"indexcol", "binary_col", "datetime"}
+        assert set(adatas["dataset_num_with_missing"].obs.columns) == {"col2"}
+        assert set(adatas["dataset_non_num_with_missing"].var_names) == {"strcol", "intcol", "boolcol"}
+        assert set(adatas["dataset_num_with_missing"].var_names) == {"col1", "col3"}


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [x] This comment contains a description of changes (with reason)
-   [x] Referenced issue is linked
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [x] Documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the user. -->
- see #321 
- added an option to read with columns that should go to X only and everything else to `.obs`
- datetime columns will be added to `.obs` regardless.