### PR TITLE
Fixes unability to normalize AnnData that does not require encoding 

### DIFF
--- a/ehrapy/anndata/anndata_ext.py
+++ b/ehrapy/anndata/anndata_ext.py
@@ -543,7 +543,7 @@ def set_numeric_vars(
         assert_numeric_vars(adata, vars)
 
     if not np.issubdtype(values.dtype, np.number):
-        raise TypeError(f"values must be numeric (current dtype is {values.dtype})")
+        raise TypeError(f"Values must be numeric (current dtype is {values.dtype})")
 
     n_values = values.shape[1]
 

--- a/ehrapy/anndata/anndata_ext.py
+++ b/ehrapy/anndata/anndata_ext.py
@@ -509,10 +509,10 @@ def get_numeric_vars(adata: AnnData) -> list[str]:
     """
     _assert_encoded(adata)
 
-    if "numerical_columns" in adata.uns_keys():
-        return adata.uns["numerical_columns"]
-    elif "numerical_columns" not in adata.uns_keys() and np.issubdtype(adata.X.dtype, np.number):
+    if "numerical_columns" not in adata.uns_keys():
         return list(adata.var_names.values)
+    else:
+        return adata.uns["numerical_columns"]
 
 
 def assert_numeric_vars(adata: AnnData, vars: Sequence[str]):

--- a/ehrapy/anndata/anndata_ext.py
+++ b/ehrapy/anndata/anndata_ext.py
@@ -509,7 +509,10 @@ def get_numeric_vars(adata: AnnData) -> list[str]:
     """
     _assert_encoded(adata)
 
-    return adata.uns["numerical_columns"]
+    if "numerical_columns" in adata.uns_keys():
+        return adata.uns["numerical_columns"]
+    elif "numerical_columns" not in adata.uns_keys() and np.issubdtype(adata.X.dtype, np.number):
+        return list(adata.var_names.values)
 
 
 def assert_numeric_vars(adata: AnnData, vars: Sequence[str]):

--- a/ehrapy/anndata/anndata_ext.py
+++ b/ehrapy/anndata/anndata_ext.py
@@ -527,7 +527,7 @@ def assert_numeric_vars(adata: AnnData, vars: Sequence[str]):
 def set_numeric_vars(
     adata: AnnData, values: np.ndarray, vars: Sequence[str] | None = None, copy: bool = False
 ) -> AnnData | None:
-    """Sets the column names for numeric variables in X.
+    """Sets the numeric values in given column names in X.
 
     Args:
         adata: :class:`~anndata.AnnData` object
@@ -561,7 +561,7 @@ def set_numeric_vars(
     for i in range(n_values):
         adata.X[:, vars_idx[i]] = values[:, i]
 
-    logg.info(f"Column names for numeric variables {vars} were replaced by {values}.")
+    logg.info(f"Values in columns {vars} were replaced by {values}.")
 
     return adata
 

--- a/tests/anndata/test_anndata_ext.py
+++ b/tests/anndata/test_anndata_ext.py
@@ -413,6 +413,12 @@ class TestAnnDataUtil:
         with pytest.raises(NotEncodedError, match=r"not yet been encoded"):
             get_numeric_vars(self.adata_strings)
 
+    def test_get_numeric_vars_numeric_only(self):
+        """Test for the numeric vars getter when AnnData does not require encoding."""
+        adata = AnnData(X=np.array([[1, 2, 3], [4, 0, 6]], dtype=np.float32))
+        vars = get_numeric_vars(adata)
+        assert vars == ["0", "1", "2"]
+
     def test_assert_numeric_vars(self):
         """Test for the numeric vars assertion."""
         assert_numeric_vars(self.adata_encoded, ["Numeric1", "Numeric2"])

--- a/tests/anndata/test_anndata_ext.py
+++ b/tests/anndata/test_anndata_ext.py
@@ -442,7 +442,7 @@ class TestAnnDataUtil:
             ]
         )
 
