### PR TITLE
Fix miceforest

### DIFF
--- a/ehrapy/anndata/anndata_ext.py
+++ b/ehrapy/anndata/anndata_ext.py
@@ -85,7 +85,9 @@ def df_to_anndata(
 
     # Prepare the AnnData object
     X = df.to_numpy(copy=True)
+    obs.index = obs.index.astype(str)
     var = pd.DataFrame(index=df.columns)
+    var.index = var.index.astype(str)
     uns = OrderedDict()  # type: ignore
 
     # Handle dtype of X based on presence of numerical columns only
@@ -93,6 +95,8 @@ def df_to_anndata(
     X = X.astype(np.float32 if all_numeric else object)
 
     adata = AnnData(X=X, obs=obs, var=var, uns=uns, layers={"original": X.copy()})
+    adata.obs_names = adata.obs_names.astype(str)
+    adata.var_names = adata.var_names.astype(str)
 
     return adata
 

--- a/tests/preprocessing/test_imputation.py
+++ b/tests/preprocessing/test_imputation.py
@@ -167,35 +167,35 @@ def test_missforest_impute_dict(impute_adata):
     assert not (np.all([item != item for item in adata_imputed.X]))
 
 
-@pytest.mark.skipif(os.name == "posix", reason="miceforest Imputation not supported by MacOS.")
-def test_miceforest_impute_no_copy(impute_iris_adata_adata):
-    adata_imputed = mice_forest_impute(impute_iris_adata_adata)
+@pytest.mark.skipif(os.name == "Darwin", reason="miceforest Imputation not supported by MacOS.")
+def test_miceforest_impute_no_copy(impute_iris_adata):
+    adata_imputed = mice_forest_impute(impute_iris_adata)
 
-    assert id(impute_iris_adata_adata) == id(adata_imputed)
+    assert id(impute_iris_adata) == id(adata_imputed)
 
 
-@pytest.mark.skipif(os.name == "posix", reason="miceforest Imputation not supported by MacOS.")
+@pytest.mark.skipif(os.name == "Darwin", reason="miceforest Imputation not supported by MacOS.")
 def test_miceforest_impute_copy(impute_iris_adata):
     adata_imputed = mice_forest_impute(impute_iris_adata, copy=True)
 
     assert id(impute_iris_adata) != id(adata_imputed)
 
 
-@pytest.mark.skipif(os.name == "posix", reason="miceforest Imputation not supported by MacOS.")
+@pytest.mark.skipif(os.name == "Darwin", reason="miceforest Imputation not supported by MacOS.")
 def test_miceforest_impute_non_numerical_data(impute_titanic_adata):
     adata_imputed = mice_forest_impute(impute_titanic_adata)
 
     assert not (np.all([item != item for item in adata_imputed.X]))
 
 
-@pytest.mark.skipif(os.name == "posix", reason="miceforest Imputation not supported by MacOS.")
+@pytest.mark.skipif(os.name == "Darwin", reason="miceforest Imputation not supported by MacOS.")
 def test_miceforest_impute_numerical_data(impute_iris_adata):
     adata_imputed = mice_forest_impute(impute_iris_adata)
 
     assert not (np.all([item != item for item in adata_imputed.X]))
 
 
-@pytest.mark.skipif(os.name == "posix", reason="miceforest Imputation not supported by MacOS.")
+@pytest.mark.skipif(os.name == "Darwin", reason="miceforest Imputation not supported by MacOS.")
 def test_miceforest_impute_list_str(impute_titanic_adata):
     adata_imputed = mice_forest_impute(impute_titanic_adata, var_names=["Cabin", "Age"])
 


### PR DESCRIPTION
Fix #799 

- Enables miceforest tests again that were accidentally disabled for Linux
- Now uses the new interface of miceforest
- Removes a few warnings