### PR TITLE
Feature/rank features group

### DIFF
--- a/ehrapy/tools/_datatypes.py
+++ b/ehrapy/tools/_datatypes.py
@@ -7,6 +7,8 @@ _Layout = Literal[_LAYOUTS]  # type: ignore
 
 _rank_features_groups_method = Optional[Literal["logreg", "t-test", "wilcoxon", "t-test_overestim_var"]]
 _corr_method = Literal["benjamini-hochberg", "bonferroni"]
-_rank_features_groups_cat_method = Literal["chi-square", "g-test", "freeman-tukey", "mod-log-likelihood", "neyman", "cressie-read"]
+_rank_features_groups_cat_method = Literal[
+    "chi-square", "g-test", "freeman-tukey", "mod-log-likelihood", "neyman", "cressie-read"
+]
 
 _marker_feature_overlap_methods = Literal["overlap_count", "overlap_coef", "jaccard"]

--- a/ehrapy/tools/_datatypes.py
+++ b/ehrapy/tools/_datatypes.py
@@ -1,0 +1,12 @@
+from typing import Literal, Optional
+
+_InitPos = Literal["paga", "spectral", "random"]
+
+_LAYOUTS = ("fr", "drl", "kk", "grid_fr", "lgl", "rt", "rt_circular", "fa")
+_Layout = Literal[_LAYOUTS]  # type: ignore
+
+_rank_features_groups_method = Optional[Literal["logreg", "t-test", "wilcoxon", "t-test_overestim_var"]]
+_corr_method = Literal["benjamini-hochberg", "bonferroni"]
+_rank_features_groups_cat_method = Literal["chi-square", "g-test", "freeman-tukey", "mod-log-likelihood", "neyman", "cressie-read"]
+
+_marker_feature_overlap_methods = Literal["overlap_count", "overlap_coef", "jaccard"]

