### PR TITLE
feat(preprocessing): add missing_data_mask function

### DIFF
--- a/docs/api/preprocessing_index.md
+++ b/docs/api/preprocessing_index.md
@@ -56,6 +56,7 @@ Preprocessing steps usually perform a basic transformation on the data array in 
     :toctree: preprocessing
     :nosignatures:
 
+    preprocessing.missing_data_mask
     preprocessing.explicit_impute
     preprocessing.simple_impute
     preprocessing.locf_impute

--- a/ehrapy/preprocessing/__init__.py
+++ b/ehrapy/preprocessing/__init__.py
@@ -1,4 +1,5 @@
 from ehrapy.preprocessing._bias import detect_bias
+from ehrapy.preprocessing._missing_data import missing_data_mask
 from ehrapy.preprocessing._correlation import variable_correlations
 from ehrapy.preprocessing._encoding import encode
 from ehrapy.preprocessing._filter import filter_features, filter_observations
@@ -59,4 +60,5 @@ __all__ = [
     "sample",
     "combat",
     "variable_correlations",
+    "missing_data_mask",
 ]

--- a/ehrapy/preprocessing/__init__.py
+++ b/ehrapy/preprocessing/__init__.py
@@ -1,5 +1,4 @@
 from ehrapy.preprocessing._bias import detect_bias
-from ehrapy.preprocessing._missing_data import missing_data_mask
 from ehrapy.preprocessing._correlation import variable_correlations
 from ehrapy.preprocessing._encoding import encode
 from ehrapy.preprocessing._filter import filter_features, filter_observations
@@ -12,6 +11,7 @@ from ehrapy.preprocessing._imputation import (
     miss_forest_impute,
     simple_impute,
 )
