### PR TITLE
fix qc_metrics bug

### DIFF
--- a/ehrapy/preprocessing/_quality_control.py
+++ b/ehrapy/preprocessing/_quality_control.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from pathlib import Path
 from typing import Collection, Literal
 
@@ -116,7 +117,19 @@ def _obs_qc_metrics(
         A Pandas DataFrame with the calculated metrics.
     """
     obs_metrics = pd.DataFrame(index=adata.obs_names)
+    var_metrics = pd.DataFrame(index=adata.var_names)
     mtx = adata.X if layer is None else adata.layers[layer]
+    if "original_values_categoricals" in adata.uns:
+        for original_values_categorical in list(adata.uns["original_values_categoricals"]):
+            mtx = mtx.astype(object)
+            index = np.where(var_metrics.index.str.contains(original_values_categorical))[0]
+            mtx[:, index[0]] = np.squeeze(
+                np.where(
+                    adata.uns["original_values_categoricals"][original_values_categorical].astype(object) == "nan",
+                    np.nan,
+                    adata.uns["original_values_categoricals"][original_values_categorical].astype(object),
+                )
+            )
 
     obs_metrics["missing_values_abs"] = np.apply_along_axis(_missing_values, 1, mtx)
     obs_metrics["missing_values_pct"] = np.apply_along_axis(_missing_values, 1, mtx, shape=mtx.shape, df_type="obs")
@@ -146,9 +159,20 @@ def _var_qc_metrics(adata: AnnData, layer: str = None) -> pd.DataFrame:
     Returns:
         Pandas DataFrame with the calculated metrics.
     """
-    # TODO we need to ensure that we are calculating the QC metrics for the original -> look at adata.uns
     var_metrics = pd.DataFrame(index=adata.var_names)
     mtx = adata.X if layer is None else adata.layers[layer]
+    if "original_values_categoricals" in adata.uns:
+        for original_values_categorical in list(adata.uns["original_values_categoricals"]):
+            mtx = copy.deepcopy(mtx.astype(object))
+            index = np.where(var_metrics.index.str.contains(original_values_categorical))[0]
+            mtx[:, index] = np.tile(
+                np.where(
+                    adata.uns["original_values_categoricals"][original_values_categorical].astype(object) == "nan",
+                    np.nan,
+                    adata.uns["original_values_categoricals"][original_values_categorical].astype(object),
+                ),
+                mtx[:, index].shape[1],
+            )
 
     var_metrics["missing_values_abs"] = np.apply_along_axis(_missing_values, 0, mtx)
     var_metrics["missing_values_pct"] = np.apply_along_axis(_missing_values, 0, mtx, shape=mtx.shape, df_type="var")

--- a/tests/preprocessing/test_quality_control.py
+++ b/tests/preprocessing/test_quality_control.py
@@ -5,10 +5,13 @@ import pandas as pd
 from anndata import AnnData
 
 import ehrapy as ep
+from ehrapy.io._read import read_csv
+from ehrapy.preprocessing._encode import encode
 from ehrapy.preprocessing._quality_control import _obs_qc_metrics, _var_qc_metrics
 
 CURRENT_DIR = Path(__file__).parent
 _TEST_PATH = f"{CURRENT_DIR}/test_preprocessing"
+_TEST_PATH_ENCODE = f"{CURRENT_DIR}/test_data_encode"
 
 
 class TestQualityControl:
@@ -59,6 +62,24 @@ class TestQualityControl:
         assert np.allclose(var_metrics["median"].values, np.array([0.21, np.nan, 24.327]), equal_nan=True)
         assert np.allclose(var_metrics["min"].values, np.array([0.21, np.nan, 7.234]), equal_nan=True)
         assert np.allclose(var_metrics["max"].values, np.array([0.21, np.nan, 41.419998]), equal_nan=True)
+
+    def test_obs_nan_qc_metrics(self):
+        adata = read_csv(dataset_path=f"{_TEST_PATH_ENCODE}/dataset1.csv")
+        adata.X[0][4] = np.nan
+        adata2 = encode(adata, encodings={"one_hot_encoding": ["clinic_day"]})
+        obs_metrics = _obs_qc_metrics(adata2)
+        assert obs_metrics.iloc[0][0] == 1
+
+    def test_var_nan_qc_metrics(self):
+        adata = read_csv(dataset_path=f"{_TEST_PATH_ENCODE}/dataset1.csv")
+        adata.X[0][4] = np.nan
+        adata2 = encode(adata, encodings={"one_hot_encoding": ["clinic_day"]})
+        var_metrics = _var_qc_metrics(adata2)
+        assert var_metrics.iloc[0][0] == 1
+        assert var_metrics.iloc[1][0] == 1
+        assert var_metrics.iloc[2][0] == 1
+        assert var_metrics.iloc[3][0] == 1
+        assert var_metrics.iloc[4][0] == 1
 
     def test_calculate_qc_metrics(self):
         obs_metrics, var_metrics = ep.pp.qc_metrics(self.test_missing_values_adata, inplace=True)


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [ ] This comment contains a description of changes (with reason)
-   [ ] Referenced issue is linked
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Calculate QC metrics for the original data. When detecting "original_values_categoricals" in adata.uns, then the adata has been decoded. And replacing the encoded columns in count matrix with original values.

<!-- Please state what you've chang
ed and how it might affect the user. -->

**Technical details**

<!-- Please state any technical details such as limitations, reasons for additional dependencies, benchmarks etc. here. -->

**Additional context**
<img width="653" alt="New results" src="https://user-images.githubusercontent.com/88339105/205018998-4da6cf93-e52c-4538-b716-e9a14533067c.png">

<!-- Add any other context or screenshots here. -->
