### PR TITLE
Solution for adata.uns["non_numericlal_columns"] being empty in mimic_2 dataset

### DIFF
--- a/ehrapy/preprocessing/_encode.py
+++ b/ehrapy/preprocessing/_encode.py
@@ -205,6 +205,9 @@ def _encode(
 
             encoded_ann_data.uns["numerical_columns"] = adata.uns["numerical_columns"].copy()
             encoded_ann_data.uns["non_numerical_columns"] = []
+            encoded_ann_data.uns["encoded_non_numerical_columns"] = [
+                column for column in encoded_ann_data.var_names if column.startswith("ehrapycat_")
+            ]
 
             _add_categoricals_to_obs(adata, encoded_ann_data, categoricals_names)
 
@@ -311,6 +314,9 @@ def _encode(
         updated_num_uns, updated_non_num_uns, _ = _update_uns(adata, categoricals)
         encoded_ann_data.uns["numerical_columns"] = updated_num_uns
         encoded_ann_data.uns["non_numerical_columns"] = updated_non_num_uns
+        encoded_ann_data.uns["encoded_non_numerical_columns"] = [
+            column for column in encoded_ann_data.var_names if column.startswith("ehrapycat_")
+        ]
 
         _add_categoricals_to_obs(adata, encoded_ann_data, categoricals)
 

--- a/ehrapy/tools/feature_ranking/_rank_features_groups.py
+++ b/ehrapy/tools/feature_ranking/_rank_features_groups.py
@@ -194,7 +194,7 @@ def _evaluate_categorical_features(
 
     groups_values = adata.obs[groupby].to_numpy()
 
-    for feature in adata.uns["non_numerical_columns"]:
+    for feature in adata.uns["encoded_non_numerical_columns"]:
         if feature == groupby or "ehrapycat_" + feature == groupby or feature == "ehrapycat_" + groupby:
             continue
 
@@ -374,7 +374,7 @@ def rank_features_groups(
             groups_order=group_names,
         )
 
-    if adata.uns["non_numerical_columns"]:
+    if adata.uns["encoded_non_numerical_columns"]:
         (
             categorical_names,
             categorical_scores,

--- a/tests/preprocessing/test_encode.py
+++ b/tests/preprocessing/test_encode.py
@@ -144,11 +144,13 @@ class TestEncode:
         )
         assert all(
             column in set(encoded_ann_data.uns["encoded_non_numerical_columns"])
-            for column in ["ehrapycat_survival",
-                           "ehrapycat_clinic_day_Friday",
-                           "ehrapycat_clinic_day_Monday",
-                           "ehrapycat_clinic_day_Saturday",
-                           "ehrapycat_clinic_day_Sunday"]
+            for column in [
+                "ehrapycat_survival",
+                "ehrapycat_clinic_day_Friday",
+                "ehrapycat_clinic_day_Monday",
+                "ehrapycat_clinic_day_Saturday",
+                "ehrapycat_clinic_day_Sunday",
+            ]
         )
         assert pd.api.types.is_bool_dtype(encoded_ann_data.obs["survival"].dtype)
         assert pd.api.types.is_categorical_dtype(encoded_ann_data.obs["clinic_day"].dtype)

--- a/tests/preprocessing/test_encode.py
+++ b/tests/preprocessing/test_encode.py
@@ -53,6 +53,10 @@ class TestEncode:
         assert not any(
             column in set(encoded_ann_data.uns["non_numerical_columns"]) for column in ["survival", "clinic_day"]
         )
+        assert all(
+            column in set(encoded_ann_data.uns["encoded_non_numerical_columns"])
+            for column in ["ehrapycat_survival", "ehrapycat_clinic_day"]
+        )
         assert pd.api.types.is_bool_dtype(encoded_ann_data.obs["survival"].dtype)
         assert pd.api.types.is_categorical_dtype(encoded_ann_data.obs["clinic_day"].dtype)
 
@@ -89,6 +93,10 @@ class TestEncode:
         assert all(column in set(adata.uns["non_numerical_columns"]) for column in ["survival", "clinic_day"])
         assert not any(
             column in set(encoded_ann_data.uns["non_numerical_columns"]) for column in ["survival", "clinic_day"]
+        )
+        assert all(
+            column in set(encoded_ann_data.uns["encoded_non_numerical_columns"])
+            for column in ["ehrapycat_survival", "ehrapycat_clinic_day"]
         )
         assert pd.api.types.is_bool_dtype(encoded_ann_data.obs["survival"].dtype)
         assert pd.api.types.is_categorical_dtype(encoded_ann_data.obs["clinic_day"].dtype)
@@ -133,6 +141,14 @@ class TestEncode:
         assert all(column in set(adata.uns["non_numerical_columns"]) for column in ["survival", "clinic_day"])
         assert not any(
             column in set(encoded_ann_data.uns["non_numerical_columns"]) for column in ["survival", "clinic_day"]
+        )
+        assert all(
+            column in set(encoded_ann_data.uns["encoded_non_numerical_columns"])
+            for column in ["ehrapycat_survival",
+                           "ehrapycat_clinic_day_Friday",
+                           "ehrapycat_clinic_day_Monday",
+                           "ehrapycat_clinic_day_Saturday",
+                           "ehrapycat_clinic_day_Sunday"]
         )
         assert pd.api.types.is_bool_dtype(encoded_ann_data.obs["survival"].dtype)
         assert pd.api.types.is_categorical_dtype(encoded_ann_data.obs["clinic_day"].dtype)

--- a/tests/tools/test_features_ranking.py
+++ b/tests/tools/test_features_ranking.py
@@ -200,10 +200,6 @@ class TestHelperFunctions:
     def test_evaluate_categorical_features(self):
         adata = ep.dt.mimic_2(encoded=True)
 
-        if not adata.uns["non_numerical_columns"]:
-            # Manually set categorical features because of the issue #543
-            adata.uns["non_numerical_columns"] = ["ehrapycat_day_icu_intime", "ehrapycat_service_unit"]
-
         group_names = pd.Categorical(adata.obs["service_unit"].astype(str)).categories.tolist()
 
         for method in ("chi-square", "g-test", "freeman-tukey", "mod-log-likelihood", "neyman", "cressie-read"):
@@ -232,10 +228,6 @@ class TestHelperFunctions:
 class TestRankFeaturesGroups:
     def test_real_dataset(self):
         adata = ep.dt.mimic_2(encoded=True)
-
-        if not adata.uns["non_numerical_columns"]:
-            # Manually set categorical features because of the issue #543
-            adata.uns["non_numerical_columns"] = ["ehrapycat_day_icu_intime", "ehrapycat_service_unit"]
 
         ep.tl.rank_features_groups(adata, groupby="service_unit")
 
@@ -269,10 +261,6 @@ class TestRankFeaturesGroups:
     def test_only_cat_features(self):
         adata = ep.dt.mimic_2(encoded=True)
         adata.uns["numerical_columns"] = []
-
-        if not adata.uns["non_numerical_columns"]:
-            # Manually set categorical features because of the issue #543
-            adata.uns["non_numerical_columns"] = ["ehrapycat_day_icu_intime", "ehrapycat_service_unit"]
 
         ep.tl.rank_features_groups(adata, groupby="service_unit")
         assert "rank_features_groups" in adata.uns


### PR DESCRIPTION
Issue was that `adata.uns["non_numerical_columns"]` was empty after calling `adata = ep.dt.mimic_2(encoded=True)`, making evaluation of categorical data in `rank_features_groups` impossible. 

I added a new slot into `adata.uns` which is called [`encoded_non_numerical_columns`]. This stores the column names of encoded categorical columns. This slot is accessed in `_rank_features_groups`.

Tests were adjusted accordingly. 

I am not sure about the naming of the new slot, so feel free to comment on this. 