### PR TITLE
Remove leiden from scanpy optionals

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,11 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - os: ubuntu-latest
+                    - os: ubuntu-22.04
                       python: "3.10"
-                    - os: ubuntu-latest
+                    - os: ubuntu-22.04
                       python: "3.13"
-                    - os: ubuntu-latest
+                    - os: ubuntu-22.04
                       python: "3.13"
                       pip-flags: "--pre"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,11 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - os: ubuntu-22.04
+                    - os: ubuntu-latest
                       python: "3.10"
-                    - os: ubuntu-22.04
+                    - os: ubuntu-latest
                       python: "3.13"
-                    - os: ubuntu-22.04
+                    - os: ubuntu-latest
                       python: "3.13"
                       pip-flags: "--pre"
 

--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -583,8 +583,7 @@ def paga(
     simpler abstracted graph (*PAGA graph*) of partitions, in which edge weights
     represent confidence in the presence of connections. By tresholding this
     confidence in :func:`~ehrapy.pl.paga`, a much simpler representation of the
-    manifold data is obtained, which is nonetheless faithful to the topology of
-    the manifold.
+    manifold data is obtained, which is nonetheless faithful to the topology of the manifold.
     The confidence should be interpreted as the ratio of the actual versus the
     expected value of connections under the null model of randomly connecting
     partitions. We do not provide a p-value as this null model does not

--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -358,16 +358,18 @@ def embedding_density(
 def leiden(
     adata: AnnData,
     resolution: float = 1,
+    *,
     restrict_to: tuple[str, Sequence[str]] | None = None,
     random_state: AnyRandom = 0,
     key_added: str = "leiden",
     adjacency: spmatrix | None = None,
-    directed: bool = True,
+    directed: bool | None = False,
     use_weights: bool = True,
     n_iterations: int = -1,
     partition_type: type[MutableVertexPartition] | None = None,
     neighbors_key: str | None = None,
     obsp: str | None = None,
+    flavor: Literal["leidenalg", "igraph"] = "igraph",
     copy: bool = False,
     **partition_kwargs,
 ) -> AnnData | None:  # pragma: no cover
@@ -401,7 +403,8 @@ def leiden(
                        If not specified, leiden looks .obsp['connectivities'] for connectivities
                        (default storage place for pp.neighbors).
                        If specified, leiden looks .obsp[.uns[neighbors_key]['connectivities_key']] for connectivities.
-        obsp: Use .obsp[obsp] as adjacency. You can't specify both `obsp` and `neighbors_key` at the same time.
+        obsp: Use `.obsp[obsp]` as adjacency. You can't specify both `obsp` and `neighbors_key` at the same time.
+        flavor: Which package's implementation to use.
         copy: Whether to copy `adata` or modify it inplace.
         **partition_kwargs: Any further arguments to pass to `~leidenalg.find_partition`
                             (which in turn passes arguments to the `partition_type`).

--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -430,6 +430,7 @@ def leiden(
         neighbors_key=neighbors_key,
         obsp=obsp,
         copy=copy,
+        flavor=flavor,
         **partition_kwargs,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,6 @@ docs = [
     "sphinx-automodapi",
     "sphinxext-opengraph",
     "pygments",
-    "pyenchant",
     "nbsphinx",
     "nbsphinx-link",
     "ipykernel",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,8 @@ dependencies = [
     "python-dateutil",
     "filelock",
     "numpy>=2.0.0",
-    "numba>=0.60.0"
+    "numba>=0.60.0",
+    "igraph"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "session-info2",
     "lamin_utils",
     "rich",
-    "scanpy[leiden]",
+    "scanpy",
     "requests",
     "pynndescent",
     "miceforest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ dependencies = [
     "rich",
     "scanpy",
     "requests",
-    "pynndescent",
     "miceforest",
     "scikit-misc",  # required for seuratv3 highly variable features
     "lifelines>=0.30.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,8 @@ dependencies = [
     "fknni>=1.2.0",
     "python-dateutil",
     "filelock",
-    "numpy>=2.0.0"
+    "numpy>=2.0.0",
+    "numba>=0.60.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
leidenalg is GPL3 and so would be ehrapy. Need a different set of defaults to make `igraph` happy.