### PR TITLE
Logger info message when writing to .h5ad files

### DIFF
--- a/ehrapy/preprocessing/_encode.py
+++ b/ehrapy/preprocessing/_encode.py
@@ -225,6 +225,7 @@ def _encode(
             )
             progress.update(task, description="Updating layer originals ...")
             # update layer content with the latest categorical encoding and the old other values
+            logg.info("Encoding strings in X to save to .h5ad. Loading the file will reverse the encoding.")
             updated_layer = _update_layer_after_encoding(
                 adata.layers["original"],
                 encoded_x,


### PR DESCRIPTION
**Description of changes**

Added a `logg.info()` message into the internal encoding method. 
