### PR TITLE
Revamp survival analysis interface

### DIFF
--- a/ehrapy/tools/_sa.py
+++ b/ehrapy/tools/_sa.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING, Literal
 
+import numpy as np  # noqa: TC002
 import pandas as pd
 import statsmodels.api as sm
 import statsmodels.formula.api as smf
@@ -22,7 +23,6 @@ from ehrapy.anndata import anndata_to_df
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    import numpy as np
     from anndata import AnnData
     from statsmodels.genmod.generalized_linear_model import GLMResultsWrapper
 

--- a/ehrapy/tools/_sa.py
+++ b/ehrapy/tools/_sa.py
@@ -607,7 +607,7 @@ def log_logistic_aft(
             If True, model the ancillary parameters with the same covariates as ``df``.
             If DataFrame, provide covariates to model the ancillary parameters. Must be the same row count as ``df``.
             If str, should be a formula
-        show_progress: since the fitter is iterative, show convergence diagnostics. Useful if convergence is failing.
+        show_progress: Since the fitter is iterative, show convergence diagnostics. Useful if convergence is failing.
         weights_col: The name of the column in DataFrame that contains the weights for each subject.
         robust: Compute the robust errors using the Huber sandwich estimator, aka Wei-Lin estimate. This does not handle ties, so if there are high number of ties, results may significantly differ.
         initial_point: set the starting point for the iterative solver.

--- a/ehrapy/tools/_sa.py
+++ b/ehrapy/tools/_sa.py
@@ -387,6 +387,7 @@ def cox_ph(
 
     The Cox proportional hazards model (CoxPH) examines the relationship between the survival time of subjects and one or more predictor variables.
     It models the hazard rate as a product of a baseline hazard function and an exponential function of the predictors, assuming proportional hazards over time.
+    The results will be stored in the uns slot of the AnnData object under the key 'cox_ph' unless specified otherwise in the uns_key parameter.
 
     See https://lifelines.readthedocs.io/en/latest/fitters/regression/CoxPHFitter.html
 
@@ -486,6 +487,8 @@ def weibull_aft(
     where the underlying assumption is that the logarithm of survival time follows a Weibull distribution.
     It models the survival time as an exponential function of the predictors, assuming a specific shape parameter
     for the distribution and allowing for accelerated or decelerated failure times based on the covariates.
+    The results will be stored in the uns slot of the AnnData object under the key 'cox_ph' unless specified otherwise in the uns_key parameter.
+
     See https://lifelines.readthedocs.io/en/latest/fitters/regression/WeibullAFTFitter.html
 
     Args:
@@ -582,6 +585,8 @@ def log_logistic_aft(
     This model operates under the assumption that the logarithm of survival time adheres to a log-logistic distribution, offering a flexible framework for understanding the impact of covariates on survival times.
     By modeling survival time as a function of predictors, the Log-Logistic AFT model enables researchers to explore
     how specific factors influence the acceleration or deceleration of failure times, providing valuable insights into the underlying mechanisms driving event occurrence.
+    The results will be stored in the uns slot of the AnnData object under the key 'cox_ph' unless specified otherwise in the uns_key parameter.
+
     See https://lifelines.readthedocs.io/en/latest/fitters/regression/LogLogisticAFTFitter.html
 
     Args:

--- a/ehrapy/tools/_sa.py
+++ b/ehrapy/tools/_sa.py
@@ -349,7 +349,7 @@ def anova_glm(result_1: GLMResultsWrapper, result_2: GLMResultsWrapper, formula_
     return dataframe
 
 
-def _regression_model_data_frame_preparation(adata: AnnData, duration_col: str, accept_zero_duration=True):
+def _build_model_input_dataframe(adata: AnnData, duration_col: str, accept_zero_duration=True):
     """Convenience function for regression models."""
     df = anndata_to_df(adata)
     df = df.dropna()
@@ -429,7 +429,7 @@ def cox_ph(
         >>> adata[:, ["censor_flg"]].X = np.where(adata[:, ["censor_flg"]].X == 0, 1, 0)
         >>> cph = ep.tl.cox_ph(adata, "mort_day_censored", "censor_flg")
     """
-    df = _regression_model_data_frame_preparation(adata, duration_col)
+    df = _build_model_input_dataframe(adata, duration_col)
     cox_ph = CoxPHFitter(
         alpha=alpha,
         label=label,
@@ -531,7 +531,7 @@ def weibull_aft(
         >>> aft.print_summary()
     """
 
-    df = _regression_model_data_frame_preparation(adata, duration_col, accept_zero_duration=False)
+    df = _build_model_input_dataframe(adata, duration_col, accept_zero_duration=False)
 
     weibull_aft = WeibullAFTFitter(
         alpha=alpha,
@@ -627,7 +627,7 @@ def log_logistic_aft(
         >>> adata = adata[:, ["mort_day_censored", "censor_flg"]]
         >>> llf = ep.tl.log_logistic_aft(adata, duration_col="mort_day_censored", event_col="censor_flg")
     """
-    df = _regression_model_data_frame_preparation(adata, duration_col, accept_zero_duration=False)
+    df = _build_model_input_dataframe(adata, duration_col, accept_zero_duration=False)
 
     log_logistic_aft = LogLogisticAFTFitter(
         alpha=alpha,
@@ -673,10 +673,7 @@ def _univariate_model(
     censoring: Literal["right", "left"] = "right",
 ):
     """Convenience function for univariate models."""
-    df = anndata_to_df(adata)
-
-    if not accept_zero_duration:
-        df.loc[df[duration_col] == 0, duration_col] += 1e-5
+    df = _build_model_input_dataframe(adata, duration_col, accept_zero_duration)
     T = df[duration_col]
     E = df[event_col]
 

--- a/ehrapy/tools/_sa.py
+++ b/ehrapy/tools/_sa.py
@@ -601,7 +601,7 @@ def log_logistic_aft(
         fit_intercept: Whether to fit an intercept term in the model.
         penalizer: Attach a penalty to the size of the coefficients during regression. This improves stability of the estimates and controls for high correlation between covariates.
         l1_ratio: Specify what ratio to assign to a L1 vs L2 penalty. Same as scikit-learn. See penalizer above.
-        model_ancillary: set the model instance to always model the ancillary parameter with the supplied Dataframe. This is useful for grid-search optimization.
+        model_ancillary: Set the model instance to always model the ancillary parameter with the supplied Dataframe. This is useful for grid-search optimization.
         ancillary: Choose to model the ancillary parameters.
             If None or False, explicitly do not fit the ancillary parameters using any covariates.
             If True, model the ancillary parameters with the same covariates as ``df``.

--- a/ehrapy/tools/_sa.py
+++ b/ehrapy/tools/_sa.py
@@ -401,7 +401,7 @@ def cox_ph(
             If left `None`, all individuals are assumed to be uncensored.
         uns_key: The key to use for the uns slot in the AnnData object.
         alpha: The alpha value in the confidence intervals.
-        label: A string to name the column of the estimate.
+        label: The name of the column of the estimate.
         baseline_estimation_method: The method used to estimate the baseline hazard. Options are 'breslow', 'spline', and 'piecewise'.
         penalizer: Attach a penalty to the size of the coefficients during regression. This improves stability of the estimates and controls for high correlation between covariates.
         l1_ratio: Specify what ratio to assign to a L1 vs L2 penalty. Same as scikit-learn. See penalizer above.

--- a/ehrapy/tools/_sa.py
+++ b/ehrapy/tools/_sa.py
@@ -199,6 +199,7 @@ def kaplan_meier(
     duration_col: str,
     event_col: str | None = None,
     *,
+    uns_key: str = "kaplan_meier",
     timeline: list[float] | None = None,
     entry: str | None = None,
     label: str | None = None,
@@ -212,6 +213,7 @@ def kaplan_meier(
 
     The Kaplan–Meier estimator, also known as the product limit estimator, is a non-parametric statistic used to estimate the survival function from lifetime data.
     In medical research, it is often used to measure the fraction of patients living for a certain amount of time after treatment.
+    The results will be stored in the `.uns` slot of the :class:`AnnData` object under the key 'kaplan_meier' unless specified otherwise in the `uns_key` parameter.
 
     See https://en.wikipedia.org/wiki/Kaplan%E2%80%93Meier_estimator
         https://lifelines.readthedocs.io/en/latest/fitters/univariate/KaplanMeierFitter.html#module-lifelines.fitters.kaplan_meier_fitter
@@ -222,6 +224,7 @@ def kaplan_meier(
         event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or censored.
             Column values are `True` if the event was observed, `False` if the event was lost (right-censored).
             If left `None`, all individuals are assumed to be uncensored.
+        uns_key: The key to use for the uns slot in the AnnData object.
         timeline: Return the best estimate at the values in timelines (positively increasing)
         entry: Relative time when a subject entered the study. This is useful for left-truncated (not left-censored) observations.
                If None, all members of the population entered study when they were "born".
@@ -249,6 +252,7 @@ def kaplan_meier(
         duration_col,
         event_col,
         KaplanMeierFitter,
+        uns_key,
         True,
         timeline,
         entry,
@@ -662,6 +666,7 @@ def _univariate_model(
     duration_col: str,
     event_col: str,
     model_class,
+    uns_key: str,
     accept_zero_duration=True,
     timeline: list[float] | None = None,
     entry: str | None = None,
@@ -694,6 +699,14 @@ def _univariate_model(
         fit_options=fit_options,
     )
 
+    if isinstance(model, NelsonAalenFitter) or isinstance(
+        model, KaplanMeierFitter
+    ):  # NelsonAalenFitter and KaplanMeierFitter have no summary attribute
+        summary = model.event_table
+    else:
+        summary = model.summary
+    adata.uns[uns_key] = summary
+
     return model
 
 
@@ -702,6 +715,7 @@ def nelson_aalen(
     duration_col: str,
     event_col: str | None = None,
     *,
+    uns_key: str = "nelson_aalen",
     timeline: list[float] | None = None,
     entry: str | None = None,
     label: str | None = None,
@@ -716,6 +730,7 @@ def nelson_aalen(
     The Nelson-Aalen estimator is a non-parametric method used in survival analysis to estimate the cumulative hazard function.
     This technique is particularly useful when dealing with censored data, as it accounts for the presence of individuals whose event times are unknown due to censoring.
     By estimating the cumulative hazard function, the Nelson-Aalen estimator allows researchers to assess the risk of an event occurring over time, providing valuable insights into the underlying dynamics of the survival process.
+    The results will be stored in the `.uns` slot of the :class:`AnnData` object under the key 'nelson_aalen' unless specified otherwise in the `uns_key` parameter.
     See https://lifelines.readthedocs.io/en/latest/fitters/univariate/NelsonAalenFitter.html
 
     Args:
@@ -724,6 +739,7 @@ def nelson_aalen(
         event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or censored.
             Column values are `True` if the event was observed, `False` if the event was lost (right-censored).
             If left `None`, all individuals are assumed to be uncensored.
+        uns_key: The key to use for the uns slot in the AnnData object.
         timeline: Return the best estimate at the values in timelines (positively increasing)
         entry: Relative time when a subject entered the study. This is useful for left-truncated (not left-censored) observations.
                If None, all members of the population entered study when they were "born".
@@ -752,7 +768,8 @@ def nelson_aalen(
         duration_col,
         event_col,
         NelsonAalenFitter,
-        True,
+        uns_key=uns_key,
+        accept_zero_duration=True,
         timeline=timeline,
         entry=entry,
         label=label,
@@ -769,6 +786,7 @@ def weibull(
     duration_col: str,
     event_col: str,
     *,
+    uns_key: str = "weibull",
     timeline: list[float] | None = None,
     entry: str | None = None,
     label: str | None = None,
@@ -785,6 +803,7 @@ def weibull(
     By fitting the Weibull model to censored survival data, researchers can estimate these parameters and gain insights
     into the hazard rate over time, facilitating comparisons between different groups or treatments.
     This method provides a comprehensive framework for examining survival data and offers valuable insights into the factors influencing event occurrence dynamics.
+    The results will be stored in the `.uns` slot of the :class:`AnnData` object under the key 'weibull' unless specified otherwise in the `uns_key` parameter.
     See https://lifelines.readthedocs.io/en/latest/fitters/univariate/WeibullFitter.html
 
     Args:
@@ -793,6 +812,7 @@ def weibull(
         event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or censored.
             Column values are `True` if the event was observed, `False` if the event was lost (right-censored).
             If left `None`, all individuals are assumed to be uncensored.
+        uns_key: The key to use for the uns slot in the AnnData object.
         timeline: Return the best estimate at the values in timelines (positively increasing)
         entry: Relative time when a subject entered the study. This is useful for left-truncated (not left-censored) observations.
                If None, all members of the population entered study when they were "born".
@@ -818,6 +838,7 @@ def weibull(
         duration_col,
         event_col,
         WeibullFitter,
+        uns_key=uns_key,
         accept_zero_duration=False,
         timeline=timeline,
         entry=entry,

--- a/ehrapy/tools/_sa.py
+++ b/ehrapy/tools/_sa.py
@@ -488,7 +488,7 @@ def weibull_aft(
     where the underlying assumption is that the logarithm of survival time follows a Weibull distribution.
     It models the survival time as an exponential function of the predictors, assuming a specific shape parameter
     for the distribution and allowing for accelerated or decelerated failure times based on the covariates.
-    The results will be stored in the uns slot of the AnnData object under the key 'weibull_aft' unless specified otherwise in the uns_key parameter.
+    The results will be stored in the `.uns` slot of the :class:`AnnData` object under the key 'weibull_aft' unless specified otherwise in the `uns_key` parameter.
 
     See https://lifelines.readthedocs.io/en/latest/fitters/regression/WeibullAFTFitter.html
 

--- a/ehrapy/tools/_sa.py
+++ b/ehrapy/tools/_sa.py
@@ -224,7 +224,7 @@ def kaplan_meier(
         event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or censored.
             Column values are `True` if the event was observed, `False` if the event was lost (right-censored).
             If left `None`, all individuals are assumed to be uncensored.
-        uns_key: The key to use for the uns slot in the AnnData object.
+        uns_key: The key to use for the `.uns` slot in the AnnData object.
         timeline: Return the best estimate at the values in timelines (positively increasing)
         entry: Relative time when a subject entered the study. This is useful for left-truncated (not left-censored) observations.
                If None, all members of the population entered study when they were "born".
@@ -403,7 +403,7 @@ def cox_ph(
         event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or censored.
             Column values are `True` if the event was observed, `False` if the event was lost (right-censored).
             If left `None`, all individuals are assumed to be uncensored.
-        uns_key: The key to use for the uns slot in the AnnData object.
+        uns_key: The key to use for the `.uns` slot in the AnnData object.
         alpha: The alpha value in the confidence intervals.
         label: The name of the column of the estimate.
         baseline_estimation_method: The method used to estimate the baseline hazard. Options are 'breslow', 'spline', and 'piecewise'.
@@ -502,7 +502,7 @@ def weibull_aft(
         event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or censored.
             Column values are `True` if the event was observed, `False` if the event was lost (right-censored).
             If left `None`, all individuals are assumed to be uncensored.
-        uns_key: The key to use for the uns slot in the AnnData object.
+        uns_key: The key to use for the `.uns` slot in the AnnData object.
         alpha: The alpha value in the confidence intervals.
         fit_intercept: Whether to fit an intercept term in the model.
         penalizer: Attach a penalty to the size of the coefficients during regression. This improves stability of the estimates and controls for high correlation between covariates.
@@ -600,7 +600,7 @@ def log_logistic_aft(
         event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or censored.
             Column values are `True` if the event was observed, `False` if the event was lost (right-censored).
             If left `None`, all individuals are assumed to be uncensored.
-        uns_key: The key to use for the uns slot in the AnnData object.
+        uns_key: The key to use for the `.uns` slot in the AnnData object.
         alpha: The alpha value in the confidence intervals.
         fit_intercept: Whether to fit an intercept term in the model.
         penalizer: Attach a penalty to the size of the coefficients during regression. This improves stability of the estimates and controls for high correlation between covariates.
@@ -739,7 +739,7 @@ def nelson_aalen(
         event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or censored.
             Column values are `True` if the event was observed, `False` if the event was lost (right-censored).
             If left `None`, all individuals are assumed to be uncensored.
-        uns_key: The key to use for the uns slot in the AnnData object.
+        uns_key: The key to use for the `.uns` slot in the AnnData object.
         timeline: Return the best estimate at the values in timelines (positively increasing)
         entry: Relative time when a subject entered the study. This is useful for left-truncated (not left-censored) observations.
                If None, all members of the population entered study when they were "born".
@@ -812,7 +812,7 @@ def weibull(
         event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or censored.
             Column values are `True` if the event was observed, `False` if the event was lost (right-censored).
             If left `None`, all individuals are assumed to be uncensored.
-        uns_key: The key to use for the uns slot in the AnnData object.
+        uns_key: The key to use for the `.uns` slot in the AnnData object.
         timeline: Return the best estimate at the values in timelines (positively increasing)
         entry: Relative time when a subject entered the study. This is useful for left-truncated (not left-censored) observations.
                If None, all members of the population entered study when they were "born".

--- a/ehrapy/tools/_sa.py
+++ b/ehrapy/tools/_sa.py
@@ -487,7 +487,7 @@ def weibull_aft(
     where the underlying assumption is that the logarithm of survival time follows a Weibull distribution.
     It models the survival time as an exponential function of the predictors, assuming a specific shape parameter
     for the distribution and allowing for accelerated or decelerated failure times based on the covariates.
-    The results will be stored in the uns slot of the AnnData object under the key 'cox_ph' unless specified otherwise in the uns_key parameter.
+    The results will be stored in the uns slot of the AnnData object under the key 'weibull_aft' unless specified otherwise in the uns_key parameter.
 
     See https://lifelines.readthedocs.io/en/latest/fitters/regression/WeibullAFTFitter.html
 
@@ -585,7 +585,7 @@ def log_logistic_aft(
     This model operates under the assumption that the logarithm of survival time adheres to a log-logistic distribution, offering a flexible framework for understanding the impact of covariates on survival times.
     By modeling survival time as a function of predictors, the Log-Logistic AFT model enables researchers to explore
     how specific factors influence the acceleration or deceleration of failure times, providing valuable insights into the underlying mechanisms driving event occurrence.
-    The results will be stored in the uns slot of the AnnData object under the key 'cox_ph' unless specified otherwise in the uns_key parameter.
+    The results will be stored in the uns slot of the AnnData object under the key 'log_logistic_aft' unless specified otherwise in the uns_key parameter.
 
     See https://lifelines.readthedocs.io/en/latest/fitters/regression/LogLogisticAFTFitter.html
 

--- a/ehrapy/tools/_sa.py
+++ b/ehrapy/tools/_sa.py
@@ -358,32 +358,12 @@ def _regression_model_data_frame_preparation(adata: AnnData, duration_col: str, 
     return df
 
 
-def _regression_model_populate_adata(adata: AnnData, model_summary: pd.DataFrame, key_added_prefix: str = None):
-    if key_added_prefix is None:
-        key_added_prefix = ""
-    else:
-        key_added_prefix = key_added_prefix + "_"
-
-    full_results = pd.DataFrame(index=adata.var.index)
-
-    # Populate with CoxPH summary data
-    for key in model_summary.columns:
-        full_results[key_added_prefix + key] = model_summary[key]
-
-    # Add a boolean column indicating rows populated by this function
-    full_results[key_added_prefix + "cox_ph_populated"] = full_results.notna().any(axis=1)
-
-    # Assign results back to adata.var
-    for col in full_results.columns:
-        adata.var[col] = full_results[col]
-
-
 def cox_ph(
     adata: AnnData,
     duration_col: str,
     *,
     inplace: bool = True,
-    key_added_prefix: str | None = None,
+    uns_key: str = "cox_ph",
     alpha: float = 0.05,
     label: str | None = None,
     baseline_estimation_method: Literal["breslow", "spline", "piecewise"] = "breslow",
@@ -417,7 +397,7 @@ def cox_ph(
         event_col: The name of the column in anndata that contains the subjects’ death observation.
                    If left as None, assume all individuals are uncensored.
         inplace: Whether to modify the AnnData object in place.
-        key_added_prefix: Prefix to add to the column names in the AnnData object. An underscore will be added between the prefix and the column
+        uns_key: The key to use for the uns slot in the AnnData object.
         alpha: The alpha value in the confidence intervals.
         label: A string to name the column of the estimate.
         baseline_estimation_method: The method used to estimate the baseline hazard. Options are 'breslow', 'spline', and 'piecewise'.
@@ -477,7 +457,8 @@ def cox_ph(
 
     # Add the results to the AnnData object
     if inplace:
-        _regression_model_populate_adata(adata, cox_ph.summary, key_added_prefix)
+        summary = cox_ph.summary
+        adata.uns[uns_key] = summary
 
     return cox_ph
 
@@ -487,7 +468,7 @@ def weibull_aft(
     duration_col: str,
     *,
     inplace: bool = True,
-    key_added_prefix: str | None = None,
+    uns_key: str = "weibull_aft",
     alpha: float = 0.05,
     fit_intercept: bool = True,
     penalizer: float | np.ndarray = 0.0,
@@ -515,7 +496,7 @@ def weibull_aft(
         adata: AnnData object with necessary columns `duration_col` and `event_col`.
         duration_col: Name of the column in the AnnData objects that contains the subjects’ lifetimes.
         inplace: Whether to modify the AnnData object in place.
-        key_added_prefix: Prefix to add to the column names in the AnnData object. An underscore will be added between the prefix and the column name.
+        uns_key: The key to use for the uns slot in the AnnData object.
         alpha: The alpha value in the confidence intervals.
         fit_intercept: Whether to fit an intercept term in the model.
         penalizer: Attach a penalty to the size of the coefficients during regression. This improves stability of the estimates and controls for high correlation between covariates.
@@ -576,7 +557,8 @@ def weibull_aft(
 
     # Add the results to the AnnData object
     if inplace:
-        _regression_model_populate_adata(adata, weibull_aft.summary, key_added_prefix)
+        summary = weibull_aft.summary
+        adata.uns[uns_key] = summary
 
     return weibull_aft
 
@@ -586,7 +568,7 @@ def log_logistic_aft(
     duration_col: str,
     *,
     inplace: bool = True,
-    key_added_prefix: str | None = None,
+    uns_key: str = "log_logistic_aft",
     alpha: float = 0.05,
     fit_intercept: bool = True,
     penalizer: float | np.ndarray = 0.0,
@@ -613,7 +595,7 @@ def log_logistic_aft(
         adata: AnnData object with necessary columns `duration_col` and `event_col`.
         duration_col: Name of the column in the AnnData objects that contains the subjects’ lifetimes.
         inplace: Whether to modify the AnnData object in place.
-        key_added_prefix: Prefix to add to the column names in the AnnData object. An underscore will be added between the prefix and the column
+        uns_key: The key to use for the uns slot in the AnnData object.
         alpha: The alpha value in the confidence intervals.
          alpha: The alpha value in the confidence intervals.
         fit_intercept: Whether to fit an intercept term in the model.
@@ -673,7 +655,8 @@ def log_logistic_aft(
 
     # Add the results to the AnnData object
     if inplace:
-        _regression_model_populate_adata(adata, log_logistic_aft.summary, key_added_prefix)
+        summary = log_logistic_aft.summary
+        adata.uns[uns_key] = summary
 
     return log_logistic_aft
 

--- a/ehrapy/tools/_sa.py
+++ b/ehrapy/tools/_sa.py
@@ -644,7 +644,8 @@ def log_logistic_aft(
         >>> adata = ep.dt.mimic_2(encoded=False)
         >>> # Flip 'censor_fl' because 0 = death and 1 = censored
         >>> adata[:, ["censor_flg"]].X = np.where(adata[:, ["censor_flg"]].X == 0, 1, 0)
-        >>> llf = ep.tl.log_logistic_aft(adata, "mort_day_censored", "censor_flg")
+        >>> adata = adata[:, ["mort_day_censored", "censor_flg"]]
+        >>> llf = ep.tl.log_logistic_aft(adata, duration_col="mort_day_censored", event_col="censor_flg")
     """
     df = _regression_model_data_frame_preparation(adata, duration_col, accept_zero_duration=False)
 

--- a/ehrapy/tools/_sa.py
+++ b/ehrapy/tools/_sa.py
@@ -362,7 +362,6 @@ def cox_ph(
     adata: AnnData,
     duration_col: str,
     *,
-    inplace: bool = True,
     uns_key: str = "cox_ph",
     alpha: float = 0.05,
     label: str | None = None,
@@ -396,7 +395,6 @@ def cox_ph(
         duration_col: The name of the column in the AnnData objects that contains the subjects’ lifetimes.
         event_col: The name of the column in anndata that contains the subjects’ death observation.
                    If left as None, assume all individuals are uncensored.
-        inplace: Whether to modify the AnnData object in place.
         uns_key: The key to use for the uns slot in the AnnData object.
         alpha: The alpha value in the confidence intervals.
         label: A string to name the column of the estimate.
@@ -455,10 +453,9 @@ def cox_ph(
         show_progress=show_progress,
     )
 
-    # Add the results to the AnnData object
-    if inplace:
-        summary = cox_ph.summary
-        adata.uns[uns_key] = summary
+    # Save the summary to the uns slot
+    summary = cox_ph.summary
+    adata.uns[uns_key] = summary
 
     return cox_ph
 
@@ -467,7 +464,6 @@ def weibull_aft(
     adata: AnnData,
     duration_col: str,
     *,
-    inplace: bool = True,
     uns_key: str = "weibull_aft",
     alpha: float = 0.05,
     fit_intercept: bool = True,
@@ -495,7 +491,6 @@ def weibull_aft(
     Args:
         adata: AnnData object with necessary columns `duration_col` and `event_col`.
         duration_col: Name of the column in the AnnData objects that contains the subjects’ lifetimes.
-        inplace: Whether to modify the AnnData object in place.
         uns_key: The key to use for the uns slot in the AnnData object.
         alpha: The alpha value in the confidence intervals.
         fit_intercept: Whether to fit an intercept term in the model.
@@ -555,10 +550,9 @@ def weibull_aft(
         fit_options=fit_options,
     )
 
-    # Add the results to the AnnData object
-    if inplace:
-        summary = weibull_aft.summary
-        adata.uns[uns_key] = summary
+    # Save the summary to the uns slot
+    summary = weibull_aft.summary
+    adata.uns[uns_key] = summary
 
     return weibull_aft
 
@@ -567,7 +561,6 @@ def log_logistic_aft(
     adata: AnnData,
     duration_col: str,
     *,
-    inplace: bool = True,
     uns_key: str = "log_logistic_aft",
     alpha: float = 0.05,
     fit_intercept: bool = True,
@@ -594,7 +587,6 @@ def log_logistic_aft(
     Args:
         adata: AnnData object with necessary columns `duration_col` and `event_col`.
         duration_col: Name of the column in the AnnData objects that contains the subjects’ lifetimes.
-        inplace: Whether to modify the AnnData object in place.
         uns_key: The key to use for the uns slot in the AnnData object.
         alpha: The alpha value in the confidence intervals.
          alpha: The alpha value in the confidence intervals.
@@ -653,10 +645,9 @@ def log_logistic_aft(
         fit_options=fit_options,
     )
 
-    # Add the results to the AnnData object
-    if inplace:
-        summary = log_logistic_aft.summary
-        adata.uns[uns_key] = summary
+    # Save the summary to the uns slot
+    summary = log_logistic_aft.summary
+    adata.uns[uns_key] = summary
 
     return log_logistic_aft
 

--- a/ehrapy/tools/_sa.py
+++ b/ehrapy/tools/_sa.py
@@ -219,7 +219,7 @@ def kaplan_meier(
     Args:
         adata: AnnData object.
         duration_col: The name of the column in the AnnData object that contains the subjects’ lifetimes.
-        event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or the individual has been censored.
+        event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or censored.
             Column values are `True` if the event was observed, `False` if the event was lost (right-censored).
             If left `None`, all individuals are assumed to be uncensored.
         timeline: Return the best estimate at the values in timelines (positively increasing)
@@ -396,7 +396,7 @@ def cox_ph(
     Args:
         adata: AnnData object.
         duration_col: The name of the column in the AnnData objects that contains the subjects’ lifetimes.
-        event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or the individual has been censored.
+        event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or censored.
             Column values are `True` if the event was observed, `False` if the event was lost (right-censored).
             If left `None`, all individuals are assumed to be uncensored.
         uns_key: The key to use for the uns slot in the AnnData object.
@@ -495,7 +495,7 @@ def weibull_aft(
     Args:
         adata: AnnData object.
         duration_col: Name of the column in the AnnData objects that contains the subjects’ lifetimes.
-        event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or the individual has been censored.
+        event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or censored.
             Column values are `True` if the event was observed, `False` if the event was lost (right-censored).
             If left `None`, all individuals are assumed to be uncensored.
         uns_key: The key to use for the uns slot in the AnnData object.
@@ -593,7 +593,7 @@ def log_logistic_aft(
     Args:
         adata: AnnData object.
         duration_col: Name of the column in the AnnData objects that contains the subjects’ lifetimes.
-        event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or the individual has been censored.
+        event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or censored.
             Column values are `True` if the event was observed, `False` if the event was lost (right-censored).
             If left `None`, all individuals are assumed to be uncensored.
         uns_key: The key to use for the uns slot in the AnnData object.
@@ -724,7 +724,7 @@ def nelson_aalen(
     Args:
         adata: AnnData object.
         duration_col: The name of the column in the AnnData objects that contains the subjects’ lifetimes.
-        event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or the individual has been censored.
+        event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or censored.
             Column values are `True` if the event was observed, `False` if the event was lost (right-censored).
             If left `None`, all individuals are assumed to be uncensored.
         timeline: Return the best estimate at the values in timelines (positively increasing)
@@ -793,7 +793,7 @@ def weibull(
     Args:
         adata: AnnData object.
         duration_col: Name of the column in the AnnData objects that contains the subjects’ lifetimes.
-        event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or the individual has been censored.
+        event_col: The name of the column in the AnnData object that specifies whether the event has been observed, or censored.
             Column values are `True` if the event was observed, `False` if the event was lost (right-censored).
             If left `None`, all individuals are assumed to be uncensored.
         timeline: Return the best estimate at the values in timelines (positively increasing)

--- a/ehrapy/tools/_sa.py
+++ b/ehrapy/tools/_sa.py
@@ -414,7 +414,7 @@ def cox_ph(
         entry_col: Column denoting when a subject entered the study, i.e. left-truncation.
         robust: Compute the robust errors using the Huber sandwich estimator, aka Wei-Lin estimate. This does not handle ties, so if there are high number of ties, results may significantly differ.
         formula: an Wilkinson formula, like in R and statsmodels, for the right-hand-side. If left as None, all columns not assigned as durations, weights, etc. are used. Uses the library Formulaic for parsing.
-        batch_mode:  enabling batch_mode can be faster for datasets with a large number of ties. If left as None, lifelines will choose the best option.
+        batch_mode:  Enabling batch_mode can be faster for datasets with a large number of ties. If left as `None`, lifelines will choose the best option.
         show_progress: since the fitter is iterative, show convergence diagnostics. Useful if convergence is failing.
         initial_point: set the starting point for the iterative solver.
         fit_options: Additional keyword arguments to pass into the estimator.

--- a/ehrapy/tools/_sa.py
+++ b/ehrapy/tools/_sa.py
@@ -389,7 +389,7 @@ def cox_ph(
 
     The Cox proportional hazards model (CoxPH) examines the relationship between the survival time of subjects and one or more predictor variables.
     It models the hazard rate as a product of a baseline hazard function and an exponential function of the predictors, assuming proportional hazards over time.
-    The results will be stored in the uns slot of the AnnData object under the key 'cox_ph' unless specified otherwise in the uns_key parameter.
+    The results will be stored in the `.uns` slot of the :class:`AnnData` object under the key 'cox_ph' unless specified otherwise in the `uns_key` parameter.
 
     See https://lifelines.readthedocs.io/en/latest/fitters/regression/CoxPHFitter.html
 

--- a/ehrapy/tools/_sa.py
+++ b/ehrapy/tools/_sa.py
@@ -586,7 +586,7 @@ def log_logistic_aft(
     This model operates under the assumption that the logarithm of survival time adheres to a log-logistic distribution, offering a flexible framework for understanding the impact of covariates on survival times.
     By modeling survival time as a function of predictors, the Log-Logistic AFT model enables researchers to explore
     how specific factors influence the acceleration or deceleration of failure times, providing valuable insights into the underlying mechanisms driving event occurrence.
-    The results will be stored in the uns slot of the AnnData object under the key 'log_logistic_aft' unless specified otherwise in the uns_key parameter.
+    The results will be stored in the `.uns` slot of the :class:`AnnData` object under the key 'log_logistic_aft' unless specified otherwise in the `uns_key` parameter.
 
     See https://lifelines.readthedocs.io/en/latest/fitters/regression/LogLogisticAFTFitter.html
 

--- a/ehrapy/tools/_sa.py
+++ b/ehrapy/tools/_sa.py
@@ -415,7 +415,7 @@ def cox_ph(
         robust: Compute the robust errors using the Huber sandwich estimator, aka Wei-Lin estimate. This does not handle ties, so if there are high number of ties, results may significantly differ.
         formula: an Wilkinson formula, like in R and statsmodels, for the right-hand-side. If left as None, all columns not assigned as durations, weights, etc. are used. Uses the library Formulaic for parsing.
         batch_mode:  Enabling batch_mode can be faster for datasets with a large number of ties. If left as `None`, lifelines will choose the best option.
-        show_progress: since the fitter is iterative, show convergence diagnostics. Useful if convergence is failing.
+        show_progress: Since the fitter is iterative, show convergence diagnostics. Useful if convergence is failing.
         initial_point: set the starting point for the iterative solver.
         fit_options: Additional keyword arguments to pass into the estimator.
 

--- a/tests/tools/test_sa.py
+++ b/tests/tools/test_sa.py
@@ -84,15 +84,23 @@ class TestSA:
         assert dataframe.iloc[1, 4] == 2
         assert pytest.approx(dataframe.iloc[1, 5], 0.1) == 0.103185
 
-    def _sa_function_assert(self, model, model_class):
+    def _sa_function_assert(self, model, model_class, adata=None):
         assert isinstance(model, model_class)
         assert len(model.durations) == 1776
         assert sum(model.event_observed) == 497
 
-    def _sa_func_test(self, sa_function, sa_class, mimic_2_sa):
-        adata, duration_col, event_col = mimic_2_sa
+        if adata is not None:
+            model_summary = adata.uns.get("test")
+            assert model_summary is not None
+            assert model_summary.equals(model.summary)
 
-        sa = sa_function(adata, duration_col=duration_col, event_col=event_col)
+    def _sa_func_test(self, sa_function, sa_class, mimic_2_sa, regression=False):
+        adata, duration_col, event_col = mimic_2_sa
+        if regression:
+            sa = sa_function(adata, duration_col=duration_col, event_col=event_col, uns_key="test")
+        else:
+            sa = sa_function(adata, duration_col=duration_col, event_col=event_col)
+
         self._sa_function_assert(sa, sa_class)
 
     def test_kmf(self, mimic_2_sa):

--- a/tests/tools/test_sa.py
+++ b/tests/tools/test_sa.py
@@ -92,7 +92,7 @@ class TestSA:
     def _sa_func_test(self, sa_function, sa_class, mimic_2_sa):
         adata, duration_col, event_col = mimic_2_sa
 
-        sa = sa_function(adata, duration_col, event_col)
+        sa = sa_function(adata, duration_col=duration_col, event_col=event_col)
         self._sa_function_assert(sa, sa_class)
 
     def test_kmf(self, mimic_2_sa):

--- a/tests/tools/test_sa.py
+++ b/tests/tools/test_sa.py
@@ -89,17 +89,14 @@ class TestSA:
         assert len(model.durations) == 1776
         assert sum(model.event_observed) == 497
 
-        if adata is not None:
+        if adata is not None:  # doing it disway, due to legacy kmf function
             model_summary = adata.uns.get("test")
             assert model_summary is not None
             assert model_summary.equals(model.summary)
 
-    def _sa_func_test(self, sa_function, sa_class, mimic_2_sa, regression=False):
+    def _sa_func_test(self, sa_function, sa_class, mimic_2_sa):
         adata, duration_col, event_col = mimic_2_sa
-        if regression:
-            sa = sa_function(adata, duration_col=duration_col, event_col=event_col, uns_key="test")
-        else:
-            sa = sa_function(adata, duration_col=duration_col, event_col=event_col)
+        sa = sa_function(adata, duration_col=duration_col, event_col=event_col, uns_key="test")
 
         self._sa_function_assert(sa, sa_class)
 

--- a/tests/tools/test_sa.py
+++ b/tests/tools/test_sa.py
@@ -92,13 +92,18 @@ class TestSA:
         if adata is not None:  # doing it disway, due to legacy kmf function
             model_summary = adata.uns.get("test")
             assert model_summary is not None
-            assert model_summary.equals(model.summary)
+            if isinstance(model, KaplanMeierFitter) or isinstance(
+                model, NelsonAalenFitter
+            ):  # kmf and nelson_aalen have event_table
+                assert model_summary.equals(model.event_table)
+            else:
+                assert model_summary.equals(model.summary)
 
     def _sa_func_test(self, sa_function, sa_class, mimic_2_sa):
         adata, duration_col, event_col = mimic_2_sa
         sa = sa_function(adata, duration_col=duration_col, event_col=event_col, uns_key="test")
 
-        self._sa_function_assert(sa, sa_class)
+        self._sa_function_assert(sa, sa_class, adata)
 
     def test_kmf(self, mimic_2_sa):
         # check for deprecation warning


### PR DESCRIPTION
Fixes #840 

This pull request includes refactoring and enhancements to the survival analysis tools, particularly focusing on the Cox Proportional Hazards (CoxPH), Weibull Accelerated Failure Time (Weibull AFT), and Log-Logistic Accelerated Failure Time (Log-Logistic AFT) models. The changes improve the flexibility and usability of these models by adding new parameters and restructuring the code.

### Refactoring and Enhancements:

* **Code Refactoring:**
  * Split the `_regression_model` function into two separate functions: `_regression_model_data_frame_preparation` and `_regression_model_populate_adata`.

* **Cox Proportional Hazards Model:**
  * Added new parameters to the `cox_ph` function to provide more control over the model fitting process, such as `inplace`, `key_added_prefix`, `alpha`, `label`, `baseline_estimation_method`, `penalizer`, `l1_ratio`, `strata`, `n_baseline_knots`, `knots`, `breakpoints`, `weights_col`, `cluster_col`, `robust`, `formula`, `batch_mode`, `show_progress`, `initial_point`, and `fit_options`.

* **Weibull Accelerated Failure Time Model:**
  * Enhanced the `weibull_aft` function with additional parameters similar to those added to the `cox_ph` function.

* **Log-Logistic Accelerated Failure Time Model:**
  * Updated the `log_logistic_aft` function to include new parameters.

* **Testing Adjustments:**
  * Modified the `_sa_func_test` method in `tests/tools/test_sa.py` to accommodate the updated function signatures, ensuring that tests pass with the new parameters.