### PR TITLE
fix ep.tl.umap when neighbors_key is not None

### DIFF
--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -159,26 +159,23 @@ def umap(
 
         **X_umap** : `adata.obsm` field UMAP coordinates of data.
     """
-    if adata.uns["neighbors"] is None or neighbors_key not in adata.uns:
-        return sc.tl.umap(
-            adata=adata,
-            min_dist=min_dist,
-            spread=spread,
-            n_components=n_components,
-            maxiter=maxiter,
-            alpha=alpha,
-            gamma=gamma,
-            negative_sample_rate=negative_sample_rate,
-            init_pos=init_pos,
-            random_state=random_state,
-            a=a,
-            b=b,
-            copy=copy,
-            method=method,
-            neighbors_key=neighbors_key,
-        )
-    else:
-        raise ValueError(f'.uns["{neighbors_key}"] or .uns["neighbors"] were not found. Run `ep.pp.neighbors` first.')
+    return sc.tl.umap(
+        adata=adata,
+        min_dist=min_dist,
+        spread=spread,
+        n_components=n_components,
+        maxiter=maxiter,
+        alpha=alpha,
+        gamma=gamma,
+        negative_sample_rate=negative_sample_rate,
+        init_pos=init_pos,
+        random_state=random_state,
+        a=a,
+        b=b,
+        copy=copy,
+        method=method,
+        neighbors_key=neighbors_key,
+    )
 
 
 def draw_graph(

--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -159,6 +159,11 @@ def umap(
 
         **X_umap** : `adata.obsm` field UMAP coordinates of data.
     """
+
+    key_to_check = neighbors_key if neighbors_key is not None else "neighbors"
+    if key_to_check not in adata.uns:
+        raise ValueError(f"Did not find .uns[{key_to_check!r}]. Ensure you run `ep.pp.neighbors` first.")
+
     return sc.tl.umap(
         adata=adata,
         min_dist=min_dist,

--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -162,7 +162,7 @@ def umap(
 
     key_to_check = neighbors_key if neighbors_key is not None else "neighbors"
     if key_to_check not in adata.uns:
-        raise ValueError(f"Did not find .uns[{key_to_check!r}]. Ensure you run `ep.pp.neighbors` first.")
+        raise ValueError(f"Did not find .uns[{key_to_check!r}]. Please run `ep.pp.neighbors` first.")
 
     return sc.tl.umap(
         adata=adata,


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [x] This comment contains a description of changes (with reason)
-   [x] Referenced issue is linked  Fixes #789
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**
Fix a bug blocking the native the use of `ep.tl.umap` when `ep.pp.neighbors(adata, key_added=<custom>)`.
<!-- Please state what you've changed and how it might affect the user. -->

**Technical details**
Simply remove a faulty check & let scanpy handle it.

Adding tests for plotting and the way to there are an open issue #666, and will be added another time more comprehensively,

<!-- Please state any technical details such as limitations, reasons for additional dependencies, benchmarks etc. here. -->

**Additional context**

<!-- Add any other context or screenshots here. -->