--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -924,7 +924,7 @@ def _evaluate_categorical_features(
     groups_values = adata.obs[groupby].to_numpy()
 
     for feature in adata.uns["non_numerical_columns"]:
-        if feature == groupby or "ehrapycat_" + feature == groupby:
+        if feature == groupby or "ehrapycat_" + feature == groupby or feature == "ehrapycat_" + groupby:
             continue
             
         feature_values = adata[:, feature].X.flatten().toarray()

--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -903,7 +903,7 @@ def rank_features_groups(
             names=categorical_names,
             scores=categorical_scores,
             pvals=categorical_pvals,
-            pvals_adj=categorical_pvals,
+            pvals_adj=categorical_pvals.copy(),
             logfoldchanges=categorical_logfoldchanges,
             pts=categorical_pts,
             groups_order=group_names

--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -837,7 +837,22 @@ def _sort_features(adata, key_added="rank_features_groups") -> None:
             # Sort every key (e.g. pvals, names) by adjusted p-value in an increasing order
             adata.uns[key_added][key][group] = adata.uns[key_added][key][group][sorted_indexes]
 
-def _save_rank_features_result(adata, key_added, names, scores, pvals, pvals_adj=None, logfoldchanges=None, pts=None, groups_order=None):
+def _save_rank_features_result(adata, key_added, names, scores, pvals, pvals_adj=None, logfoldchanges=None, pts=None, groups_order=None) -> None:
+    """Write keys with statistical test results to adata.uns
+    
+    Args:
+        adata: Annotated data matrix after running :func:`~ehrapy.tl.rank_features_groups`
+        key_added: The key in `adata.uns` information is saved to.
+        names: Structured array storing the feature names
+        scores: Array with the statistics
+        logfoldchanges: logarithm of fold changes or other info to store under logfoldchanges key
+        pvals: p-values of a statistical test 
+        pts: Percentages of cells containing features
+        groups_order: order of groups in structured arrays
+
+    Returns:
+        Nothing. The operation is performed in place
+    """
     fields = (names, scores, pvals, pvals_adj, logfoldchanges, pts)
     field_names = ("names", "scores", "pvals", "pvals_adj", "logfoldchanges", "pts")
 

--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -925,18 +925,16 @@ def rank_features_groups(
             numerical_logfoldchanges = numerical_adata.uns[key_added]["logfoldchanges"]
         else:
             numerical_logfoldchanges = None
-        if "pts" in numerical_adata.uns[key_added]:
-            numerical_pts = numerical_adata.uns[key_added]["pts"]
-        else:
-            numerical_pts = None
         adata.uns[key_added] = {
             "names": numerical_adata.uns[key_added]["names"],
             "scores": numerical_adata.uns[key_added]["scores"],
             "pvals": numerical_adata.uns[key_added]["pvals"],
             "pvals_adj": numerical_adata.uns[key_added]["pvals_adj"],
             "logfoldchanges": numerical_logfoldchanges,
-            "pts": numerical_pts,
         }
+        
+        if "pts" in numerical_adata.uns[key_added]:
+            adata.uns[key_added]["pts"] = numerical_adata.uns[key_added]["pts"]
         
         adata.uns[key_added]["params"] = numerical_adata.uns[key_added]["params"]
 
@@ -998,8 +996,10 @@ def rank_features_groups(
                 "scores": np.array(categorical_scores),
                 "pvals": np.array(categorical_pvals),
                 "logfoldchanges": np.array(categorical_logfoldchanges),
-                "pts": np.array(categorical_pts),
             }
+            
+            if pts:
+                adata.uns[key_added]["pts"]: np.array(categorical_pts)
         else:
             # TODO: remove copy pasting
             adata.uns[key_added]["names"] = _merge_arrays(
@@ -1026,15 +1026,20 @@ def rank_features_groups(
                 groups_order=group_names
             )
 
-            adata.uns[key_added]["pts"] = _merge_arrays(
-                recarray=adata.uns[key_added]["pts"],
-                array=np.array(categorical_pts),
-                groups_order=group_names
-            )
+            if pts:
+                adata.uns[key_added]["pts"] = _merge_arrays(
+                    recarray=adata.uns[key_added]["pts"],
+                    array=np.array(categorical_pts),
+                    groups_order=group_names
+                )
             
     # Adjust p values  
     if "pvals" in adata.uns[key_added]:
         adata.uns[key_added]["pvals_adj"] = _adjust_pvalues(adata.uns[key_added]["pvals"], corr_method=corr_method)
+        
+    # For some reason, pts should be a DataFrame
+    if "pts" in adata.uns[key_added]:
+        adata.uns[key_added]["pts"] = pd.DataFrame(adata.uns[key_added]["pts"])
 
     return adata if copy else None
 

--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -903,6 +903,19 @@ def _evaluate_categorical_features(
                    If a group identifier, compare with respect to this group.
         pts: Whether to add 'pts' key to output. Doesn't contain useful information in this case.
         categorical_method: statistical method to calculate differences between categories
+
+    Returns:
+        *names*: `np.array` 
+                  Structured array to be indexed by group id storing the feature names
+        *scores*: `np.array`
+                  Array to be indexed by group id storing the statistic underlying
+                  the computation of a p-value for each feature for each group.
+        *logfoldchanges*: `np.array`
+                          Always equal to 1 for this function 
+        *pvals*: `np.array`
+                 p-values of a statistical test 
+        *pts*: `np.array`
+                 Always equal to 1 for this function
     """
     tests_to_lambdas = {
         "chi-square": 1,

--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -840,9 +840,6 @@ def _sort_features(adata, key_added="rank_features_groups") -> None:
 def _save_rank_features_result(adata, key_added, names, scores, pvals, pvals_adj=None, logfoldchanges=None, pts=None, groups_order=None):
     fields = (names, scores, pvals, pvals_adj, logfoldchanges, pts)
     field_names = ("names", "scores", "pvals", "pvals_adj", "logfoldchanges", "pts")
-    
-    if key_added not in adata.uns:
-        adata.uns[key_added] = {}
 
     for values, key in zip(fields, field_names):
         if values is None or not len(values):
@@ -939,6 +936,16 @@ def rank_features_groups(
         
     if not adata.obs[groupby].dtype == "category":
         adata.obs[groupby] = pd.Categorical(adata.obs[groupby])
+
+    adata.uns[key_added] = {}
+    adata.uns[key_added]["params"] = dict(
+        groupby=groupby,
+        reference=reference,
+        method=method,
+        categorical_method=categorical_method,
+        layer=layer,
+        corr_method=corr_method,
+    )
 
     groups_values = adata.obs[groupby].to_numpy()
     group_names = pd.Categorical(adata.obs[groupby].astype(str)).categories.tolist()

--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -1097,9 +1097,7 @@ def rank_features_groups(
             pts=numerical_adata.uns[key_added].get("pts", None),
             groups_order=group_names
         )
-        
-        adata.uns[key_added]["params"] = numerical_adata.uns[key_added]["params"]
-
+    
     if adata.uns["non_numerical_columns"]:
         categorical_names, categorical_scores, categorical_pvals, categorical_logfoldchanges, categorical_pts = _evaluate_categorical_features(
             adata=adata,

--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -916,10 +916,6 @@ def rank_features_groups(
          >>> ep.pl.rank_features_groups(adata)
     """
     adata = adata.copy() if copy else adata
-    
-    if groupby not in adata.obs.columns and groupby in adata.var_names:
-        # TODO: delete it from obs afterwards?
-        adata.obs[groupby] = adata[:, groupby].X.flatten().tolist()
         
     if not adata.obs[groupby].dtype == "category":
         adata.obs[groupby] = pd.Categorical(adata.obs[groupby])

--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -944,6 +944,8 @@ def rank_features_groups(
         categorical_names = []
         categorical_scores = []
         categorical_pvals = []
+        categorical_logfoldchanges = []
+        categorical_pts = []
 
         tests_to_lambdas = {
             "chi-square": 1,
@@ -983,6 +985,10 @@ def rank_features_groups(
             categorical_names.append([feature] * len(group_names))
             categorical_scores.append(scores)
             categorical_pvals.append(pvals)
+            # It is not clear, how to interpret logFC or percentages for categorical data
+            # For now, leave some values so that plotting and sorting methods work
+            categorical_logfoldchanges.append(np.ones(len(group_names)))
+            categorical_pts.append(np.ones(len(group_names)))
 
         # Append categorical results to adata.uns
     
@@ -991,9 +997,11 @@ def rank_features_groups(
                 "names": np.array(categorical_names),
                 "scores": np.array(categorical_scores),
                 "pvals": np.array(categorical_pvals),
+                "logfoldchanges": np.array(categorical_logfoldchanges),
+                "pts": np.array(categorical_pts),
             }
         else:
-            
+            # TODO: remove copy pasting
             adata.uns[key_added]["names"] = _merge_arrays(
                 recarray=adata.uns[key_added]["names"],
                 array=np.array(categorical_names),
@@ -1010,7 +1018,19 @@ def rank_features_groups(
                 recarray=adata.uns[key_added]["pvals"],
                 array=np.array(categorical_pvals),
                 groups_order=group_names
-            )    
+            )
+
+            adata.uns[key_added]["logfoldchanges"] = _merge_arrays(
+                recarray=adata.uns[key_added]["logfoldchanges"],
+                array=np.array(categorical_logfoldchanges),
+                groups_order=group_names
+            )
+
+            adata.uns[key_added]["pts"] = _merge_arrays(
+                recarray=adata.uns[key_added]["pts"],
+                array=np.array(categorical_pts),
+                groups_order=group_names
+            )
             
     # Adjust p values  
     if "pvals" in adata.uns[key_added]:

--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -921,24 +921,24 @@ def rank_features_groups(
         )
 
         # Update adata.uns with numerical result
-        if 'logfoldchanges' in numerical_adata.uns[key_added]:
-            numerical_logfoldchanges = numerical_adata.uns[key_added]['logfoldchanges']
+        if "logfoldchanges" in numerical_adata.uns[key_added]:
+            numerical_logfoldchanges = numerical_adata.uns[key_added]["logfoldchanges"]
         else:
             numerical_logfoldchanges = None
-        if 'pts' in numerical_adata.uns[key_added]:
-            numerical_pts = numerical_adata.uns[key_added]['pts']
+        if "pts" in numerical_adata.uns[key_added]:
+            numerical_pts = numerical_adata.uns[key_added]["pts"]
         else:
             numerical_pts = None
         adata.uns[key_added] = {
-            'names': numerical_adata.uns[key_added]['names'],
-            'scores': numerical_adata.uns[key_added]['scores'],
-            'pvals': numerical_adata.uns[key_added]['pvals'],
-            'pvals_adj': numerical_adata.uns[key_added]['pvals_adj'],
-            'logfoldchanges': numerical_logfoldchanges,
-            'pts': numerical_pts,
+            "names": numerical_adata.uns[key_added]["names"],
+            "scores": numerical_adata.uns[key_added]["scores"],
+            "pvals": numerical_adata.uns[key_added]["pvals"],
+            "pvals_adj": numerical_adata.uns[key_added]["pvals_adj"],
+            "logfoldchanges": numerical_logfoldchanges,
+            "pts": numerical_pts,
         }
         
-        adata.uns[key_added]['params'] = numerical_adata.uns[key_added]['params']
+        adata.uns[key_added]["params"] = numerical_adata.uns[key_added]["params"]
 
     if adata.uns["non_numerical_columns"]:
         categorical_names = []
@@ -988,25 +988,25 @@ def rank_features_groups(
     
         if key_added not in adata.uns:
             adata.uns[key_added] = {
-                'names': np.array(categorical_names),
-                'scores': np.array(categorical_scores),
-                'pvals': np.array(categorical_pvals),
+                "names": np.array(categorical_names),
+                "scores": np.array(categorical_scores),
+                "pvals": np.array(categorical_pvals),
             }
         else:
             
-            adata.uns[key_added]['names'] = _merge_arrays(
+            adata.uns[key_added]["names"] = _merge_arrays(
                 recarray=adata.uns[key_added]["names"],
                 array=np.array(categorical_names),
                 groups_order=group_names
             )
             
-            adata.uns[key_added]['scores'] = _merge_arrays(
+            adata.uns[key_added]["scores"] = _merge_arrays(
                 recarray=adata.uns[key_added]["scores"],
                 array=np.array(categorical_scores),
                 groups_order=group_names
             )
             
-            adata.uns[key_added]['pvals'] = _merge_arrays(
+            adata.uns[key_added]["pvals"] = _merge_arrays(
                 recarray=adata.uns[key_added]["pvals"],
                 array=np.array(categorical_pvals),
                 groups_order=group_names

--- a/ehrapy/tools/_utils.py
+++ b/ehrapy/tools/_utils.py
@@ -14,9 +14,7 @@ def _merge_arrays(arrays: Iterable[Iterable], groups_order):
     # The easiest way to merge recarrays is through dataframe conversion
     dfs = []
     for array in arrays:
-        if type(array) == np.recarray:
-            dfs.append(pd.DataFrame(array)[groups_order])
-        elif type(array) == np.ndarray:
+        if type(array) == np.recarray or type(array) == np.ndarray:
             dfs.append(pd.DataFrame(array, columns=groups_order))
         elif type(array) == pd.DataFrame:
             dfs.append(array[groups_order])

--- a/ehrapy/tools/_utils.py
+++ b/ehrapy/tools/_utils.py
@@ -137,7 +137,7 @@ def _get_groups_order(groups_subset, group_names, reference):
             f"reference = {reference} needs to be one of groupby = {group_names}."
         )
     
-    return groups_order
+    return tuple(groups_order)
 
 def _evaluate_categorical_features(
         adata,

--- a/ehrapy/tools/_utils.py
+++ b/ehrapy/tools/_utils.py
@@ -12,8 +12,8 @@ def _merge_arrays(recarray, array, groups_order):
     # The easiest way to convert recarray to a normal array is through pandas
     df = pd.DataFrame(recarray)
 
-    # In case groups have different order
-    converted_recarray = df[groups_order]
+    # In case groups have different order. List conversion helps to prevent error, when `groups_order` is hashable (e.g. tuple)
+    converted_recarray = df[list(groups_order)]
     concatenated_arrays = pd.concat([converted_recarray, pd.DataFrame(array, columns=groups_order)],
                                     ignore_index=True, axis=0)
     

--- a/ehrapy/tools/_utils.py
+++ b/ehrapy/tools/_utils.py
@@ -121,6 +121,14 @@ def _get_groups_order(groups_subset, group_names, reference):
 
     Returns:
         List of groups, subsetted or full
+
+    Examples:
+        >>> _get_groups_order(groups_subset="all", group_names=("A", "B", "C"), reference="B")
+        ('A', 'B', 'C')
+        >>> _get_groups_order(groups_subset=("A", "B"), group_names=("A", "B", "C"), reference="rest")
+        ('A', 'B')
+        >>> _get_groups_order(groups_subset=("A", "B"), group_names=("A", "B", "C"), reference="C")
+        ('A', 'B', 'C'])
     """
     if groups_subset == "all":
         groups_order = group_names

--- a/ehrapy/tools/_utils.py
+++ b/ehrapy/tools/_utils.py
@@ -1,0 +1,238 @@
+from typing import Union, Iterable, Literal
+
+import numpy as np
+import pandas as pd
+
+from ehrapy.tools import _datatypes
+
+
+def _merge_arrays(recarray, array, groups_order):
+    """Merge `recarray` obtained from scanpy with manually created numpy `array`"""
+
+    # The easiest way to convert recarray to a normal array is through pandas
+    df = pd.DataFrame(recarray)
+
+    # In case groups have different order
+    converted_recarray = df[groups_order]
+    concatenated_arrays = pd.concat([converted_recarray, pd.DataFrame(array, columns=groups_order)],
+                                    ignore_index=True, axis=0)
+    
+    return concatenated_arrays.to_records(index=False)
+
+
+def _adjust_pvalues(pvals: np.recarray, corr_method: _datatypes._corr_method):
+    """Perform per group p-values correction with a given `corr_method`
+    
+    Args:
+        pvals: numpy records array with p-values. The resulting p-values are corrected per group (i.e. column)
+        corr_method: p-value correction method
+
+    Returns:
+        Records array of the same format as an input but with corrected p-values
+    """
+    from statsmodels.stats.multitest import multipletests
+
+    method_map = {
+        "benjamini-hochberg": "fdr_bh",
+        "bonferroni": "bonferroni"
+    }
+
+    pvals_adj = np.ones_like(pvals)
+
+    for group in pvals.dtype.names:
+        group_pvals = pvals[group]
+        
+        _, group_pvals_adj, _, _ = multipletests(
+            group_pvals, alpha=0.05, method=method_map[corr_method]
+        )
+        pvals_adj[group] = group_pvals_adj
+
+    return pvals_adj
+
+
+def _sort_features(adata, key_added="rank_features_groups") -> None:
+    """Sort results of :func:`~ehrapy.tl.rank_features_groups` by adjusted p-value
+    
+    Args:
+        adata: Annotated data matrix after running :func:`~ehrapy.tl.rank_features_groups`
+        key_added: The key in `adata.uns` information is saved to.
+
+    Returns:
+        Nothing. The operation is performed in place
+    """
+    if key_added not in adata.uns:
+        return
+
+    pvals_adj = adata.uns[key_added]["pvals_adj"]
+
+    for group in pvals_adj.dtype.names:
+        group_pvals = pvals_adj[group]
+        sorted_indexes = np.argsort(group_pvals)
+        
+        for key in adata.uns[key_added].keys():
+            if key == "params":
+                # This key only stores technical information, nothing to sort here
+                continue
+            
+            # Sort every key (e.g. pvals, names) by adjusted p-value in an increasing order
+            adata.uns[key_added][key][group] = adata.uns[key_added][key][group][sorted_indexes]
+
+
+def _save_rank_features_result(adata, key_added, names, scores, pvals, pvals_adj=None, logfoldchanges=None, pts=None, groups_order=None) -> None:
+    """Write keys with statistical test results to adata.uns
+    
+    Args:
+        adata: Annotated data matrix after running :func:`~ehrapy.tl.rank_features_groups`
+        key_added: The key in `adata.uns` information is saved to.
+        names: Structured array storing the feature names
+        scores: Array with the statistics
+        logfoldchanges: logarithm of fold changes or other info to store under logfoldchanges key
+        pvals: p-values of a statistical test 
+        pts: Percentages of cells containing features
+        groups_order: order of groups in structured arrays
+
+    Returns:
+        Nothing. The operation is performed in place
+    """
+    fields = (names, scores, pvals, pvals_adj, logfoldchanges, pts)
+    field_names = ("names", "scores", "pvals", "pvals_adj", "logfoldchanges", "pts")
+
+    for values, key in zip(fields, field_names):
+        if values is None or not len(values):
+            continue
+
+        if key not in adata.uns[key_added]:
+            adata.uns[key_added][key] = values
+        else:
+            adata.uns[key_added][key] = _merge_arrays(
+                recarray=adata.uns[key_added][key],
+                array=np.array(values),
+                groups_order=groups_order
+            )
+
+def _get_groups_order(groups_subset, group_names, reference):
+    """Convert `groups` parameter of :func:`~ehrapy.tl.rank_features_groups` to a list of groups
+    
+    Args:
+        groups_subset: Subset of groups, e.g. [`'g1'`, `'g2'`, `'g3'`], to which comparison
+                       shall be restricted, or `'all'` (default), for all groups.
+        group_names: list of all available group names
+        reference: One of the groups of `'rest'`
+
+    Returns:
+        List of groups, subsetted or full
+    """
+    if groups_subset == "all":
+        groups_order = group_names
+    elif isinstance(groups_subset, (str, int)):
+        raise ValueError("Specify a sequence of groups")
+    else:
+        groups_order = list(groups_subset)
+        if isinstance(groups_order[0], int):
+            groups_order = [str(n) for n in groups_order]
+        if reference != "rest" and reference not in groups_order:
+            groups_order += [reference]
+    if reference != "rest" and reference not in group_names:
+        raise ValueError(
+            f"reference = {reference} needs to be one of groupby = {group_names}."
+        )
+    
+    return groups_order
+
+def _evaluate_categorical_features(
+        adata,
+        groupby,
+        group_names,
+        groups: Union[Literal["all"], Iterable[str]] = "all",
+        reference: str = "rest", 
+        categorical_method: _datatypes._rank_features_groups_cat_method = "g-test", 
+        pts=False
+):
+    """Run statistical test for categorical features
+
+    Args:
+        adata: Annotated data matrix.
+        groupby: The key of the observations grouping to consider.
+        groups: Subset of groups, e.g. [`'g1'`, `'g2'`, `'g3'`], to which comparison
+                shall be restricted, or `'all'` (default), for all groups.
+        reference: If `'rest'`, compare each group to the union of the rest of the group.
+                   If a group identifier, compare with respect to this group.
+        pts: Whether to add 'pts' key to output. Doesn't contain useful information in this case.
+        categorical_method: statistical method to calculate differences between categories
+
+    Returns:
+        *names*: `np.array` 
+                  Structured array to be indexed by group id storing the feature names
+        *scores*: `np.array`
+                  Array to be indexed by group id storing the statistic underlying
+                  the computation of a p-value for each feature for each group.
+        *logfoldchanges*: `np.array`
+                          Always equal to 1 for this function 
+        *pvals*: `np.array`
+                 p-values of a statistical test 
+        *pts*: `np.array`
+                 Always equal to 1 for this function
+    """
+    from scipy.stats import chi2_contingency
+
+    tests_to_lambdas = {
+        "chi-square": 1,
+        "g-test": 0,
+        "freeman-tukey": -1/2,
+        "mod-log-likelihood": -1,
+        "neyman": -2,
+        "cressie-read": 2/3,
+    }
+
+    categorical_names = []
+    categorical_scores = []
+    categorical_pvals = []
+    categorical_logfoldchanges = []
+    categorical_pts = []
+
+    groups_order = _get_groups_order(groups_subset=groups, group_names=group_names, reference=reference)
+
+    groups_values = adata.obs[groupby].to_numpy()
+
+    for feature in adata.uns["non_numerical_columns"]:
+        if feature == groupby or "ehrapycat_" + feature == groupby or feature == "ehrapycat_" + groupby:
+            continue
+            
+        feature_values = adata[:, feature].X.flatten().toarray()
+
+        pvals = []
+        scores = []
+
+        for group in group_names:
+            if group not in groups_order:
+                continue
+
+            if reference == "rest":
+                reference_mask = (groups_values != group) & np.isin(groups_values, groups_order)
+                contingency_table = pd.crosstab(feature_values, reference_mask)
+            else:
+                obs_to_take = np.isin(groups_values, [group, reference])
+                reference_mask = groups_values[obs_to_take] == reference
+                contingency_table = pd.crosstab(feature_values[obs_to_take], reference_mask)
+
+            score, p_value, _, _ = chi2_contingency(
+                contingency_table.values, lambda_=tests_to_lambdas[categorical_method])
+            scores.append(score)
+            pvals.append(p_value)
+        
+        categorical_names.append([feature] * len(group_names))
+        categorical_scores.append(scores)
+        categorical_pvals.append(pvals)
+        # It is not clear, how to interpret logFC or percentages for categorical data
+        # For now, leave some values so that plotting and sorting methods work
+        categorical_logfoldchanges.append(np.ones(len(group_names)))
+        if pts:
+            categorical_pts.append(np.ones(len(group_names)))
+
+    return (
+        np.array(categorical_names), 
+        np.array(categorical_scores),
+        np.array(categorical_pvals),
+        np.array(categorical_logfoldchanges),
+        np.array(categorical_pts)
+    )

--- a/ehrapy/tools/_utils.py
+++ b/ehrapy/tools/_utils.py
@@ -106,7 +106,7 @@ def _save_rank_features_result(adata, key_added, names, scores, pvals, pvals_adj
             continue
 
         if key not in adata.uns[key_added]:
-            adata.uns[key_added][key] = pd.DataFrame(values, columns=groups_order).to_records()
+            adata.uns[key_added][key] = pd.DataFrame(values, columns=groups_order).to_records(index=False)
         else:
             adata.uns[key_added][key] = _merge_arrays([adata.uns[key_added][key], values], groups_order=groups_order)
 

--- a/ehrapy/tools/_utils.py
+++ b/ehrapy/tools/_utils.py
@@ -128,7 +128,7 @@ def _get_groups_order(groups_subset, group_names, reference):
         >>> _get_groups_order(groups_subset=("A", "B"), group_names=("A", "B", "C"), reference="rest")
         ('A', 'B')
         >>> _get_groups_order(groups_subset=("A", "B"), group_names=("A", "B", "C"), reference="C")
-        ('A', 'B', 'C'])
+        ('A', 'B', 'C')
     """
     if groups_subset == "all":
         groups_order = group_names

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ehrapy"
-version = "0.4.0"  # <<COOKIETEMPLE_FORCE_BUMP>>
+version = "0.5.0"  # <<COOKIETEMPLE_FORCE_BUMP>>
 description = "Electronic Health Record Analysis with Python."
 authors = ["Lukas Heumos <lukas.heumos@posteo.net>", "Philipp Ehmele <philipp_ehm@protonmail.com>"]
 license = "Apache2.0"

--- a/tests/tools/test_features_ranking.py
+++ b/tests/tools/test_features_ranking.py
@@ -159,6 +159,9 @@ class TestHelperFunctions:
             assert "service_unit" not in names
             assert "ehrapycat_service_unit" not in names
 
+            # Check that the only other categorical feature is in the results
+            assert "ehrapycat_day_icu_intime" in names
+
 
 class TestRankFeaturesGroups():
     def test_real_dataset(self):

--- a/tests/tools/test_features_ranking.py
+++ b/tests/tools/test_features_ranking.py
@@ -4,6 +4,38 @@ import pandas as pd
 import ehrapy as ep
 from ehrapy.tools import _utils
 
+def _save_rank_features_result(adata, key_added, names, scores, pvals, pvals_adj=None, logfoldchanges=None, pts=None, groups_order=None) -> None:
+    """Write keys with statistical test results to adata.uns
+    
+    Args:
+        adata: Annotated data matrix after running :func:`~ehrapy.tl.rank_features_groups`
+        key_added: The key in `adata.uns` information is saved to.
+        names: Structured array storing the feature names
+        scores: Array with the statistics
+        logfoldchanges: logarithm of fold changes or other info to store under logfoldchanges key
+        pvals: p-values of a statistical test 
+        pts: Percentages of cells containing features
+        groups_order: order of groups in structured arrays
+
+    Returns:
+        Nothing. The operation is performed in place
+    """
+    fields = (names, scores, pvals, pvals_adj, logfoldchanges, pts)
+    field_names = ("names", "scores", "pvals", "pvals_adj", "logfoldchanges", "pts")
+
+    for values, key in zip(fields, field_names):
+        if values is None or not len(values):
+            continue
+
+        if key not in adata.uns[key_added]:
+            adata.uns[key_added][key] = values
+        else:
+            adata.uns[key_added][key] = _merge_arrays(
+                recarray=adata.uns[key_added][key],
+                array=np.array(values),
+                groups_order=groups_order
+            )
+
 
 class TestHelperFunctions:
     def test_adjust_pvalues(self):
@@ -52,3 +84,41 @@ class TestHelperFunctions:
                 continue
             assert _is_sorted(adata.uns["rank_features_groups"][key]["group1"])
             assert _is_sorted(adata.uns["rank_features_groups"][key]["group2"])
+
+    # Write a test for _save_rank_features_result
+    # Test several cases
+    # 1. All keys are present
+    # 2. Some keys are missing
+    # 3. Some keys are present but empty (e.g. lists, empty arrays)
+    def test_save_rank_features_result(self):
+        groups = ("group1", "group2")
+
+        adata = ep.dt.mimic_2(encoded=False)
+        adata.uns["rank_features_groups"] = {
+            "params": {"whatever": "here is", "it does": "not matter", "but this key should be": "present for testing"}
+        }
+        
+        names =  pd.DataFrame({"group1": ("gene2", "gene1", "gene4", "gene3"), "group2": ("gene5", "gene6", "gene7", "gene8")}).to_records()
+        pvals =  pd.DataFrame({"group1": (0.02, 0.01, 1.00, 0.03), "group2": (0.04, 0.05, 0.06, 0.99)}).to_records()
+        scores =  pd.DataFrame({"group1": (2, 1, 100, 3), "group2": (4, 5, 6, 7)}).to_records()
+        log2foldchanges = pd.DataFrame({"group1": (2, 1, 10, 3), "group2": (4, 5, 6, 7)}).to_records()
+        
+        adata_only_required = adata.copy()
+        _utils._save_rank_features_result(adata_only_required, key_added="rank_features_groups", groups_order=groups, names=names, scores=scores, pvals=pvals)
+
+        assert "names" in adata_only_required.uns["rank_features_groups"]
+        assert "pvals" in adata_only_required.uns["rank_features_groups"]
+        assert "scores" in adata_only_required.uns["rank_features_groups"]
+        assert "log2foldchanges" not in adata_only_required.uns["rank_features_groups"]
+        assert "pvals_adj" not in adata_only_required.uns["rank_features_groups"]
+        assert "pts" not in adata_only_required.uns["rank_features_groups"]
+        assert adata_only_required.uns["rank_features_groups"]["names"].dtype.names[1: ] == ("group1", "group2")
+        assert len(adata_only_required.uns["rank_features_groups"]["names"]) == 4  # It only captures the length of each group
+        assert len(adata_only_required.uns["rank_features_groups"]["pvals"]) == 4
+        assert len(adata_only_required.uns["rank_features_groups"]["scores"]) == 4
+
+        # Check that running the function on adata with existing keys merges the arrays correctly
+        _utils._save_rank_features_result(adata_only_required, key_added="rank_features_groups", groups_order=groups, names=names, scores=scores, pvals=pvals)
+        assert len(adata_only_required.uns["rank_features_groups"]["names"]) == 8
+        assert len(adata_only_required.uns["rank_features_groups"]["pvals"]) == 8
+        assert len(adata_only_required.uns["rank_features_groups"]["scores"]) == 8

--- a/tests/tools/test_features_ranking.py
+++ b/tests/tools/test_features_ranking.py
@@ -10,9 +10,9 @@ class TestHelperFunctions:
     def test_adjust_pvalues(self):
         groups = ("group1", "group2")
 
-        pvals: np.recarray = pd.DataFrame({"group1": (0.01, 0.02, 0.03, 1.00), "group2": (0.04, 0.05, 0.06, 0.99)}).to_records()
-        expected_result_bh = pd.DataFrame({"group1": (0.04, 0.04, 0.04, 1.00), "group2": (0.08, 0.08, 0.08, 0.99)}).to_records()
-        expected_result_bf = pd.DataFrame({"group1": (0.04, 0.08, 0.12, 1.00), "group2": (0.16, 0.20, 0.24, 1.00)}).to_records()
+        pvals: np.recarray = pd.DataFrame({"group1": (0.01, 0.02, 0.03, 1.00), "group2": (0.04, 0.05, 0.06, 0.99)}).to_records(index=False)
+        expected_result_bh = pd.DataFrame({"group1": (0.04, 0.04, 0.04, 1.00), "group2": (0.08, 0.08, 0.08, 0.99)}).to_records(index=False)
+        expected_result_bf = pd.DataFrame({"group1": (0.04, 0.08, 0.12, 1.00), "group2": (0.16, 0.20, 0.24, 1.00)}).to_records(index=False)
 
         result_bh = _utils._adjust_pvalues(pvals, corr_method="benjamini-hochberg")
 
@@ -34,11 +34,11 @@ class TestHelperFunctions:
         adata = ep.dt.mimic_2(encoded=False)        
         adata.uns["rank_features_groups"] = {
             "params": {"whatever": "here is", "it does": "not matter", "but this key should be": "present for testing"},
-            "names": pd.DataFrame({"group1": ("gene2", "gene1", "gene4", "gene3"), "group2": ("gene5", "gene6", "gene7", "gene8")}).to_records(),
+            "names": pd.DataFrame({"group1": ("gene2", "gene1", "gene4", "gene3"), "group2": ("gene5", "gene6", "gene7", "gene8")}).to_records(index=False),
             # Let's mix genes in group1, and leave them sorted in group2
-            "pvals": pd.DataFrame({"group1": (0.02, 0.01, 1.00, 0.03), "group2": (0.04, 0.05, 0.06, 0.99)}).to_records(),
-            "scores": pd.DataFrame({"group1": (2, 1, 100, 3), "group2": (4, 5, 6, 7)}).to_records(),
-            "log2foldchanges": pd.DataFrame({"group1": (2, 1, 10, 3), "group2": (4, 5, 6, 7)}).to_records(),
+            "pvals": pd.DataFrame({"group1": (0.02, 0.01, 1.00, 0.03), "group2": (0.04, 0.05, 0.06, 0.99)}).to_records(index=False),
+            "scores": pd.DataFrame({"group1": (2, 1, 100, 3), "group2": (4, 5, 6, 7)}).to_records(index=False),
+            "log2foldchanges": pd.DataFrame({"group1": (2, 1, 10, 3), "group2": (4, 5, 6, 7)}).to_records(index=False),
         }
         # Doesn't really matter that they are the same here but order should be preserved
         adata.uns["rank_features_groups"]["pvals_adj"] = adata.uns["rank_features_groups"]["pvals"].copy()
@@ -62,10 +62,10 @@ class TestHelperFunctions:
             "params": {"whatever": "here is", "it does": "not matter", "but this key should be": "present for testing"}
         }
         
-        names =  pd.DataFrame({"group1": ("gene2", "gene1", "gene4", "gene3"), "group2": ("gene5", "gene6", "gene7", "gene8")}).to_records()
-        pvals =  pd.DataFrame({"group1": (0.02, 0.01, 1.00, 0.03), "group2": (0.04, 0.05, 0.06, 0.99)}).to_records()
-        scores =  pd.DataFrame({"group1": (2, 1, 100, 3), "group2": (4, 5, 6, 7)}).to_records()
-        logfoldchanges = pd.DataFrame({"group1": (2, 1, 10, 3), "group2": (4, 5, 6, 7)}).to_records()
+        names =  pd.DataFrame({"group1": ("gene2", "gene1", "gene4", "gene3"), "group2": ("gene5", "gene6", "gene7", "gene8")}).to_records(index=False)
+        pvals =  pd.DataFrame({"group1": (0.02, 0.01, 1.00, 0.03), "group2": (0.04, 0.05, 0.06, 0.99)}).to_records(index=False)
+        scores =  pd.DataFrame({"group1": (2, 1, 100, 3), "group2": (4, 5, 6, 7)}).to_records(index=False)
+        logfoldchanges = pd.DataFrame({"group1": (2, 1, 10, 3), "group2": (4, 5, 6, 7)}).to_records(index=False)
 
         # Chack that adding onle required keys works        
         adata_only_required = adata.copy()
@@ -77,7 +77,7 @@ class TestHelperFunctions:
         assert "log2foldchanges" not in adata_only_required.uns["rank_features_groups"]
         assert "pvals_adj" not in adata_only_required.uns["rank_features_groups"]
         assert "pts" not in adata_only_required.uns["rank_features_groups"]
-        assert adata_only_required.uns["rank_features_groups"]["names"].dtype.names[1: ] == groups
+        assert adata_only_required.uns["rank_features_groups"]["names"].dtype.names == groups
         assert len(adata_only_required.uns["rank_features_groups"]["names"]) == 4  # It only captures the length of each group
         assert len(adata_only_required.uns["rank_features_groups"]["pvals"]) == 4
         assert len(adata_only_required.uns["rank_features_groups"]["scores"]) == 4
@@ -99,7 +99,7 @@ class TestHelperFunctions:
         assert "logfoldchanges" in adata_all_keys.uns["rank_features_groups"]
         assert "pvals_adj" in adata_all_keys.uns["rank_features_groups"]
         assert "pts" in adata_all_keys.uns["rank_features_groups"]
-        assert adata_all_keys.uns["rank_features_groups"]["names"].dtype.names[1: ] == groups
+        assert adata_all_keys.uns["rank_features_groups"]["names"].dtype.names == groups
         assert len(adata_all_keys.uns["rank_features_groups"]["names"]) == 4
         assert len(adata_all_keys.uns["rank_features_groups"]["pvals"]) == 4
         assert len(adata_all_keys.uns["rank_features_groups"]["pvals_adj"]) == 4

--- a/tests/tools/test_features_ranking.py
+++ b/tests/tools/test_features_ranking.py
@@ -158,3 +158,29 @@ class TestHelperFunctions:
             # Check that grouping feature is not in the results
             assert "service_unit" not in names
             assert "ehrapycat_service_unit" not in names
+
+
+class TestRankFeaturesGroups():
+    def test_real_dataset(self):
+        adata = ep.dt.mimic_2(encoded=True)
+
+        if not adata.uns["non_numerical_columns"]:
+            # Manually set categorical features because of the issue #543
+            adata.uns["non_numerical_columns"] = ['ehrapycat_day_icu_intime', 'ehrapycat_service_unit']
+
+        ep.tl.rank_features_groups(adata, groupby="service_unit")
+
+        assert "rank_features_groups" in adata.uns
+        assert "names" in adata.uns["rank_features_groups"]
+        assert "pvals" in adata.uns["rank_features_groups"]
+        assert "scores" in adata.uns["rank_features_groups"]
+        assert "logfoldchanges" in adata.uns["rank_features_groups"]
+        assert "pvals_adj" in adata.uns["rank_features_groups"]
+
+        assert "params" in adata.uns["rank_features_groups"]
+        assert "method" in adata.uns["rank_features_groups"]["params"]
+        assert "categorical_method" in adata.uns["rank_features_groups"]["params"]
+        assert "reference" in adata.uns["rank_features_groups"]["params"]
+        assert "groupby" in adata.uns["rank_features_groups"]["params"]
+        assert "layer" in adata.uns["rank_features_groups"]["params"]
+        assert "corr_method" in adata.uns["rank_features_groups"]["params"]

--- a/tests/tools/test_features_ranking.py
+++ b/tests/tools/test_features_ranking.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 
 import ehrapy as ep
+from ehrapy.tools import _utils
 
 
 class TestHelperFunctions:
@@ -10,12 +11,12 @@ class TestHelperFunctions:
         expected_result_bh = pd.DataFrame({"group1": (0.04, 0.04, 0.04, 1.00), "group2": (0.08, 0.08, 0.08, 0.99)}).to_records()
         expected_result_bf = pd.DataFrame({"group1": (0.04, 0.08, 0.12, 1.00), "group2": (0.16, 0.20, 0.24, 1.00)}).to_records()
 
-        result_bh = ep.tl._adjust_pvalues(pvals, method="benjamini-hochberg")
+        result_bh = _utils._adjust_pvalues(pvals, method="benjamini-hochberg")
         assert pvals["group1"] <= result_bh["group1"]
         assert pvals["group2"] <= result_bh["group2"]
         assert np.allclose(result_bh, expected_result_bh)
         
-        result_bf = ep.tl._adjust_pvalues(pvals, method="bonferroni")
+        result_bf = _utils._adjust_pvalues(pvals, method="bonferroni")
         assert pvals["group1"] <= result_bf["group1"]
         assert pvals["group2"] <= result_bf["group2"]
         assert np.allclose(result_bf, expected_result_bf)
@@ -37,7 +38,7 @@ class TestHelperFunctions:
         # Doesn't really matter that they are the same here but order should be preserved
         adata.uns["rank_features_groups"]["pvals_adj"] = adata.uns["rank_features_groups"]["pvals"]
 
-        ep.tl._sort_features(adata)
+        _utils._sort_features(adata)
 
         # Check that every feature is sorted
         # Actually, some of them would be sorted in the opposite direction (e.g. scores) for real data

--- a/tests/tools/test_features_ranking.py
+++ b/tests/tools/test_features_ranking.py
@@ -7,19 +7,23 @@ from ehrapy.tools import _utils
 
 class TestHelperFunctions:
     def test_adjust_pvalues(self):
+        groups = ("group1", "group2")
+
         pvals: np.recarray = pd.DataFrame({"group1": (0.01, 0.02, 0.03, 1.00), "group2": (0.04, 0.05, 0.06, 0.99)}).to_records()
         expected_result_bh = pd.DataFrame({"group1": (0.04, 0.04, 0.04, 1.00), "group2": (0.08, 0.08, 0.08, 0.99)}).to_records()
         expected_result_bf = pd.DataFrame({"group1": (0.04, 0.08, 0.12, 1.00), "group2": (0.16, 0.20, 0.24, 1.00)}).to_records()
 
         result_bh = _utils._adjust_pvalues(pvals, corr_method="benjamini-hochberg")
-        assert (pvals["group1"] <= result_bh["group1"]).all()
-        assert (pvals["group2"] <= result_bh["group2"]).all()
-        assert np.allclose(result_bh, expected_result_bh)
+
+        for group in groups:
+            assert (pvals[group] <= result_bh[group]).all()
+            assert np.allclose(result_bh[group], expected_result_bh[group])
         
         result_bf = _utils._adjust_pvalues(pvals, corr_method="bonferroni")
-        assert (pvals["group1"] <= result_bf["group1"]).all()
-        assert (pvals["group2"] <= result_bf["group2"]).all()
-        assert np.allclose(result_bf, expected_result_bf)
+
+        for group in groups:
+            assert (pvals[group] <= result_bf[group]).all()
+            assert np.allclose(result_bf[group], expected_result_bf[group])
 
 
     def test_sort_features(self):

--- a/tests/tools/test_features_ranking.py
+++ b/tests/tools/test_features_ranking.py
@@ -10,33 +10,42 @@ class TestHelperFunctions:
     def test_adjust_pvalues(self):
         groups = ("group1", "group2")
 
-        pvals: np.recarray = pd.DataFrame({"group1": (0.01, 0.02, 0.03, 1.00), "group2": (0.04, 0.05, 0.06, 0.99)}).to_records(index=False)
-        expected_result_bh = pd.DataFrame({"group1": (0.04, 0.04, 0.04, 1.00), "group2": (0.08, 0.08, 0.08, 0.99)}).to_records(index=False)
-        expected_result_bf = pd.DataFrame({"group1": (0.04, 0.08, 0.12, 1.00), "group2": (0.16, 0.20, 0.24, 1.00)}).to_records(index=False)
+        pvals: np.recarray = pd.DataFrame(
+            {"group1": (0.01, 0.02, 0.03, 1.00), "group2": (0.04, 0.05, 0.06, 0.99)}
+        ).to_records(index=False)
+        expected_result_bh = pd.DataFrame(
+            {"group1": (0.04, 0.04, 0.04, 1.00), "group2": (0.08, 0.08, 0.08, 0.99)}
+        ).to_records(index=False)
+        expected_result_bf = pd.DataFrame(
+            {"group1": (0.04, 0.08, 0.12, 1.00), "group2": (0.16, 0.20, 0.24, 1.00)}
+        ).to_records(index=False)
 
         result_bh = _utils._adjust_pvalues(pvals, corr_method="benjamini-hochberg")
 
         for group in groups:
             assert (pvals[group] <= result_bh[group]).all()
             assert np.allclose(result_bh[group], expected_result_bh[group])
-        
+
         result_bf = _utils._adjust_pvalues(pvals, corr_method="bonferroni")
 
         for group in groups:
             assert (pvals[group] <= result_bf[group]).all()
             assert np.allclose(result_bf[group], expected_result_bf[group])
 
-
     def test_sort_features(self):
         def _is_sorted(arr: np.array):
             return np.all(arr[:-1] <= arr[1:])
 
-        adata = ep.dt.mimic_2(encoded=False)        
+        adata = ep.dt.mimic_2(encoded=False)
         adata.uns["rank_features_groups"] = {
             "params": {"whatever": "here is", "it does": "not matter", "but this key should be": "present for testing"},
-            "names": pd.DataFrame({"group1": ("gene2", "gene1", "gene4", "gene3"), "group2": ("gene5", "gene6", "gene7", "gene8")}).to_records(index=False),
+            "names": pd.DataFrame(
+                {"group1": ("gene2", "gene1", "gene4", "gene3"), "group2": ("gene5", "gene6", "gene7", "gene8")}
+            ).to_records(index=False),
             # Let's mix genes in group1, and leave them sorted in group2
-            "pvals": pd.DataFrame({"group1": (0.02, 0.01, 1.00, 0.03), "group2": (0.04, 0.05, 0.06, 0.99)}).to_records(index=False),
+            "pvals": pd.DataFrame({"group1": (0.02, 0.01, 1.00, 0.03), "group2": (0.04, 0.05, 0.06, 0.99)}).to_records(
+                index=False
+            ),
             "scores": pd.DataFrame({"group1": (2, 1, 100, 3), "group2": (4, 5, 6, 7)}).to_records(index=False),
             "log2foldchanges": pd.DataFrame({"group1": (2, 1, 10, 3), "group2": (4, 5, 6, 7)}).to_records(index=False),
         }
@@ -61,15 +70,26 @@ class TestHelperFunctions:
         adata.uns["rank_features_groups"] = {
             "params": {"whatever": "here is", "it does": "not matter", "but this key should be": "present for testing"}
         }
-        
-        names =  pd.DataFrame({"group1": ("gene2", "gene1", "gene4", "gene3"), "group2": ("gene5", "gene6", "gene7", "gene8")}).to_records(index=False)
-        pvals =  pd.DataFrame({"group1": (0.02, 0.01, 1.00, 0.03), "group2": (0.04, 0.05, 0.06, 0.99)}).to_records(index=False)
-        scores =  pd.DataFrame({"group1": (2, 1, 100, 3), "group2": (4, 5, 6, 7)}).to_records(index=False)
+
+        names = pd.DataFrame(
+            {"group1": ("gene2", "gene1", "gene4", "gene3"), "group2": ("gene5", "gene6", "gene7", "gene8")}
+        ).to_records(index=False)
+        pvals = pd.DataFrame({"group1": (0.02, 0.01, 1.00, 0.03), "group2": (0.04, 0.05, 0.06, 0.99)}).to_records(
+            index=False
+        )
+        scores = pd.DataFrame({"group1": (2, 1, 100, 3), "group2": (4, 5, 6, 7)}).to_records(index=False)
         logfoldchanges = pd.DataFrame({"group1": (2, 1, 10, 3), "group2": (4, 5, 6, 7)}).to_records(index=False)
 
-        # Chack that adding onle required keys works        
+        # Chack that adding onle required keys works
         adata_only_required = adata.copy()
-        _utils._save_rank_features_result(adata_only_required, key_added="rank_features_groups", groups_order=groups, names=names, scores=scores, pvals=pvals)
+        _utils._save_rank_features_result(
+            adata_only_required,
+            key_added="rank_features_groups",
+            groups_order=groups,
+            names=names,
+            scores=scores,
+            pvals=pvals,
+        )
 
         assert "names" in adata_only_required.uns["rank_features_groups"]
         assert "pvals" in adata_only_required.uns["rank_features_groups"]
@@ -78,20 +98,38 @@ class TestHelperFunctions:
         assert "pvals_adj" not in adata_only_required.uns["rank_features_groups"]
         assert "pts" not in adata_only_required.uns["rank_features_groups"]
         assert adata_only_required.uns["rank_features_groups"]["names"].dtype.names == groups
-        assert len(adata_only_required.uns["rank_features_groups"]["names"]) == 4  # It only captures the length of each group
+        assert (
+            len(adata_only_required.uns["rank_features_groups"]["names"]) == 4
+        )  # It only captures the length of each group
         assert len(adata_only_required.uns["rank_features_groups"]["pvals"]) == 4
         assert len(adata_only_required.uns["rank_features_groups"]["scores"]) == 4
 
         # Check that running the function on adata with existing keys merges the arrays correctly
-        _utils._save_rank_features_result(adata_only_required, key_added="rank_features_groups", groups_order=groups, names=names, scores=scores, pvals=pvals)
+        _utils._save_rank_features_result(
+            adata_only_required,
+            key_added="rank_features_groups",
+            groups_order=groups,
+            names=names,
+            scores=scores,
+            pvals=pvals,
+        )
         assert len(adata_only_required.uns["rank_features_groups"]["names"]) == 8
         assert len(adata_only_required.uns["rank_features_groups"]["pvals"]) == 8
         assert len(adata_only_required.uns["rank_features_groups"]["scores"]) == 8
 
         # Check that adding other keys works
         adata_all_keys = adata.copy()
-        _utils._save_rank_features_result(adata_all_keys, key_added="rank_features_groups", groups_order=groups, names=names, scores=scores, 
-                                          pvals=pvals, pvals_adj=pvals.copy(), pts=pvals.copy(), logfoldchanges=logfoldchanges)
+        _utils._save_rank_features_result(
+            adata_all_keys,
+            key_added="rank_features_groups",
+            groups_order=groups,
+            names=names,
+            scores=scores,
+            pvals=pvals,
+            pvals_adj=pvals.copy(),
+            pts=pvals.copy(),
+            logfoldchanges=logfoldchanges,
+        )
 
         assert "names" in adata_all_keys.uns["rank_features_groups"]
         assert "pvals" in adata_all_keys.uns["rank_features_groups"]
@@ -108,8 +146,17 @@ class TestHelperFunctions:
         assert len(adata_all_keys.uns["rank_features_groups"]["pts"]) == 4
 
         # Check that passing empty objects doesn't add keys
-        _utils._save_rank_features_result(adata, key_added="rank_features_groups", groups_order=groups, names=names, scores=scores, 
-                                          pvals=pvals, pvals_adj=[], pts=np.array([]), logfoldchanges=pd.DataFrame([]))
+        _utils._save_rank_features_result(
+            adata,
+            key_added="rank_features_groups",
+            groups_order=groups,
+            names=names,
+            scores=scores,
+            pvals=pvals,
+            pvals_adj=[],
+            pts=np.array([]),
+            logfoldchanges=pd.DataFrame([]),
+        )
         assert "names" in adata.uns["rank_features_groups"]
         assert "pvals" in adata.uns["rank_features_groups"]
         assert "scores" in adata.uns["rank_features_groups"]
@@ -117,12 +164,25 @@ class TestHelperFunctions:
         assert "pvals_adj" not in adata.uns["rank_features_groups"]
         assert "pts" not in adata.uns["rank_features_groups"]
 
-
     def test_get_groups_order(self):
-        assert _utils._get_groups_order(groups_subset="all", group_names=("A", "B", "C"), reference="B") == ("A", "B", "C") 
-        assert _utils._get_groups_order(groups_subset=("A", "B"), group_names=("A", "B", "C"), reference="B") == ("A", "B")
-        assert _utils._get_groups_order(groups_subset=("A", "B"), group_names=("A", "B", "C"), reference="rest") == ("A", "B")
-        assert _utils._get_groups_order(groups_subset=("A", "B"), group_names=("A", "B", "C"), reference="C") == ("A", "B", "C")
+        assert _utils._get_groups_order(groups_subset="all", group_names=("A", "B", "C"), reference="B") == (
+            "A",
+            "B",
+            "C",
+        )
+        assert _utils._get_groups_order(groups_subset=("A", "B"), group_names=("A", "B", "C"), reference="B") == (
+            "A",
+            "B",
+        )
+        assert _utils._get_groups_order(groups_subset=("A", "B"), group_names=("A", "B", "C"), reference="rest") == (
+            "A",
+            "B",
+        )
+        assert _utils._get_groups_order(groups_subset=("A", "B"), group_names=("A", "B", "C"), reference="C") == (
+            "A",
+            "B",
+            "C",
+        )
 
         # Check that array with ints (e.g. leiden clusters) works correctly
         assert _utils._get_groups_order(groups_subset=(1, 2), group_names=np.arange(3), reference="rest") == ("1", "2")
@@ -131,20 +191,20 @@ class TestHelperFunctions:
             # Reference not in group_names
             _utils._get_groups_order(groups_subset=("A", "B"), group_names=("A", "B", "C"), reference="D")
 
-
     def test_evaluate_categorical_features(self):
         adata = ep.dt.mimic_2(encoded=True)
 
         if not adata.uns["non_numerical_columns"]:
             # Manually set categorical features because of the issue #543
-            adata.uns["non_numerical_columns"] = ['ehrapycat_day_icu_intime', 'ehrapycat_service_unit']
+            adata.uns["non_numerical_columns"] = ["ehrapycat_day_icu_intime", "ehrapycat_service_unit"]
 
         group_names = pd.Categorical(adata.obs["service_unit"].astype(str)).categories.tolist()
 
         for method in ("chi-square", "g-test", "freeman-tukey", "mod-log-likelihood", "neyman", "cressie-read"):
             names, scores, pvals, logfc, pts = _utils._evaluate_categorical_features(
-                adata, groupby="service_unit", group_names=group_names, categorical_method=method)
-            
+                adata, groupby="service_unit", group_names=group_names, categorical_method=method
+            )
+
             # Check that important fields are not empty
             assert len(names)
             assert len(scores)
@@ -163,13 +223,13 @@ class TestHelperFunctions:
             assert "ehrapycat_day_icu_intime" in names
 
 
-class TestRankFeaturesGroups():
+class TestRankFeaturesGroups:
     def test_real_dataset(self):
         adata = ep.dt.mimic_2(encoded=True)
 
         if not adata.uns["non_numerical_columns"]:
             # Manually set categorical features because of the issue #543
-            adata.uns["non_numerical_columns"] = ['ehrapycat_day_icu_intime', 'ehrapycat_service_unit']
+            adata.uns["non_numerical_columns"] = ["ehrapycat_day_icu_intime", "ehrapycat_service_unit"]
 
         ep.tl.rank_features_groups(adata, groupby="service_unit")
 
@@ -206,7 +266,7 @@ class TestRankFeaturesGroups():
 
         if not adata.uns["non_numerical_columns"]:
             # Manually set categorical features because of the issue #543
-            adata.uns["non_numerical_columns"] = ['ehrapycat_day_icu_intime', 'ehrapycat_service_unit']
+            adata.uns["non_numerical_columns"] = ["ehrapycat_day_icu_intime", "ehrapycat_service_unit"]
 
         ep.tl.rank_features_groups(adata, groupby="service_unit")
         assert "rank_features_groups" in adata.uns

--- a/tests/tools/test_features_ranking.py
+++ b/tests/tools/test_features_ranking.py
@@ -5,38 +5,6 @@ import pytest
 import ehrapy as ep
 from ehrapy.tools import _utils
 
-def _save_rank_features_result(adata, key_added, names, scores, pvals, pvals_adj=None, logfoldchanges=None, pts=None, groups_order=None) -> None:
-    """Write keys with statistical test results to adata.uns
-    
-    Args:
-        adata: Annotated data matrix after running :func:`~ehrapy.tl.rank_features_groups`
-        key_added: The key in `adata.uns` information is saved to.
-        names: Structured array storing the feature names
-        scores: Array with the statistics
-        logfoldchanges: logarithm of fold changes or other info to store under logfoldchanges key
-        pvals: p-values of a statistical test 
-        pts: Percentages of cells containing features
-        groups_order: order of groups in structured arrays
-
-    Returns:
-        Nothing. The operation is performed in place
-    """
-    fields = (names, scores, pvals, pvals_adj, logfoldchanges, pts)
-    field_names = ("names", "scores", "pvals", "pvals_adj", "logfoldchanges", "pts")
-
-    for values, key in zip(fields, field_names):
-        if values is None or not len(values):
-            continue
-
-        if key not in adata.uns[key_added]:
-            adata.uns[key_added][key] = values
-        else:
-            adata.uns[key_added][key] = _merge_arrays(
-                recarray=adata.uns[key_added][key],
-                array=np.array(values),
-                groups_order=groups_order
-            )
-
 
 class TestHelperFunctions:
     def test_adjust_pvalues(self):
@@ -162,3 +130,5 @@ class TestHelperFunctions:
         with pytest.raises(ValueError):
             # Reference not in group_names
             _utils._get_groups_order(groups_subset=("A", "B"), group_names=("A", "B", "C"), reference="D")
+
+    def test_evaluate_categorical_features():

--- a/tests/tools/test_features_ranking.py
+++ b/tests/tools/test_features_ranking.py
@@ -19,3 +19,32 @@ class TestHelperFunctions:
         assert pvals["group1"] <= result_bf["group1"]
         assert pvals["group2"] <= result_bf["group2"]
         assert np.allclose(result_bf, expected_result_bf)
+
+
+    def test_sort_features(self):
+        def _is_sorted(arr: np.array):
+            return np.all(arr[:-1] <= arr[1:])
+
+        adata = ep.datasets.pbmc3k()
+        
+        adata.uns["rank_features_groups"] = {
+            "params": {"whatever": "here is", "it does": "not matter", "but this key should be": "present for testing"},
+            "names": pd.DataFrame({"group1": ("gene2", "gene1", "gene4", "gene3"), "group2": ("gene5", "gene6", "gene7", "gene8")}).to_records(),
+            # Let's mix genes in group1, and leave them sorted in group2
+            "pvals": pd.DataFrame({"group1": (0.02, 0.01, 1.00, 0.03), "group2": (0.04, 0.05, 0.06, 0.99)}).to_records(),
+            "scores": pd.DataFrame({"group1": (2, 1, 100, 3), "group2": (4, 5, 6, 7)}).to_records(),
+            "log2foldchanges": pd.DataFrame({"group1": (2, 1, 10, 3), "group2": (4, 5, 6, 7)}).to_records(),
+        }
+        # Doesn't really matter that they are the same here but order should be preserved
+        adata.uns["rank_features_groups"]["pvals_adj"] = adata.uns["rank_features_groups"]["pvals"]
+
+        ep.tl._sort_features(adata)
+
+        # Check that every feature is sorted
+        # Actually, some of them would be sorted in the opposite direction (e.g. scores) for real data
+        # But what matters here is that the permutation is the same for every key and is based on adjusted p-values
+        for key in adata.uns["rank_features_groups"]:
+            if key == "params":
+                continue
+            assert _is_sorted(adata.uns["rank_features_groups"][key]["group1"])
+            assert _is_sorted(adata.uns["rank_features_groups"][key]["group2"])

--- a/tests/tools/test_features_ranking.py
+++ b/tests/tools/test_features_ranking.py
@@ -1,0 +1,21 @@
+import numpy as np
+import pandas as pd
+
+import ehrapy as ep
+
+
+class TestHelperFunctions:
+    def test_adjust_pvalues(self):
+        pvals: np.recarray = pd.DataFrame({"group1": (0.01, 0.02, 0.03, 1.00), "group2": (0.04, 0.05, 0.06, 0.99)}).to_records()
+        expected_result_bh = pd.DataFrame({"group1": (0.04, 0.04, 0.04, 1.00), "group2": (0.08, 0.08, 0.08, 0.99)}).to_records()
+        expected_result_bf = pd.DataFrame({"group1": (0.04, 0.08, 0.12, 1.00), "group2": (0.16, 0.20, 0.24, 1.00)}).to_records()
+
+        result_bh = ep.tl._adjust_pvalues(pvals, method="benjamini-hochberg")
+        assert pvals["group1"] <= result_bh["group1"]
+        assert pvals["group2"] <= result_bh["group2"]
+        assert np.allclose(result_bh, expected_result_bh)
+        
+        result_bf = ep.tl._adjust_pvalues(pvals, method="bonferroni")
+        assert pvals["group1"] <= result_bf["group1"]
+        assert pvals["group2"] <= result_bf["group2"]
+        assert np.allclose(result_bf, expected_result_bf)

--- a/tests/tools/test_features_ranking.py
+++ b/tests/tools/test_features_ranking.py
@@ -184,3 +184,15 @@ class TestRankFeaturesGroups():
         assert "groupby" in adata.uns["rank_features_groups"]["params"]
         assert "layer" in adata.uns["rank_features_groups"]["params"]
         assert "corr_method" in adata.uns["rank_features_groups"]["params"]
+
+    def test_only_continous_features(self):
+        adata = ep.dt.mimic_2(encoded=True)
+        adata.uns["non_numerical_columns"] = []
+
+        ep.tl.rank_features_groups(adata, groupby="service_unit")
+        assert "rank_features_groups" in adata.uns
+        assert "names" in adata.uns["rank_features_groups"]
+        assert "pvals" in adata.uns["rank_features_groups"]
+        assert "scores" in adata.uns["rank_features_groups"]
+        assert "logfoldchanges" in adata.uns["rank_features_groups"]
+        assert "pvals_adj" in adata.uns["rank_features_groups"]

--- a/tests/tools/test_features_ranking.py
+++ b/tests/tools/test_features_ranking.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 import ehrapy as ep
 from ehrapy.tools import _utils
@@ -147,3 +148,17 @@ class TestHelperFunctions:
         assert "logfoldchanges" not in adata.uns["rank_features_groups"]
         assert "pvals_adj" not in adata.uns["rank_features_groups"]
         assert "pts" not in adata.uns["rank_features_groups"]
+
+
+    def test_get_groups_order(self):
+        assert _utils._get_groups_order(groups_subset="all", group_names=("A", "B", "C"), reference="B") == ("A", "B", "C") 
+        assert _utils._get_groups_order(groups_subset=("A", "B"), group_names=("A", "B", "C"), reference="B") == ("A", "B")
+        assert _utils._get_groups_order(groups_subset=("A", "B"), group_names=("A", "B", "C"), reference="rest") == ("A", "B")
+        assert _utils._get_groups_order(groups_subset=("A", "B"), group_names=("A", "B", "C"), reference="C") == ("A", "B", "C")
+
+        # Check that array with ints (e.g. leiden clusters) works correctly
+        assert _utils._get_groups_order(groups_subset=(1, 2), group_names=np.arange(3), reference="rest") == ("1", "2")
+
+        with pytest.raises(ValueError):
+            # Reference not in group_names
+            _utils._get_groups_order(groups_subset=("A", "B"), group_names=("A", "B", "C"), reference="D")

--- a/tests/tools/test_features_ranking.py
+++ b/tests/tools/test_features_ranking.py
@@ -40,7 +40,7 @@ class TestHelperFunctions:
             "log2foldchanges": pd.DataFrame({"group1": (2, 1, 10, 3), "group2": (4, 5, 6, 7)}).to_records(),
         }
         # Doesn't really matter that they are the same here but order should be preserved
-        adata.uns["rank_features_groups"]["pvals_adj"] = adata.uns["rank_features_groups"]["pvals"]
+        adata.uns["rank_features_groups"]["pvals_adj"] = adata.uns["rank_features_groups"]["pvals"].copy()
 
         _utils._sort_features(adata)
 

--- a/tests/tools/test_features_ranking.py
+++ b/tests/tools/test_features_ranking.py
@@ -196,3 +196,19 @@ class TestRankFeaturesGroups():
         assert "scores" in adata.uns["rank_features_groups"]
         assert "logfoldchanges" in adata.uns["rank_features_groups"]
         assert "pvals_adj" in adata.uns["rank_features_groups"]
+
+    def test_only_cat_features(self):
+        adata = ep.dt.mimic_2(encoded=True)
+        adata.uns["numerical_columns"] = []
+
+        if not adata.uns["non_numerical_columns"]:
+            # Manually set categorical features because of the issue #543
+            adata.uns["non_numerical_columns"] = ['ehrapycat_day_icu_intime', 'ehrapycat_service_unit']
+
+        ep.tl.rank_features_groups(adata, groupby="service_unit")
+        assert "rank_features_groups" in adata.uns
+        assert "names" in adata.uns["rank_features_groups"]
+        assert "pvals" in adata.uns["rank_features_groups"]
+        assert "scores" in adata.uns["rank_features_groups"]
+        assert "logfoldchanges" in adata.uns["rank_features_groups"]
+        assert "pvals_adj" in adata.uns["rank_features_groups"]

--- a/tests/tools/test_features_ranking.py
+++ b/tests/tools/test_features_ranking.py
@@ -11,12 +11,12 @@ class TestHelperFunctions:
         expected_result_bh = pd.DataFrame({"group1": (0.04, 0.04, 0.04, 1.00), "group2": (0.08, 0.08, 0.08, 0.99)}).to_records()
         expected_result_bf = pd.DataFrame({"group1": (0.04, 0.08, 0.12, 1.00), "group2": (0.16, 0.20, 0.24, 1.00)}).to_records()
 
-        result_bh = _utils._adjust_pvalues(pvals, method="benjamini-hochberg")
+        result_bh = _utils._adjust_pvalues(pvals, corr_method="benjamini-hochberg")
         assert pvals["group1"] <= result_bh["group1"]
         assert pvals["group2"] <= result_bh["group2"]
         assert np.allclose(result_bh, expected_result_bh)
         
-        result_bf = _utils._adjust_pvalues(pvals, method="bonferroni")
+        result_bf = _utils._adjust_pvalues(pvals, corr_method="bonferroni")
         assert pvals["group1"] <= result_bf["group1"]
         assert pvals["group2"] <= result_bf["group2"]
         assert np.allclose(result_bf, expected_result_bf)

--- a/tests/tools/test_features_ranking.py
+++ b/tests/tools/test_features_ranking.py
@@ -12,13 +12,13 @@ class TestHelperFunctions:
         expected_result_bf = pd.DataFrame({"group1": (0.04, 0.08, 0.12, 1.00), "group2": (0.16, 0.20, 0.24, 1.00)}).to_records()
 
         result_bh = _utils._adjust_pvalues(pvals, corr_method="benjamini-hochberg")
-        assert pvals["group1"] <= result_bh["group1"]
-        assert pvals["group2"] <= result_bh["group2"]
+        assert (pvals["group1"] <= result_bh["group1"]).all()
+        assert (pvals["group2"] <= result_bh["group2"]).all()
         assert np.allclose(result_bh, expected_result_bh)
         
         result_bf = _utils._adjust_pvalues(pvals, corr_method="bonferroni")
-        assert pvals["group1"] <= result_bf["group1"]
-        assert pvals["group2"] <= result_bf["group2"]
+        assert (pvals["group1"] <= result_bf["group1"]).all()
+        assert (pvals["group2"] <= result_bf["group2"]).all()
         assert np.allclose(result_bf, expected_result_bf)
 
 

--- a/tests/tools/test_features_ranking.py
+++ b/tests/tools/test_features_ranking.py
@@ -25,8 +25,7 @@ class TestHelperFunctions:
         def _is_sorted(arr: np.array):
             return np.all(arr[:-1] <= arr[1:])
 
-        adata = ep.datasets.pbmc3k()
-        
+        adata = ep.dt.mimic_2(encoded=False)        
         adata.uns["rank_features_groups"] = {
             "params": {"whatever": "here is", "it does": "not matter", "but this key should be": "present for testing"},
             "names": pd.DataFrame({"group1": ("gene2", "gene1", "gene4", "gene3"), "group2": ("gene5", "gene6", "gene7", "gene8")}).to_records(),


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [ ] This comment contains a description of changes (with reason)
-   [ ] Referenced issue is linked: https://github.com/theislab/ehrapy/issues/532
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**
Previously, for non-numerical features the standard statistical test was run by `ep.tl.rank_features_groups` (e.g. Wilcoxon rank sum test). This PR adds functionality to run statistical tests specifically developed for categorical features (e.g. Chi-square test).


**Technical details**

- The same approach that in `scanpy.tl.rank_genes_groups` is used. E.g., when the reference is set to "rest", for each subgroup of `groupby`, the composition of a categorical variable is compared to the composition in all other groups mixed together. This is not a common approach, I would say, but it is consistent with `scanpy`, which is used for numerical features.
- The default test is [G-test](https://en.wikipedia.org/wiki/G-test), which is similar to the Chi-square test but should work better for groups with a small expected number of observations.
- P-values should be treated carefully. I would only use them for ranking marker features, and re-run statistical analysis in a conventional way to test your hypotheses.