### PR TITLE
Fixed reading format warnings 

### DIFF
--- a/ehrapy/io/_read.py
+++ b/ehrapy/io/_read.py
@@ -561,7 +561,7 @@ def _prepare_dataframe(initial_df: pd.DataFrame, columns_obs_only, columns_x_onl
     no_datetime_object_col = []
     for col in object_type_columns:
         try:
-            pd.to_datetime(initial_df[col])
+            pd.to_datetime(initial_df[col], format="ISO8601")
             # only add to column_obs_only if not present already to avoid duplicates
             if col not in columns_obs_only:
                 columns_obs_only.append(col)

--- a/ehrapy/io/_read.py
+++ b/ehrapy/io/_read.py
@@ -561,7 +561,7 @@ def _prepare_dataframe(initial_df: pd.DataFrame, columns_obs_only, columns_x_onl
     no_datetime_object_col = []
     for col in object_type_columns:
         try:
-            pd.to_datetime(initial_df[col], format="ISO8601")
+            pd.to_datetime(initial_df[col], format="mixed")
             # only add to column_obs_only if not present already to avoid duplicates
             if col not in columns_obs_only:
                 columns_obs_only.append(col)


### PR DESCRIPTION
Fixed reading format warnings by specifying the format in `pd.to_datetime(initial_df[col], format="ISO8601")`. 

Pandas documentation states:
- "ISO8601", to parse any `ISO8601 <https://en.wikipedia.org/wiki/ISO_8601>` time string (not necessarily in exactly the same format);
 - "mixed", to infer the format for each element individually. This is risky, and you should probably use it along with `dayfirst`.

Went with the first option.