### PR TITLE
Refactor Dask usage pattern

### DIFF
--- a/ehrapy/_settings.py
+++ b/ehrapy/_settings.py
@@ -170,7 +170,7 @@ class EhrapyConfig:  # pragma: no cover
 
     @property
     def autosave(self) -> bool:
-        """Automatically save figures in :attr:`~scanpy._settings.ScanpyConfig.figdir` (default `False`).
+        """Automatically save figures to the default fig dir.
 
         Do not show plots/figures interactively.
         """

--- a/ehrapy/preprocessing/_normalization.py
+++ b/ehrapy/preprocessing/_normalization.py
@@ -6,17 +6,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import sklearn.preprocessing as sklearn_pp
 
-from ehrapy._compat import _raise_array_type_not_implemented
-
-try:
-    import dask.array as da
-    import dask_ml.preprocessing as daskml_pp
-
-    DASK_AVAILABLE = True
-except ImportError:
-    daskml_pp = None
-    DASK_AVAILABLE = False
-
+from ehrapy._compat import DaskArray, _raise_array_type_not_implemented
 from ehrapy.anndata._constants import NUMERIC_TAG
 from ehrapy.anndata.anndata_ext import (
     _assert_numeric_vars,
@@ -82,11 +72,11 @@ def _(arr: np.ndarray, **kwargs):
     return sklearn_pp.StandardScaler(**kwargs).fit_transform
 
 
-if DASK_AVAILABLE:
+@_scale_norm_function.register
+def _(arr: DaskArray, **kwargs):
+    import dask_ml.preprocessing as daskml_pp
 
-    @_scale_norm_function.register
-    def _(arr: da.Array, **kwargs):
-        return daskml_pp.StandardScaler(**kwargs).fit_transform
+    return daskml_pp.StandardScaler(**kwargs).fit_transform
 
 
 def scale_norm(
@@ -139,11 +129,11 @@ def _(arr: np.ndarray, **kwargs):
     return sklearn_pp.MinMaxScaler(**kwargs).fit_transform
 
 
-if DASK_AVAILABLE:
+@_minmax_norm_function.register
+def _(arr: DaskArray, **kwargs):
+    import dask_ml.preprocessing as daskml_pp
 
-    @_minmax_norm_function.register
-    def _(arr: da.Array, **kwargs):
-        return daskml_pp.MinMaxScaler(**kwargs).fit_transform
+    return daskml_pp.MinMaxScaler(**kwargs).fit_transform
 
 
 def minmax_norm(
@@ -245,11 +235,11 @@ def _(arr: np.ndarray, **kwargs):
     return sklearn_pp.RobustScaler(**kwargs).fit_transform
 
 
-if DASK_AVAILABLE:
+@_robust_scale_norm_function.register
+def _(arr: DaskArray, **kwargs):
+    import dask_ml.preprocessing as daskml_pp
 
-    @_robust_scale_norm_function.register
-    def _(arr: da.Array, **kwargs):
-        return daskml_pp.RobustScaler(**kwargs).fit_transform
+    return daskml_pp.RobustScaler(**kwargs).fit_transform
 
 
 def robust_scale_norm(
@@ -304,11 +294,11 @@ def _(arr: np.ndarray, **kwargs):
     return sklearn_pp.QuantileTransformer(**kwargs).fit_transform
 
 
-if DASK_AVAILABLE:
+@_quantile_norm_function.register
+def _(arr: DaskArray, **kwargs):
+    import dask_ml.preprocessing as daskml_pp
 
-    @_quantile_norm_function.register
-    def _(arr: da.Array, **kwargs):
-        return daskml_pp.QuantileTransformer(**kwargs).fit_transform
+    return daskml_pp.QuantileTransformer(**kwargs).fit_transform
 
 
 def quantile_norm(

--- a/ehrapy/preprocessing/_scanpy_pp_api.py
+++ b/ehrapy/preprocessing/_scanpy_pp_api.py
@@ -112,7 +112,7 @@ def regress_out(
     Args:
         adata: :class:`~anndata.AnnData` object containing all observations.
         keys: Keys for observation annotation on which to regress on.
-        n_jobs: Number of jobs for parallel computation. `None` means using :attr:`scanpy._settings.ScanpyConfig.n_jobs`.
+        n_jobs: Number of jobs for parallel computation.
         copy: Determines whether a copy of `adata` is returned.
 
     Returns:

--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -60,7 +60,6 @@ def tsne(
         random_state: Change this to use different intial states for the optimization.
                       If `None`, the initial state is not reproducible.
         n_jobs: Number of jobs for parallel computation.
-                `None` means using :attr:`scanpy._settings.ScanpyConfig.n_jobs`.
         copy: Return a copy instead of writing to `adata`.
         metric: Distance metric to calculate neighbors on.
 
@@ -232,7 +231,6 @@ def draw_graph(
         random_state: For layouts with random initialization like 'fr', change this to use
                       different intial states for the optimization. If `None`, no seed is set.
         n_jobs: Number of jobs for parallel computation.
-                `None` means using :attr:`scanpy._settings.ScanpyConfig.n_jobs`.
         adjacency: Sparse adjacency matrix of the graph, defaults to neighbors connectivities.
         key_added_ext: By default, append `layout`.
         neighbors_key: If not specified, draw_graph looks .obsp['connectivities'] for connectivities

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
     "numpy>=2.0.0",
     "numba>=0.60.0",
     "igraph",
-    "fast-array-utils",
+    "fast-array-utils[sparse,accel]",
     "networkx<3.5", # dowhy breaks - see https://github.com/py-why/dowhy/issues/680#issuecomment-2957189390
     "scipy<=1.15.3", # statsmodel breaks - see https://github.com/statsmodels/statsmodels/issues/9584
 ]

--- a/tests/utils/test_utils_available.py
+++ b/tests/utils/test_utils_available.py
@@ -1,12 +1,4 @@
-from ehrapy._compat import _check_module_importable, _shell_command_accessible
-
-
-def test_check_module_importable_true():
-    assert _check_module_importable("math") is True
-
-
-def test_check_module_importable_false():
-    assert _check_module_importable("nonexistentmodule12345") is False
+from ehrapy._compat import _shell_command_accessible
 
 
 def test_shell_command_accessible_true(monkeypatch):


### PR DESCRIPTION
Fixes https://github.com/theislab/ehrapy/issues/871

- Now using the proper way of registering DaskArrays like scanpy
- Removed some no longer working intersphinx references. They will be replaced by different patterns (numba cores & deprecated figdir) respectively