### PR TITLE
Dataloader throwing an error using Windows

### DIFF
--- a/ehrapy/data/_dataloader.py
+++ b/ehrapy/data/_dataloader.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import platform
 import shutil
 import tempfile
 from pathlib import Path
@@ -39,18 +38,9 @@ def download(
     if output_path is None:
         output_path = tempfile.gettempdir()
 
-    if platform.system() == "Windows":
-        download_to_path = (
-            f"{output_path}{output_file_name}"
-            if str(output_path).endswith("\\")
-            else f"{output_path}\\{output_file_name}"
-        )
-    else:
-        download_to_path = (
-            f"{output_path}{output_file_name}"
-            if str(output_path).endswith("/")
-            else f"{output_path}/{output_file_name}"
-        )
+    download_to_path = (
+        f"{output_path}{output_file_name}" if str(output_path).endswith("/") else f"{output_path}/{output_file_name}"
+    )
 
     if Path(download_to_path).exists():
         warning = f"[bold red]File {download_to_path} already exists!"

--- a/ehrapy/data/_dataloader.py
+++ b/ehrapy/data/_dataloader.py
@@ -56,7 +56,7 @@ def download(
     with Progress(refresh_per_second=1500) as progress:
         task = progress.add_task("[red]Downloading...", total=total)
         Path(output_path).mkdir(parents=True, exist_ok=True)
-        with open(Path(download_to_path), "wb") as file:
+        with open(Path(download_to_path).resolve(), "wb") as file:
             for data in response.iter_content(block_size):
                 file.write(data)
                 progress.update(task, advance=block_size)

--- a/ehrapy/data/_dataloader.py
+++ b/ehrapy/data/_dataloader.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shutil
 import tempfile
+import platform
 from pathlib import Path
 from random import choice
 from string import ascii_lowercase
@@ -38,9 +39,19 @@ def download(
     if output_path is None:
         output_path = tempfile.gettempdir()
 
-    download_to_path = (
-        f"{output_path}{output_file_name}" if str(output_path).endswith("/") else f"{output_path}/{output_file_name}"
-    )
+    if platform.system() == "Windows":
+        download_to_path = (
+            f"{output_path}{output_file_name}"
+            if str(output_path).endswith("\\")
+            else f"{output_path}\\{output_file_name}"
+        )
+    else:
+        download_to_path = (
+            f"{output_path}{output_file_name}"
+            if str(output_path).endswith("/")
+            else f"{output_path}/{output_file_name}"
+        )
+
     if Path(download_to_path).exists():
         warning = f"[bold red]File {download_to_path} already exists!"
         if not overwrite:

--- a/ehrapy/data/_dataloader.py
+++ b/ehrapy/data/_dataloader.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import platform
 import shutil
 import tempfile
-import platform
 from pathlib import Path
 from random import choice
 from string import ascii_lowercase

--- a/ehrapy/data/_dataloader.py
+++ b/ehrapy/data/_dataloader.py
@@ -42,9 +42,7 @@ def download(
         f"{output_path}{output_file_name}" if str(output_path).endswith("/") else f"{output_path}/{output_file_name}"
     )
 
-    download_to_path = Path(download_to_path).resolve()
-
-    if download_to_path.exists():
+    if Path(download_to_path).exists():
         warning = f"[bold red]File {download_to_path} already exists!"
         if not overwrite:
             print(warning)
@@ -58,7 +56,7 @@ def download(
     with Progress(refresh_per_second=1500) as progress:
         task = progress.add_task("[red]Downloading...", total=total)
         Path(output_path).mkdir(parents=True, exist_ok=True)
-        with open(download_to_path, "wb") as file:
+        with open(Path(download_to_path), "wb") as file:
             for data in response.iter_content(block_size):
                 file.write(data)
                 progress.update(task, advance=block_size)

--- a/ehrapy/data/_dataloader.py
+++ b/ehrapy/data/_dataloader.py
@@ -42,7 +42,9 @@ def download(
         f"{output_path}{output_file_name}" if str(output_path).endswith("/") else f"{output_path}/{output_file_name}"
     )
 
-    if Path(download_to_path).exists():
+    download_to_path = Path(download_to_path).resolve()
+
+    if download_to_path.exists():
         warning = f"[bold red]File {download_to_path} already exists!"
         if not overwrite:
             print(warning)

--- a/ehrapy/data/_dataloader.py
+++ b/ehrapy/data/_dataloader.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import platform
 import shutil
 import tempfile
 from pathlib import Path
@@ -42,9 +41,6 @@ def download(
     download_to_path = (
         f"{output_path}{output_file_name}" if str(output_path).endswith("/") else f"{output_path}/{output_file_name}"
     )
-
-    if platform.system() == "Windows":
-        download_to_path = "".join([c for c in download_to_path if c not in r'\/:*?"<>|'])
 
     if Path(download_to_path).exists():
         warning = f"[bold red]File {download_to_path} already exists!"

--- a/ehrapy/data/_dataloader.py
+++ b/ehrapy/data/_dataloader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import platform
 import shutil
 import tempfile
 from pathlib import Path
@@ -42,6 +43,9 @@ def download(
         f"{output_path}{output_file_name}" if str(output_path).endswith("/") else f"{output_path}/{output_file_name}"
     )
 
+    if platform.system() == "Windows":
+        download_to_path = "".join([c for c in download_to_path if c not in r'\/:*?"<>|'])
+
     if Path(download_to_path).exists():
         warning = f"[bold red]File {download_to_path} already exists!"
         if not overwrite:
@@ -56,7 +60,7 @@ def download(
     with Progress(refresh_per_second=1500) as progress:
         task = progress.add_task("[red]Downloading...", total=total)
         Path(output_path).mkdir(parents=True, exist_ok=True)
-        with open(Path(download_to_path).resolve(), "wb") as file:
+        with open(Path(download_to_path), "wb") as file:
             for data in response.iter_content(block_size):
                 file.write(data)
                 progress.update(task, advance=block_size)


### PR DESCRIPTION
Previous approach for building the download path did not take the Windows platform feature into account (`\\` instead of `/`). 