### PR TITLE
add functools.wraps to type check

### DIFF
--- a/ehrapy/anndata/_feature_specifications.py
+++ b/ehrapy/anndata/_feature_specifications.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from typing import Literal
 
 import numpy as np
@@ -61,6 +62,7 @@ def infer_feature_types(adata: AnnData, layer: str | None = None, output: Litera
 
 
 def check_feature_types(func):
+    @wraps(func)
     def wrapper(adata, *args, **kwargs):
         if FEATURE_TYPE_KEY not in adata.var.keys():
             raise ValueError("Feature types are not specified in adata.var. Please run `infer_feature_types` first.")


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [x] This comment contains a description of changes (with reason)
-   [ ] Referenced issue is linked none
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [x] Documentation in `docs` is updated

**Description of changes**
Wrappers can cause the function docstring to be lost: [functools.wraps](https://docs.python.org/3/library/functools.html#functools.wraps) can solve that

Currently have that e.g. [here](https://ehrapy.readthedocs.io/en/latest/usage/preprocessing/ehrapy.preprocessing.knn_impute.html).

<!-- Please state what you've changed and how it might affect the user. -->

**Technical details**

<!-- Please state any technical details such as limitations, reasons for additional dependencies, benchmarks etc. here. -->

**Additional context**

<!-- Add any other context or screenshots here. -->
