### PR TITLE
typo in the documentation of ehrapy.data.mimic_2_preprocessed

### DIFF
--- a/ehrapy/data/_datasets.py
+++ b/ehrapy/data/_datasets.py
@@ -54,7 +54,7 @@ def mimic_2_preprocessed() -> AnnData:
     The dataset was preprocessed according to: https://github.com/theislab/ehrapy-datasets/tree/main/mimic_2
 
     Returns:
-        :class:`~anndata.AnnData` object of the prprocessed MIMIC-II dataset
+        :class:`~anndata.AnnData` object of the preprocessed MIMIC-II dataset
 
     Examples:
         >>> import ehrapy as ep


### PR DESCRIPTION
typo in the returns field of ehrapy.data.mimic_2_preprocessed documentation
Closes #916 
- line 57 in _datasets: renamed prprocessed into preprocessed