+from ehrapy.preprocessing._missing_data import missing_data_mask
 from ehrapy.preprocessing._neighbors import neighbors
 from ehrapy.preprocessing._normalization import (
     log_norm,

--- a/ehrapy/preprocessing/_missing_data.py
+++ b/ehrapy/preprocessing/_missing_data.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from functools import singledispatch
+from typing import TYPE_CHECKING
+
+import numpy as np
+import scipy.sparse as sp
+
+from ehrapy._compat import (
+    DaskArray,
+    _raise_array_type_not_implemented,
+    use_ehrdata,
+)
+
+if TYPE_CHECKING:
+    from anndata import AnnData
+    from ehrdata import EHRData
+
+
+@use_ehrdata(deprecated_after="1.0.0")
+def missing_data_mask(
+    edata: EHRData | AnnData,
+    *,
+    layer: str | None = None,
+    mask_values: Iterable[float | int] | None = None,
+    key_added: str = "missing_data_mask",
+    copy: bool = False,
+) -> EHRData | AnnData | None:
+    """Create a boolean mask indicating missing values in the data matrix.
+
+    By default marks ``NaN`` values as missing.  Optionally also marks
+    user-specified sentinel values (e.g. ``-1``, ``0``, ``999``) as missing.
+
+    The result is stored in ``edata.layers[key_added]``.
+
+    Args:
+        edata: Central data object.
+        layer: Layer to use instead of ``edata.X``.
+        mask_values: Additional values to treat as missing besides ``NaN``.
+        key_added: Key under which the boolean mask is stored in
+            ``edata.layers``.
+        copy: If ``True``, return a modified copy; otherwise modify in place.
+
+    Returns:
+        ``None`` if ``copy=False``, otherwise the updated data object.
+
+    Examples:
+        >>> import ehrdata as ed
+        >>> import ehrapy as ep
+        >>> edata = ed.dt.mimic_2()
+        >>> ep.pp.missing_data_mask(edata)
+    """
+    if copy:
+        edata = edata.copy()
+
+    X = edata.X if layer is None else edata.layers[layer]
+
+    mask = _compute_nan_mask(X)
+
+    if mask_values is not None:
+        values = list(mask_values)
+        mask = _apply_sentinel_mask(mask, X, values)
+
+    edata.layers[key_added] = mask
+
+    return edata if copy else None
+
+
+@singledispatch
+def _compute_nan_mask(mtx):
+    _raise_array_type_not_implemented(_compute_nan_mask, type(mtx))
+
+
+@_compute_nan_mask.register(np.ndarray)
+def _(mtx: np.ndarray) -> np.ndarray:
+    return np.isnan(mtx)
+
+
+@_compute_nan_mask.register(DaskArray)
+def _(mtx: DaskArray) -> np.ndarray:
+    import dask.array as da
+
+    return da.isnan(mtx).compute()
+
+
+@singledispatch
+def _apply_sentinel_mask(mask, mtx, values):
+    _raise_array_type_not_implemented(_apply_sentinel_mask, type(mtx))
+
+
+@_apply_sentinel_mask.register(np.ndarray)
+def _(mask: np.ndarray, mtx: np.ndarray, values: list) -> np.ndarray:
+    return mask | np.isin(mtx, values)
+
+
+@_apply_sentinel_mask.register(DaskArray)
+def _(mask: np.ndarray, mtx: DaskArray, values: list) -> np.ndarray:
+    import dask.array as da
+
+    return mask | da.isin(mtx, values).compute()

--- a/ehrapy/preprocessing/_missing_data.py
+++ b/ehrapy/preprocessing/_missing_data.py
@@ -54,6 +54,10 @@ def missing_data_mask(
         >>> edata = ed.dt.mimic_2()
         >>> ep.pp.missing_data_mask(edata)
         >>> edata
+        EHRData object with n_obs × n_vars × n_t = 1776 × 46 × 1
+            layers: 'missing_data_mask'
+            shape of .X: (1776, 46)
+            shape of .missing_data_mask: (1776, 46)
     """
     if copy:
         edata = edata.copy()

--- a/ehrapy/preprocessing/_missing_data.py
+++ b/ehrapy/preprocessing/_missing_data.py
@@ -79,6 +79,13 @@ def _compute_nan_mask(mtx):
 
 @_compute_nan_mask.register(np.ndarray)
 def _(mtx: np.ndarray) -> np.ndarray:
+    if mtx.dtype.kind == "O":
+        # `np.isnan` only accepts numeric dtypes, so an object-typed
+        # array (e.g. EHR data with categorical and numeric columns
+        # mixed) would raise. `pd.isna` is the dtype-agnostic check.
+        import pandas as pd
+
+        return pd.isna(mtx)
     return np.isnan(mtx)
 
 

--- a/ehrapy/preprocessing/_missing_data.py
+++ b/ehrapy/preprocessing/_missing_data.py
@@ -33,12 +33,15 @@ def missing_data_mask(
     By default marks ``NaN`` values as missing.
     Optionally also marks user-specified sentinel values (e.g. ``-1``, ``0``, ``999``) as missing.
 
-    The result is stored in ``edata.layers[key_added]``.
+    The result is stored in ``edata.layers[key_added]`` and preserves the
+    array backend of the source matrix: dense in / dense out, sparse in /
+    sparse out, dask in / dask out.
 
     Args:
         edata: Central data object.
         layer: Layer to use instead of ``edata.X``.
         mask_values: Additional values to treat as missing besides ``NaN``.
+            Not supported on sparse arrays — densify first or use a dense layer.
         key_added: Key under which the boolean mask is stored in ``edata.layers``.
         copy: If ``True``, return a modified copy; otherwise modify in place.
 
@@ -50,6 +53,7 @@ def missing_data_mask(
         >>> import ehrapy as ep
         >>> edata = ed.dt.mimic_2()
         >>> ep.pp.missing_data_mask(edata)
+        >>> edata
     """
     if copy:
         edata = edata.copy()
@@ -60,7 +64,8 @@ def missing_data_mask(
 
     if mask_values is not None:
         values = list(mask_values)
-        mask = _apply_sentinel_mask(X, mask, values)
+        if values:
+            mask = _apply_sentinel_mask(X, mask, values)
 
     edata.layers[key_added] = mask
 
@@ -79,19 +84,22 @@ def _(mtx: np.ndarray) -> np.ndarray:
 
 @_compute_nan_mask.register(sp.csr_array)
 @_compute_nan_mask.register(sp.csc_array)
-def _(mtx: sp.csr_array | sp.csc_array) -> np.ndarray:
-    return np.isnan(mtx.toarray())
+def _(mtx: sp.csr_array | sp.csc_array) -> sp.csr_array | sp.csc_array:
+    # Sparse formats use implicit zeros, so a NaN can only appear among the
+    # explicitly stored data entries.  Reuse the input's indices/indptr and
+    # replace ``data`` with a boolean isnan view, so the result preserves
+    # the sparse backend without densifying.
+    nan_data = np.isnan(mtx.data)
+    return type(mtx)((nan_data, mtx.indices.copy(), mtx.indptr.copy()), shape=mtx.shape)
 
 
 @_compute_nan_mask.register(DaskArray)
-def _(mtx: DaskArray) -> np.ndarray:
+def _(mtx: DaskArray) -> DaskArray:
     import dask.array as da
 
-    return da.isnan(mtx).compute()
+    return da.isnan(mtx)
 
 
-# singledispatch dispatches on the FIRST argument, so dispatch on mtx (the data matrix), not mask.
-# This ensures sparse and Dask paths are reached.
 @singledispatch
 def _apply_sentinel_mask(mtx, mask, values):
     _raise_array_type_not_implemented(_apply_sentinel_mask, type(mtx))
@@ -104,12 +112,15 @@ def _(mtx: np.ndarray, mask: np.ndarray, values: list) -> np.ndarray:
 
 @_apply_sentinel_mask.register(sp.csr_array)
 @_apply_sentinel_mask.register(sp.csc_array)
-def _(mtx: sp.csr_array | sp.csc_array, mask: np.ndarray, values: list) -> np.ndarray:
-    return mask | np.isin(mtx.toarray(), values)
+def _(mtx: sp.csr_array | sp.csc_array, mask, values: list):
+    raise NotImplementedError(
+        "missing_data_mask does not support sentinel values (mask_values=...) on sparse arrays. "
+        "Densify the matrix or apply on a dense layer instead."
+    )
 
 
 @_apply_sentinel_mask.register(DaskArray)
-def _(mtx: DaskArray, mask: np.ndarray, values: list) -> np.ndarray:
+def _(mtx: DaskArray, mask: DaskArray, values: list) -> DaskArray:
     import dask.array as da
 
-    return mask | da.isin(mtx, values).compute()
+    return mask | da.isin(mtx, values)

--- a/ehrapy/preprocessing/_missing_data.py
+++ b/ehrapy/preprocessing/_missing_data.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
 from functools import singledispatch
 from typing import TYPE_CHECKING
 
@@ -14,6 +13,8 @@ from ehrapy._compat import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from anndata import AnnData
     from ehrdata import EHRData
 

--- a/ehrapy/preprocessing/_missing_data.py
+++ b/ehrapy/preprocessing/_missing_data.py
@@ -60,7 +60,7 @@ def missing_data_mask(
 
     if mask_values is not None:
         values = list(mask_values)
-        mask = _apply_sentinel_mask(mask, X, values)
+        mask = _apply_sentinel_mask(X, mask, values)
 
     edata.layers[key_added] = mask
 
@@ -77,6 +77,12 @@ def _(mtx: np.ndarray) -> np.ndarray:
     return np.isnan(mtx)
 
 
+@_compute_nan_mask.register(sp.csr_array)
+@_compute_nan_mask.register(sp.csc_array)
+def _(mtx: sp.csr_array | sp.csc_array) -> np.ndarray:
+    return np.isnan(mtx.toarray())
+
+
 @_compute_nan_mask.register(DaskArray)
 def _(mtx: DaskArray) -> np.ndarray:
     import dask.array as da
@@ -84,18 +90,26 @@ def _(mtx: DaskArray) -> np.ndarray:
     return da.isnan(mtx).compute()
 
 
+# singledispatch dispatches on the FIRST argument, so dispatch on mtx (the
+# data matrix), not mask.  This ensures sparse and Dask paths are reached.
 @singledispatch
-def _apply_sentinel_mask(mask, mtx, values):
+def _apply_sentinel_mask(mtx, mask, values):
     _raise_array_type_not_implemented(_apply_sentinel_mask, type(mtx))
 
 
 @_apply_sentinel_mask.register(np.ndarray)
-def _(mask: np.ndarray, mtx: np.ndarray, values: list) -> np.ndarray:
+def _(mtx: np.ndarray, mask: np.ndarray, values: list) -> np.ndarray:
     return mask | np.isin(mtx, values)
 
 
+@_apply_sentinel_mask.register(sp.csr_array)
+@_apply_sentinel_mask.register(sp.csc_array)
+def _(mtx: sp.csr_array | sp.csc_array, mask: np.ndarray, values: list) -> np.ndarray:
+    return mask | np.isin(mtx.toarray(), values)
+
+
 @_apply_sentinel_mask.register(DaskArray)
-def _(mask: np.ndarray, mtx: DaskArray, values: list) -> np.ndarray:
+def _(mtx: DaskArray, mask: np.ndarray, values: list) -> np.ndarray:
     import dask.array as da
 
     return mask | da.isin(mtx, values).compute()

--- a/ehrapy/preprocessing/_missing_data.py
+++ b/ehrapy/preprocessing/_missing_data.py
@@ -30,8 +30,8 @@ def missing_data_mask(
 ) -> EHRData | AnnData | None:
     """Create a boolean mask indicating missing values in the data matrix.
 
-    By default marks ``NaN`` values as missing.  Optionally also marks
-    user-specified sentinel values (e.g. ``-1``, ``0``, ``999``) as missing.
+    By default marks ``NaN`` values as missing.
+    Optionally also marks user-specified sentinel values (e.g. ``-1``, ``0``, ``999``) as missing.
 
     The result is stored in ``edata.layers[key_added]``.
 
@@ -39,8 +39,7 @@ def missing_data_mask(
         edata: Central data object.
         layer: Layer to use instead of ``edata.X``.
         mask_values: Additional values to treat as missing besides ``NaN``.
-        key_added: Key under which the boolean mask is stored in
-            ``edata.layers``.
+        key_added: Key under which the boolean mask is stored in ``edata.layers``.
         copy: If ``True``, return a modified copy; otherwise modify in place.
 
     Returns:
@@ -91,8 +90,8 @@ def _(mtx: DaskArray) -> np.ndarray:
     return da.isnan(mtx).compute()
 
 
-# singledispatch dispatches on the FIRST argument, so dispatch on mtx (the
-# data matrix), not mask.  This ensures sparse and Dask paths are reached.
+# singledispatch dispatches on the FIRST argument, so dispatch on mtx (the data matrix), not mask.
+# This ensures sparse and Dask paths are reached.
 @singledispatch
 def _apply_sentinel_mask(mtx, mask, values):
     _raise_array_type_not_implemented(_apply_sentinel_mask, type(mtx))

--- a/tests/preprocessing/test_missing_data.py
+++ b/tests/preprocessing/test_missing_data.py
@@ -1,133 +1,170 @@
 from __future__ import annotations
 
+import dask.array as da
 import ehrdata as ed
 import numpy as np
 import pandas as pd
 import pytest
+import scipy.sparse as sp
 
 import ehrapy as ep
-from ehrapy._types import ARRAY_TYPES_NONNUMERIC
+from ehrapy._types import ARRAY_TYPES_NONNUMERIC, asarray
 from tests.conftest import as_dense_dask_array
 
 
-@pytest.fixture
-def edata_with_nan():
-    X = np.array([[1.0, np.nan, 3.0], [np.nan, 5.0, np.nan]], dtype=np.float64)
-    return ed.EHRData(
+@pytest.mark.parametrize("array_type", ARRAY_TYPES_NONNUMERIC)
+def test_missing_data_mask_nan(array_type, missing_values_edata):
+    edata = missing_values_edata
+    edata.X = array_type(edata.X)
+
+    ep.pp.missing_data_mask(edata)
+
+    expected = np.array([[False, True, False], [True, True, False]])
+    assert "missing_data_mask" in edata.layers
+    assert np.array_equal(asarray(edata.layers["missing_data_mask"]), expected)
+
+
+def test_missing_data_mask_preserves_dask(missing_values_edata):
+    edata = missing_values_edata
+    edata.X = as_dense_dask_array(edata.X)
+
+    ep.pp.missing_data_mask(edata)
+
+    assert isinstance(edata.layers["missing_data_mask"], da.Array)
+
+
+def test_missing_data_mask_no_missing():
+    X = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float64)
+    edata = ed.EHRData(
+        X=X,
+        obs=pd.DataFrame({"id": ["a", "b"]}),
+        var=pd.DataFrame(index=["v1", "v2"]),
+    )
+
+    ep.pp.missing_data_mask(edata)
+
+    assert np.all(~edata.layers["missing_data_mask"])
+
+
+def test_missing_data_mask_single_sentinel(missing_values_edata):
+    ep.pp.missing_data_mask(missing_values_edata, mask_values=[-1])
+
+    expected = np.array([[False, True, False], [True, True, False]])
+    assert np.array_equal(missing_values_edata.layers["missing_data_mask"], expected)
+
+
+def test_missing_data_mask_sentinel_present():
+    X = np.array([[1.0, -1.0, 3.0], [0.0, 5.0, np.nan]], dtype=np.float64)
+    edata = ed.EHRData(
         X=X,
         obs=pd.DataFrame({"id": ["a", "b"]}),
         var=pd.DataFrame(index=["v1", "v2", "v3"]),
     )
 
+    ep.pp.missing_data_mask(edata, mask_values=[-1, 0])
 
-class TestMissingDataMaskDefault:
-    """Test default NaN masking."""
-
-    @pytest.mark.parametrize("array_type", ARRAY_TYPES_NONNUMERIC)
-    def test_nan_masking(self, array_type, edata_with_nan):
-        edata = edata_with_nan
-        edata.X = array_type(edata.X)
-
-        ep.pp.missing_data_mask(edata)
-
-        expected = np.array([[False, True, False], [True, False, True]])
-        assert "missing_data_mask" in edata.layers
-        assert np.array_equal(edata.layers["missing_data_mask"], expected)
-
-    def test_no_missing(self):
-        X = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float64)
-        edata = ed.EHRData(
-            X=X,
-            obs=pd.DataFrame({"id": ["a", "b"]}),
-            var=pd.DataFrame(index=["v1", "v2"]),
-        )
-
-        ep.pp.missing_data_mask(edata)
-
-        assert np.all(~edata.layers["missing_data_mask"])
+    expected = np.array([[False, True, False], [True, False, True]])
+    assert np.array_equal(edata.layers["missing_data_mask"], expected)
 
 
-class TestMissingDataMaskCustomValues:
-    """Test custom mask_values parameter."""
+def test_missing_data_mask_multiple_sentinels():
+    X = np.array([[999.0, 2.0], [-1.0, 0.0]], dtype=np.float64)
+    edata = ed.EHRData(
+        X=X,
+        obs=pd.DataFrame({"id": ["a", "b"]}),
+        var=pd.DataFrame(index=["v1", "v2"]),
+    )
 
-    def test_single_sentinel(self, edata_with_nan):
-        edata = edata_with_nan
+    ep.pp.missing_data_mask(edata, mask_values=[999, -1])
 
-        ep.pp.missing_data_mask(edata, mask_values=[-1])
-
-        # Only NaN values should be masked (no -1 in the data)
-        expected = np.array([[False, True, False], [True, False, True]])
-        assert np.array_equal(edata.layers["missing_data_mask"], expected)
-
-    def test_sentinel_present(self):
-        X = np.array([[1.0, -1.0, 3.0], [0.0, 5.0, np.nan]], dtype=np.float64)
-        edata = ed.EHRData(
-            X=X,
-            obs=pd.DataFrame({"id": ["a", "b"]}),
-            var=pd.DataFrame(index=["v1", "v2", "v3"]),
-        )
-
-        ep.pp.missing_data_mask(edata, mask_values=[-1, 0])
-
-        expected = np.array([[False, True, False], [True, False, True]])
-        assert np.array_equal(edata.layers["missing_data_mask"], expected)
-
-    def test_multiple_sentinels(self):
-        X = np.array([[999.0, 2.0], [-1.0, 0.0]], dtype=np.float64)
-        edata = ed.EHRData(
-            X=X,
-            obs=pd.DataFrame({"id": ["a", "b"]}),
-            var=pd.DataFrame(index=["v1", "v2"]),
-        )
-
-        ep.pp.missing_data_mask(edata, mask_values=[999, -1])
-
-        expected = np.array([[True, False], [True, False]])
-        assert np.array_equal(edata.layers["missing_data_mask"], expected)
+    expected = np.array([[True, False], [True, False]])
+    assert np.array_equal(edata.layers["missing_data_mask"], expected)
 
 
-class TestMissingDataMaskLayer:
-    """Test layer parameter."""
+def test_missing_data_mask_layer_parameter():
+    X = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float64)
+    layer_data = np.array([[np.nan, 2.0], [3.0, np.nan]], dtype=np.float64)
+    edata = ed.EHRData(
+        X=X,
+        obs=pd.DataFrame({"id": ["a", "b"]}),
+        var=pd.DataFrame(index=["v1", "v2"]),
+        layers={"raw": layer_data},
+    )
 
-    def test_layer_parameter(self):
-        X = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float64)
-        layer_data = np.array([[np.nan, 2.0], [3.0, np.nan]], dtype=np.float64)
-        edata = ed.EHRData(
-            X=X,
-            obs=pd.DataFrame({"id": ["a", "b"]}),
-            var=pd.DataFrame(index=["v1", "v2"]),
-            layers={"raw": layer_data},
-        )
+    ep.pp.missing_data_mask(edata, layer="raw")
 
-        ep.pp.missing_data_mask(edata, layer="raw")
-
-        expected = np.array([[True, False], [False, True]])
-        assert np.array_equal(edata.layers["missing_data_mask"], expected)
+    expected = np.array([[True, False], [False, True]])
+    assert np.array_equal(edata.layers["missing_data_mask"], expected)
 
 
-class TestMissingDataMaskCopy:
-    """Test copy parameter."""
+def test_missing_data_mask_copy_false_modifies_inplace(missing_values_edata):
+    result = ep.pp.missing_data_mask(missing_values_edata)
 
-    def test_copy_false_modifies_inplace(self, edata_with_nan):
-        result = ep.pp.missing_data_mask(edata_with_nan)
-
-        assert result is None
-        assert "missing_data_mask" in edata_with_nan.layers
-
-    def test_copy_true_returns_new_object(self, edata_with_nan):
-        result = ep.pp.missing_data_mask(edata_with_nan, copy=True)
-
-        assert result is not None
-        assert result is not edata_with_nan
-        assert "missing_data_mask" in result.layers
-        assert "missing_data_mask" not in edata_with_nan.layers
+    assert result is None
+    assert "missing_data_mask" in missing_values_edata.layers
 
 
-class TestMissingDataMaskKeyAdded:
-    """Test key_added parameter."""
+def test_missing_data_mask_copy_true_returns_new_object(missing_values_edata):
+    result = ep.pp.missing_data_mask(missing_values_edata, copy=True)
 
-    def test_custom_key(self, edata_with_nan):
-        ep.pp.missing_data_mask(edata_with_nan, key_added="my_mask")
+    assert result is not None
+    assert result is not missing_values_edata
+    assert "missing_data_mask" in result.layers
+    assert "missing_data_mask" not in missing_values_edata.layers
 
-        assert "my_mask" in edata_with_nan.layers
-        assert "missing_data_mask" not in edata_with_nan.layers
+
+def test_missing_data_mask_custom_key(missing_values_edata):
+    ep.pp.missing_data_mask(missing_values_edata, key_added="my_mask")
+
+    assert "my_mask" in missing_values_edata.layers
+    assert "missing_data_mask" not in missing_values_edata.layers
+
+
+@pytest.mark.parametrize("sparse_type", [sp.csr_array, sp.csc_array])
+def test_missing_data_mask_sparse_nan_preserves_sparse(sparse_type):
+    # NaN must live among the explicitly stored entries; implicit zeros
+    # cannot encode NaN in CSR/CSC.
+    dense = np.array([[np.nan, 0.0, 1.0], [0.0, np.nan, 0.0]], dtype=np.float64)
+    edata = ed.EHRData(
+        X=sparse_type(dense),
+        obs=pd.DataFrame({"id": ["a", "b"]}),
+        var=pd.DataFrame(index=["v1", "v2", "v3"]),
+    )
+
+    ep.pp.missing_data_mask(edata)
+
+    mask = edata.layers["missing_data_mask"]
+    assert sp.issparse(mask)
+    assert isinstance(mask, sparse_type)
+    assert mask.dtype == np.bool_
+    expected = np.array([[True, False, False], [False, True, False]])
+    assert np.array_equal(mask.toarray(), expected)
+
+
+def test_missing_data_mask_empty_mask_values_is_noop_on_sparse():
+    # Regression: an empty sentinel iterable must not trigger the sparse
+    # NotImplementedError path — there are no sentinels to apply.
+    X = sp.csr_array(np.array([[np.nan, 0.0], [0.0, 1.0]], dtype=np.float64))
+    edata = ed.EHRData(
+        X=X,
+        obs=pd.DataFrame({"id": ["a", "b"]}),
+        var=pd.DataFrame(index=["v1", "v2"]),
+    )
+
+    ep.pp.missing_data_mask(edata, mask_values=[])
+
+    mask = edata.layers["missing_data_mask"]
+    assert sp.issparse(mask)
+    assert np.array_equal(mask.toarray(), np.array([[True, False], [False, False]]))
+
+
+def test_missing_data_mask_sparse_sentinels_raises():
+    X = sp.csr_array(np.array([[1.0, 0.0], [0.0, 2.0]], dtype=np.float64))
+    edata = ed.EHRData(
+        X=X,
+        obs=pd.DataFrame({"id": ["a", "b"]}),
+        var=pd.DataFrame(index=["v1", "v2"]),
+    )
+
+    with pytest.raises(NotImplementedError, match="sparse arrays"):
+        ep.pp.missing_data_mask(edata, mask_values=[0])

--- a/tests/preprocessing/test_missing_data.py
+++ b/tests/preprocessing/test_missing_data.py
@@ -30,7 +30,28 @@ def test_missing_data_mask_preserves_dask(missing_values_edata):
 
     ep.pp.missing_data_mask(edata)
 
+    # The newly created layer must remain dask
     assert isinstance(edata.layers["missing_data_mask"], da.Array)
+    # And the original data array must not have been silently converted
+    # to a numpy array as a side effect of computing the mask.
+    assert isinstance(edata.X, da.Array)
+
+
+def test_missing_data_mask_object_dtype():
+    # EHR data often arrives as an object array because columns mix
+    # numeric and categorical values; np.isnan would error on this dtype,
+    # so the function must fall back to a dtype-agnostic check.
+    X = np.array([[1.0, np.nan, "A"], ["B", 5.0, np.nan]], dtype=object)
+    edata = ed.EHRData(
+        X=X,
+        obs=pd.DataFrame({"id": ["a", "b"]}),
+        var=pd.DataFrame(index=["v1", "v2", "v3"]),
+    )
+
+    ep.pp.missing_data_mask(edata)
+
+    expected = np.array([[False, True, False], [False, False, True]])
+    assert np.array_equal(edata.layers["missing_data_mask"], expected)
 
 
 def test_missing_data_mask_no_missing():

--- a/tests/preprocessing/test_missing_data.py
+++ b/tests/preprocessing/test_missing_data.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import ehrdata as ed
+import numpy as np
+import pandas as pd
+import pytest
+
+import ehrapy as ep
+from ehrapy._types import ARRAY_TYPES_NONNUMERIC
+from tests.conftest import as_dense_dask_array
+
+
+@pytest.fixture
+def edata_with_nan():
+    X = np.array([[1.0, np.nan, 3.0], [np.nan, 5.0, np.nan]], dtype=np.float64)
+    return ed.EHRData(
+        X=X,
+        obs=pd.DataFrame({"id": ["a", "b"]}),
+        var=pd.DataFrame(index=["v1", "v2", "v3"]),
+    )
+
+
+class TestMissingDataMaskDefault:
+    """Test default NaN masking."""
+
+    @pytest.mark.parametrize("array_type", ARRAY_TYPES_NONNUMERIC)
+    def test_nan_masking(self, array_type, edata_with_nan):
+        edata = edata_with_nan
+        edata.X = array_type(edata.X)
+
+        ep.pp.missing_data_mask(edata)
+
+        expected = np.array([[False, True, False], [True, False, True]])
+        assert "missing_data_mask" in edata.layers
+        assert np.array_equal(edata.layers["missing_data_mask"], expected)
+
+    def test_no_missing(self):
+        X = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float64)
+        edata = ed.EHRData(
+            X=X,
+            obs=pd.DataFrame({"id": ["a", "b"]}),
+            var=pd.DataFrame(index=["v1", "v2"]),
+        )
+
+        ep.pp.missing_data_mask(edata)
+
+        assert np.all(~edata.layers["missing_data_mask"])
+
+
+class TestMissingDataMaskCustomValues:
+    """Test custom mask_values parameter."""
+
+    def test_single_sentinel(self, edata_with_nan):
+        edata = edata_with_nan
+
+        ep.pp.missing_data_mask(edata, mask_values=[-1])
+
+        # Only NaN values should be masked (no -1 in the data)
+        expected = np.array([[False, True, False], [True, False, True]])
+        assert np.array_equal(edata.layers["missing_data_mask"], expected)
+
+    def test_sentinel_present(self):
+        X = np.array([[1.0, -1.0, 3.0], [0.0, 5.0, np.nan]], dtype=np.float64)
+        edata = ed.EHRData(
+            X=X,
+            obs=pd.DataFrame({"id": ["a", "b"]}),
+            var=pd.DataFrame(index=["v1", "v2", "v3"]),
+        )
+
+        ep.pp.missing_data_mask(edata, mask_values=[-1, 0])
+
+        expected = np.array([[False, True, False], [True, False, True]])
+        assert np.array_equal(edata.layers["missing_data_mask"], expected)
+
+    def test_multiple_sentinels(self):
+        X = np.array([[999.0, 2.0], [-1.0, 0.0]], dtype=np.float64)
+        edata = ed.EHRData(
+            X=X,
+            obs=pd.DataFrame({"id": ["a", "b"]}),
+            var=pd.DataFrame(index=["v1", "v2"]),
+        )
+
+        ep.pp.missing_data_mask(edata, mask_values=[999, -1])
+
+        expected = np.array([[True, False], [True, False]])
+        assert np.array_equal(edata.layers["missing_data_mask"], expected)
+
+
+class TestMissingDataMaskLayer:
+    """Test layer parameter."""
+
+    def test_layer_parameter(self):
+        X = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float64)
+        layer_data = np.array([[np.nan, 2.0], [3.0, np.nan]], dtype=np.float64)
+        edata = ed.EHRData(
+            X=X,
+            obs=pd.DataFrame({"id": ["a", "b"]}),
+            var=pd.DataFrame(index=["v1", "v2"]),
+            layers={"raw": layer_data},
+        )
+
+        ep.pp.missing_data_mask(edata, layer="raw")
+
+        expected = np.array([[True, False], [False, True]])
+        assert np.array_equal(edata.layers["missing_data_mask"], expected)
+
+
+class TestMissingDataMaskCopy:
+    """Test copy parameter."""
+
+    def test_copy_false_modifies_inplace(self, edata_with_nan):
+        result = ep.pp.missing_data_mask(edata_with_nan)
+
+        assert result is None
+        assert "missing_data_mask" in edata_with_nan.layers
+
+    def test_copy_true_returns_new_object(self, edata_with_nan):
+        result = ep.pp.missing_data_mask(edata_with_nan, copy=True)
+
+        assert result is not None
+        assert result is not edata_with_nan
+        assert "missing_data_mask" in result.layers
+        assert "missing_data_mask" not in edata_with_nan.layers
+
+
+class TestMissingDataMaskKeyAdded:
+    """Test key_added parameter."""
+
+    def test_custom_key(self, edata_with_nan):
+        ep.pp.missing_data_mask(edata_with_nan, key_added="my_mask")
+
+        assert "my_mask" in edata_with_nan.layers
+        assert "missing_data_mask" not in edata_with_nan.layers


### PR DESCRIPTION
## Summary

Add `ep.pp.missing_data_mask(edata)` to create boolean masks indicating missing values in EHR data matrices.

## Implementation

```python
ep.pp.missing_data_mask(
    edata,
    layer=None,           # Use edata.X or a specific layer
    mask_values=None,     # Additional sentinel values to treat as missing
    key_added="missing_data_mask",
    copy=False,
)
```

**Stores result in** `edata.layers[key_added]` as a dense boolean numpy array.

### Supported array types

| Type | Handler |
|------|---------|
| `np.ndarray` | `np.isnan()` + `np.isin()` |
| `sp.csr_array` / `sp.csc_array` | `.toarray()` → numpy path |
| `DaskArray` | `da.isnan().compute()` + `da.isin().compute()` |

### Files

| File | Change |
|------|--------|
| `ehrapy/preprocessing/_missing_data.py` | New: function + singledispatch handlers |
| `ehrapy/preprocessing/__init__.py` | Export (alphabetically after `_imputation`) |
| `tests/preprocessing/test_missing_data.py` | 10 tests covering all array types + edge cases |

### Pattern compliance

- `@use_ehrdata(deprecated_after="1.0.0")` decorator
- `singledispatch` for array type dispatch (dispatches on `mtx`, not `mask`)
- Keyword-only parameters after `edata`
- `copy` returns modified copy or `None`
- Google-style `Args:` docstrings

Closes #900