-        with pytest.raises(TypeError, match=r"values must be numeric"):
+        with pytest.raises(TypeError, match=r"Values must be numeric"):
             set_numeric_vars(self.adata_encoded, string_values)
 
         extra_values = np.array(

--- a/tests/preprocessing/test_normalization.py
+++ b/tests/preprocessing/test_normalization.py
@@ -250,3 +250,10 @@ class TestNormalization:
         expected_adata = AnnData(X=np.array([[19, 15, 10], [25, 26, 0]], dtype=np.float32))
 
         assert np.array_equal(expected_adata.X, ep.pp.offset_negative_values(to_offset_adata, copy=True).X)
+
+    def test_norm_numerical_only(self):
+        """Test for the log_norm method."""
+        to_normalize_adata = AnnData(X=np.array([[1, 2, 3], [4, 0, 6]], dtype=np.float32))
+        expected_adata = AnnData(X=np.array([[0.6931472, 1.0986123, 1.3862944], [1.609438, 0, 1.9459101]], dtype=np.float32))
+
+        assert np.array_equal(expected_adata.X, ep.pp.log_norm(to_normalize_adata, copy=True).X)

--- a/tests/preprocessing/test_normalization.py
+++ b/tests/preprocessing/test_normalization.py
@@ -254,8 +254,6 @@ class TestNormalization:
     def test_norm_numerical_only(self):
         """Test for the log_norm method."""
         to_normalize_adata = AnnData(X=np.array([[1, 0, 0], [0, 0, 1]], dtype=np.float32))
-        expected_adata = AnnData(
-            X=np.array([[0.6931472, 0, 0], [0, 0, 0.6931472]], dtype=np.float32)
-        )
+        expected_adata = AnnData(X=np.array([[0.6931472, 0, 0], [0, 0, 0.6931472]], dtype=np.float32))
 
         assert np.array_equal(expected_adata.X, ep.pp.log_norm(to_normalize_adata, copy=True).X)

--- a/tests/preprocessing/test_normalization.py
+++ b/tests/preprocessing/test_normalization.py
@@ -253,9 +253,9 @@ class TestNormalization:
 
     def test_norm_numerical_only(self):
         """Test for the log_norm method."""
-        to_normalize_adata = AnnData(X=np.array([[1, 2, 3], [4, 0, 6]], dtype=np.float32))
+        to_normalize_adata = AnnData(X=np.array([[1, 0, 0], [0, 0, 1]], dtype=np.float32))
         expected_adata = AnnData(
-            X=np.array([[0.6931472, 1.0986123, 1.3862944], [1.609438, 0, 1.9459102]], dtype=np.float32)
+            X=np.array([[0.6931472, 0, 0], [0, 0, 0.6931472]], dtype=np.float32)
         )
 
         assert np.array_equal(expected_adata.X, ep.pp.log_norm(to_normalize_adata, copy=True).X)

--- a/tests/preprocessing/test_normalization.py
+++ b/tests/preprocessing/test_normalization.py
@@ -254,6 +254,8 @@ class TestNormalization:
     def test_norm_numerical_only(self):
         """Test for the log_norm method."""
         to_normalize_adata = AnnData(X=np.array([[1, 2, 3], [4, 0, 6]], dtype=np.float32))
-        expected_adata = AnnData(X=np.array([[0.6931472, 1.0986123, 1.3862944], [1.609438, 0, 1.9459101]], dtype=np.float32))
+        expected_adata = AnnData(
+            X=np.array([[0.6931472, 1.0986123, 1.3862944], [1.609438, 0, 1.9459102]], dtype=np.float32)
+        )
 
         assert np.array_equal(expected_adata.X, ep.pp.log_norm(to_normalize_adata, copy=True).X)


### PR DESCRIPTION
Fixes the unability to normalize fully numerical AnnData (does not require encoding) by introducing an additional if-statement into the `get_numeric_vars()` function after making sure that the function `_assert_encoded()` (checks if all columns are numerical) is True. The if-statement checks, if `['numerical_columns']` slot exists in `.uns`, if not, all var_names get returned.