### PR TITLE
Fix a typo in `pl.paga_compare`: `pos` -> `pos,`

### DIFF
--- a/ehrapy/plot/_scanpy_pl_api.py
+++ b/ehrapy/plot/_scanpy_pl_api.py
@@ -1984,7 +1984,8 @@ def paga_compare(
         save=save,
         title_graph=title_graph,
         groups_graph=groups_graph,
-        pos=pos**paga_graph_params,
+        pos=pos,
+        **paga_graph_params,
     )
 
 


### PR DESCRIPTION
The function wasn't working because of a small typo