### PR TITLE
Add 3D support to `miss_forest_impute`

### DIFF
--- a/ehrapy/preprocessing/_imputation.py
+++ b/ehrapy/preprocessing/_imputation.py
@@ -444,6 +444,42 @@ def _knn_impute(
             edata.layers[layer][:, imputer_data_indices] = X_imputed
 
 
+@singledispatch
+def _miss_forest_impute_function(arr, num_initial_strategy, n_estimators, max_iter, random_state):
+    _raise_array_type_not_implemented(_miss_forest_impute_function, type(arr))
+
+
+@_miss_forest_impute_function.register(DaskArray)
+def _(arr: DaskArray, num_initial_strategy, n_estimators, max_iter, random_state):
+    _raise_array_type_not_implemented(_miss_forest_impute_function, type(arr))
+
+
+@_miss_forest_impute_function.register(sp.coo_array)
+def _(arr: sp.coo_array, num_initial_strategy, n_estimators, max_iter, random_state):
+    _raise_array_type_not_implemented(_miss_forest_impute_function, type(arr))
+
+
+@_miss_forest_impute_function.register(np.ndarray)
+@_miss_forest_impute_function.register(sp.csr_array)
+@_miss_forest_impute_function.register(sp.csc_array)
+@_apply_over_time_axis
+def _(arr: np.ndarray, num_initial_strategy, n_estimators, max_iter, random_state):
+
+    if set(range(arr.shape[1])).issubset(_get_non_numerical_column_indices(arr)):
+        raise ValueError(
+            "Can only impute numerical data. Try to restrict imputation to certain columns using var_names parameter."
+        )
+    from sklearn.ensemble import ExtraTreesRegressor
+    from sklearn.impute import IterativeImputer
+
+    return IterativeImputer(
+        estimator=ExtraTreesRegressor(n_estimators=n_estimators, n_jobs=settings.n_jobs),
+        initial_strategy=num_initial_strategy,
+        max_iter=max_iter,
+        random_state=random_state,
+    ).fit_transform(arr)
+
+
 @use_ehrdata(deprecated_after="1.0.0")
 @spinner("Performing miss-forest impute")
 def miss_forest_impute(
@@ -464,6 +500,9 @@ def miss_forest_impute(
     The strategy works by fitting a random forest model on each feature containing missing values,
     and using the trained model to predict the missing values.
 
+    For 2D data, if layer is `None`, `edata.X` is used directly.
+    For 3D data, the layer is flattened along axis 0 before imputation and reshaped back to 3D afterwards.
+
     See https://academic.oup.com/bioinformatics/article/28/1/112/219101.
 
     If required, the data needs to be properly encoded as this imputation requires numerical data only.
@@ -477,7 +516,7 @@ def miss_forest_impute(
                       Decrease for faster computations.
         random_state: The random seed for the initialization.
         warning_threshold: Threshold of percentage of missing values to display a warning for.
-        layer: The layer to impute.
+        layer: The layer to impute. Required when input data is 3D.
         copy: Whether to return a copy or act in place.
 
     Returns:
@@ -509,16 +548,11 @@ def miss_forest_impute(
 
         patch_sklearn()
 
-    from sklearn.ensemble import ExtraTreesRegressor, RandomForestClassifier
+    from sklearn.ensemble import RandomForestClassifier
     from sklearn.impute import IterativeImputer
 
     try:
-        imp_num = IterativeImputer(
-            estimator=ExtraTreesRegressor(n_estimators=n_estimators, n_jobs=settings.n_jobs),
-            initial_strategy=num_initial_strategy,
-            max_iter=max_iter,
-            random_state=random_state,
-        )
+        # not sure if this should be kept?
         # initial strategy here will not be parametrized since only most_frequent will be applied to non numerical data
         IterativeImputer(
             estimator=RandomForestClassifier(n_estimators=n_estimators, n_jobs=settings.n_jobs),
@@ -533,43 +567,24 @@ def miss_forest_impute(
 
         mtx = edata.X if layer is None else edata.layers[layer]
         input_dtype = mtx.dtype if np.issubdtype(mtx.dtype, np.floating) else np.float64
-        var_indices_original = var_indices
 
-        is_3d = False
         if mtx.ndim == 3:
-            is_3d = True
-            n_obs, n_vars, n_t = mtx.shape
-            mtx = (
-                mtx[:, var_indices, :]
-                .astype(input_dtype, copy=True)
-                .transpose(0, 2, 1)
-                .reshape(n_obs * n_t, len(var_indices))
-            )
-            numerical_indices = list(range(len(var_indices)))
-            var_indices = numerical_indices
-
-        if set(var_indices).issubset(_get_non_numerical_column_indices(mtx)):
-            raise ValueError(
-                "Can only impute numerical data. Try to restrict imputation to certain columns using "
-                "var_names parameter."
-            )
+            mtx_slice = mtx[:, var_indices, :].astype(input_dtype, copy=True)
+        else:
+            mtx_slice = mtx[:, var_indices].astype(input_dtype, copy=True)
 
         # this step is the most expensive one and might extremely slow down the impute process
         if var_indices:
-            imputer_x = mtx[:, var_indices]
-            X_imputed = imp_num.fit_transform(imputer_x)
-            if is_3d:
-                X_imputed = (
-                    X_imputed[:, : len(var_indices_original)]
-                    .reshape(n_obs, n_t, len(var_indices_original))
-                    .transpose(0, 2, 1)
-                )
-                edata.layers[layer][:, var_indices_original, :] = X_imputed
+            X_imputed = _miss_forest_impute_function(
+                mtx_slice, num_initial_strategy, n_estimators, max_iter, random_state
+            )
+            if mtx.ndim == 3:
+                edata.layers[layer][:, var_indices, :] = X_imputed
             else:
                 if layer is None:
-                    edata.X[::, var_indices] = X_imputed
+                    edata.X[:, var_indices] = X_imputed
                 else:
-                    edata.layers[layer][::, var_indices] = X_imputed
+                    edata.layers[layer][:, var_indices] = X_imputed
         else:
             raise ValueError("Cannot find any feature to perform imputation")
 

--- a/ehrapy/preprocessing/_imputation.py
+++ b/ehrapy/preprocessing/_imputation.py
@@ -459,9 +459,13 @@ def _(arr: sp.coo_array, num_initial_strategy, n_estimators, max_iter, random_st
     _raise_array_type_not_implemented(_miss_forest_impute_function, type(arr))
 
 
-@_miss_forest_impute_function.register(np.ndarray)
 @_miss_forest_impute_function.register(sp.csr_array)
 @_miss_forest_impute_function.register(sp.csc_array)
+def _(arr: sp.csr_array | sp.csc_array, num_initial_strategy, n_estimators, max_iter, random_state):
+    _raise_array_type_not_implemented(_miss_forest_impute_function, type(arr))
+
+
+@_miss_forest_impute_function.register(np.ndarray)
 @_apply_over_time_axis
 def _(arr: np.ndarray, num_initial_strategy, n_estimators, max_iter, random_state):
 
@@ -506,9 +510,7 @@ def miss_forest_impute(
     See https://academic.oup.com/bioinformatics/article/28/1/112/219101.
 
     If required, the data needs to be properly encoded as this imputation requires numerical data only.
-    If the data is stored as sparse arrays (:class:`scipy.sparse.csr_array`, :class:`scipy.sparse.csc_array`), 
-    they will be converted to dense internally during imputation.
-    
+
     Args:
         edata: Central data object.
         var_names: Iterable of columns to impute
@@ -562,13 +564,14 @@ def miss_forest_impute(
         patch_sklearn()
 
     try:
-
         if var_names is None:
             var_names = edata.var_names
         var_indices = edata.var_names.get_indexer(var_names).tolist()
 
         mtx = edata.X if layer is None else edata.layers[layer]
-        input_dtype = mtx.dtype if np.issubdtype(mtx.dtype, np.floating) else np.float64 #ensure floating point dtype before imputation, e.g. in case input layer dtype=object
+        input_dtype = (
+            mtx.dtype if np.issubdtype(mtx.dtype, np.floating) else np.float64
+        )  # ensure floating point dtype before imputation, e.g. in case input layer dtype=object
 
         if mtx.ndim == 3:
             mtx_slice = mtx[:, var_indices, :].astype(input_dtype, copy=True)

--- a/ehrapy/preprocessing/_imputation.py
+++ b/ehrapy/preprocessing/_imputation.py
@@ -526,9 +526,20 @@ def miss_forest_impute(
     Examples:
         >>> import ehrdata as ed
         >>> import ehrapy as ep
-        >>> edata = ed.dt.mimic_2()
-        >>> edata = ep.pp.encode(edata, autodetect=True)
-        >>> ep.pp.miss_forest_impute(edata)
+        >>> edata_3d = ed.dt.ehrdata_blobs(n_variables=3, n_observations=3, base_timepoints=2, missing_values=0.3)
+        >>> edata_imputed = ep.pp.knn_impute(edata_3d, layer="tem_data", copy=True)
+
+        Example Output:
+
+        >>> edata_3d.layers["tem_data"][0, :, :]
+        [[-12.12732884, -18.37304373],
+        [         nan,  -0.91339411],
+        [         nan,  -7.88514984]]
+        >>> edata_imputed.layers["tem_data"][0, :, :]
+        [[-12.12732884, -18.37304373],
+        [ -0.3278448 ,  -0.91339411],
+        [ -4.39722201,  -7.88514984]]
+
     """
     if copy:
         edata = edata.copy()

--- a/ehrapy/preprocessing/_imputation.py
+++ b/ehrapy/preprocessing/_imputation.py
@@ -449,22 +449,6 @@ def _miss_forest_impute_function(arr, num_initial_strategy, n_estimators, max_it
     _raise_array_type_not_implemented(_miss_forest_impute_function, type(arr))
 
 
-@_miss_forest_impute_function.register(DaskArray)
-def _(arr: DaskArray, num_initial_strategy, n_estimators, max_iter, random_state):
-    _raise_array_type_not_implemented(_miss_forest_impute_function, type(arr))
-
-
-@_miss_forest_impute_function.register(sp.coo_array)
-def _(arr: sp.coo_array, num_initial_strategy, n_estimators, max_iter, random_state):
-    _raise_array_type_not_implemented(_miss_forest_impute_function, type(arr))
-
-
-@_miss_forest_impute_function.register(sp.csr_array)
-@_miss_forest_impute_function.register(sp.csc_array)
-def _(arr: sp.csr_array | sp.csc_array, num_initial_strategy, n_estimators, max_iter, random_state):
-    _raise_array_type_not_implemented(_miss_forest_impute_function, type(arr))
-
-
 @_miss_forest_impute_function.register(np.ndarray)
 @_apply_over_time_axis
 def _(arr: np.ndarray, num_initial_strategy, n_estimators, max_iter, random_state):
@@ -530,12 +514,12 @@ def miss_forest_impute(
     Examples:
         >>> import ehrdata as ed
         >>> import ehrapy as ep
-        >>> edata_3d = ed.dt.ehrdata_blobs(n_variables=3, n_observations=3, base_timepoints=2, missing_values=0.3)
-        >>> edata_imputed = ep.pp.knn_impute(edata_3d, layer="tem_data", copy=True)
+        >>> edata = ed.dt.ehrdata_blobs(n_variables=3, n_observations=3, base_timepoints=2, missing_values=0.3)
+        >>> edata_imputed = ep.pp.knn_impute(edata, layer="tem_data", copy=True)
 
         Example Output:
 
-        >>> edata_3d.layers["tem_data"][0, :, :]
+        >>> edata.layers["tem_data"][0, :, :]
         [[-12.12732884, -18.37304373],
         [         nan,  -0.91339411],
         [         nan,  -7.88514984]]

--- a/ehrapy/preprocessing/_imputation.py
+++ b/ehrapy/preprocessing/_imputation.py
@@ -445,7 +445,6 @@ def _knn_impute(
 
 
 @use_ehrdata(deprecated_after="1.0.0")
-@function_2D_only()
 @spinner("Performing miss-forest impute")
 def miss_forest_impute(
     edata: EHRData | AnnData,
@@ -495,6 +494,11 @@ def miss_forest_impute(
     if copy:
         edata = edata.copy()
 
+    if edata.X is None and layer is None:  # if edata is 3D
+        raise ValueError(
+            "3D imputation requires a layer to be specified. Pass the layer containing the full temporal data."
+        )
+
     if var_names is None:
         _warn_imputation_threshold(edata, list(edata.var_names), threshold=warning_threshold, layer=layer)
     elif isinstance(var_names, Iterable) and all(isinstance(item, str) for item in var_names):
@@ -527,7 +531,24 @@ def miss_forest_impute(
             var_names = edata.var_names
         var_indices = edata.var_names.get_indexer(var_names).tolist()
 
-        if set(var_indices).issubset(_get_non_numerical_column_indices(edata.X)):
+        mtx = edata.X if layer is None else edata.layers[layer]
+        input_dtype = mtx.dtype if np.issubdtype(mtx.dtype, np.floating) else np.float64
+        var_indices_original = var_indices
+
+        is_3d = False
+        if mtx.ndim == 3:
+            is_3d = True
+            n_obs, n_vars, n_t = mtx.shape
+            mtx = (
+                mtx[:, var_indices, :]
+                .astype(input_dtype, copy=True)
+                .transpose(0, 2, 1)
+                .reshape(n_obs * n_t, len(var_indices))
+            )
+            numerical_indices = list(range(len(var_indices)))
+            var_indices = numerical_indices
+
+        if set(var_indices).issubset(_get_non_numerical_column_indices(mtx)):
             raise ValueError(
                 "Can only impute numerical data. Try to restrict imputation to certain columns using "
                 "var_names parameter."
@@ -535,10 +556,20 @@ def miss_forest_impute(
 
         # this step is the most expensive one and might extremely slow down the impute process
         if var_indices:
-            if layer is None:
-                edata.X[::, var_indices] = imp_num.fit_transform(edata.X[::, var_indices])
+            imputer_x = mtx[:, var_indices]
+            X_imputed = imp_num.fit_transform(imputer_x)
+            if is_3d:
+                X_imputed = (
+                    X_imputed[:, : len(var_indices_original)]
+                    .reshape(n_obs, n_t, len(var_indices_original))
+                    .transpose(0, 2, 1)
+                )
+                edata.layers[layer][:, var_indices_original, :] = X_imputed
             else:
-                edata.layers[layer][::, var_indices] = imp_num.fit_transform(edata.layers[layer][::, var_indices])
+                if layer is None:
+                    edata.X[::, var_indices] = X_imputed
+                else:
+                    edata.layers[layer][::, var_indices] = X_imputed
         else:
             raise ValueError("Cannot find any feature to perform imputation")
 

--- a/ehrapy/preprocessing/_imputation.py
+++ b/ehrapy/preprocessing/_imputation.py
@@ -506,7 +506,9 @@ def miss_forest_impute(
     See https://academic.oup.com/bioinformatics/article/28/1/112/219101.
 
     If required, the data needs to be properly encoded as this imputation requires numerical data only.
-
+    If the data is stored as sparse arrays (:class:`scipy.sparse.csr_array`, :class:`scipy.sparse.csc_array`), 
+    they will be converted to dense internally during imputation.
+    
     Args:
         edata: Central data object.
         var_names: Iterable of columns to impute
@@ -559,25 +561,14 @@ def miss_forest_impute(
 
         patch_sklearn()
 
-    from sklearn.ensemble import RandomForestClassifier
-    from sklearn.impute import IterativeImputer
-
     try:
-        # not sure if this should be kept?
-        # initial strategy here will not be parametrized since only most_frequent will be applied to non numerical data
-        IterativeImputer(
-            estimator=RandomForestClassifier(n_estimators=n_estimators, n_jobs=settings.n_jobs),
-            initial_strategy="most_frequent",
-            max_iter=max_iter,
-            random_state=random_state,
-        )
 
         if var_names is None:
             var_names = edata.var_names
         var_indices = edata.var_names.get_indexer(var_names).tolist()
 
         mtx = edata.X if layer is None else edata.layers[layer]
-        input_dtype = mtx.dtype if np.issubdtype(mtx.dtype, np.floating) else np.float64
+        input_dtype = mtx.dtype if np.issubdtype(mtx.dtype, np.floating) else np.float64 #ensure floating point dtype before imputation, e.g. in case input layer dtype=object
 
         if mtx.ndim == 3:
             mtx_slice = mtx[:, var_indices, :].astype(input_dtype, copy=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ classifiers = [
 
 dependencies = [
     "ehrdata",
+    "anndata<0.12.12",  # temporary pin until ehrdata is compatible with latest anndata
     "scanpy",
     "requests",
     "miceforest",

--- a/tests/preprocessing/test_imputation.py
+++ b/tests/preprocessing/test_imputation.py
@@ -376,6 +376,7 @@ def test_missforest_impute_3d_var_names_subset(edata_mini_3D_missing_values):
         before_imputation_layer=DEFAULT_TEM_LAYER_NAME,
         after_imputation_layer=DEFAULT_TEM_LAYER_NAME,
     )
+    assert edata.shape == imputed.shape
 
 
 def test_missforest_impute_3d_layer_none(edata_mini_3D_missing_values):

--- a/tests/preprocessing/test_imputation.py
+++ b/tests/preprocessing/test_imputation.py
@@ -388,12 +388,13 @@ def test_missforest_impute_non_numerical_data(impute_edata):
     with pytest.raises(ValueError):
         miss_forest_impute(impute_edata, copy=True)
 
+
 @pytest.mark.parametrize("array_type", ARRAY_TYPES_NUMERIC)
 def test_missforest_impute_numerical_data(impute_num_edata, array_type):
     warnings.filterwarnings("ignore", category=ConvergenceWarning)
     impute_num_edata.X = array_type(impute_num_edata.X)
 
-    if isinstance(impute_num_edata.X, da.Array):
+    if isinstance(impute_num_edata.X, da.Array | sparse.csr_array | sparse.csc_array):
         with pytest.raises(NotImplementedError):
             edata_imputed = miss_forest_impute(impute_num_edata, copy=True)
     else:

--- a/tests/preprocessing/test_imputation.py
+++ b/tests/preprocessing/test_imputation.py
@@ -354,10 +354,33 @@ def test_knn_impute_numerical_data(impute_num_edata):
     _base_check_imputation(impute_num_edata, edata_imputed)
 
 
-def test_missforest_impute_3D_edata(edata_blob_small):
-    miss_forest_impute(edata_blob_small, layer="layer_2")
-    with pytest.raises(ValueError, match=r"only supports 2D data"):
-        miss_forest_impute(edata_blob_small, layer=DEFAULT_TEM_LAYER_NAME)
+@pytest.mark.parametrize("edata_mini_3D_missing_values", [True], indirect=True)
+def test_missforest_impute_3D_edata(edata_mini_3D_missing_values):
+    edata = edata_mini_3D_missing_values.copy()
+    edata_imputed = miss_forest_impute(edata, layer=DEFAULT_TEM_LAYER_NAME, copy=True)
+    _base_check_imputation(
+        edata_mini_3D_missing_values,
+        edata_imputed,
+        before_imputation_layer=DEFAULT_TEM_LAYER_NAME,
+        after_imputation_layer=DEFAULT_TEM_LAYER_NAME,
+    )
+
+
+def test_missforest_impute_3d_var_names_subset(edata_mini_3D_missing_values):
+    edata = edata_mini_3D_missing_values.copy()
+    imputed = miss_forest_impute(edata, layer=DEFAULT_TEM_LAYER_NAME, var_names=["1", "2"], copy=True)
+    edata_imputed = imputed[:, :2].copy()
+    _base_check_imputation(
+        edata_mini_3D_missing_values[:, :2],
+        edata_imputed,
+        before_imputation_layer=DEFAULT_TEM_LAYER_NAME,
+        after_imputation_layer=DEFAULT_TEM_LAYER_NAME,
+    )
+
+
+def test_missforest_impute_3d_layer_none(edata_mini_3D_missing_values):
+    with pytest.raises(ValueError, match="requires a layer"):
+        miss_forest_impute(edata_mini_3D_missing_values, copy=True)
 
 
 def test_missforest_impute_non_numerical_data(impute_edata):

--- a/tests/preprocessing/test_imputation.py
+++ b/tests/preprocessing/test_imputation.py
@@ -388,12 +388,18 @@ def test_missforest_impute_non_numerical_data(impute_edata):
     with pytest.raises(ValueError):
         miss_forest_impute(impute_edata, copy=True)
 
-
-def test_missforest_impute_numerical_data(impute_num_edata):
+@pytest.mark.parametrize("array_type", ARRAY_TYPES_NUMERIC)
+def test_missforest_impute_numerical_data(impute_num_edata, array_type):
     warnings.filterwarnings("ignore", category=ConvergenceWarning)
-    edata_imputed = miss_forest_impute(impute_num_edata, copy=True)
+    impute_num_edata.X = array_type(impute_num_edata.X)
 
-    _base_check_imputation(impute_num_edata, edata_imputed)
+    if isinstance(impute_num_edata.X, da.Array):
+        with pytest.raises(NotImplementedError):
+            edata_imputed = miss_forest_impute(impute_num_edata, copy=True)
+    else:
+        edata_imputed = miss_forest_impute(impute_num_edata, copy=True)
+
+        _base_check_imputation(impute_num_edata, edata_imputed)
 
 
 def test_missforest_impute_subset(impute_num_edata):


### PR DESCRIPTION
fixes #948 
Extends `miss_forest_impute` to handle 3D `EHRData` inputs

- Removed `@function_2D_only()` decorator
-  If the input is 3D: flattens the layer to `(n_obs * n_t, n_vars)` (flattening along axis 0) before imputation and reshapes back to `(n_obs, n_vars, n_t)` afterwards using `_apply_over_time_axis`
- Added guard raising `ValueError` when input is 3D but no layer is specified
- Added tests for 3D imputation
- Raising NotImplemented error for unsupported array types (sparse and dask)

Comparison of `miss_forest_impute` and `simple_impute `with mean strategy using physionet2012 dataset with a missingness of 10%: 

```python3
import ehrapy as ep
import ehrdata as ed
import numpy as np

edata_full = ed.dt.physionet2012(layer="tem_data")
edata = edata_full[:200]

full_layer = edata.layers["tem_data"].copy()

rng = np.random.default_rng(42)
non_nan_mask = ~np.isnan(full_layer)
mask_indices = np.where(non_nan_mask)
n_to_mask = int(0.1 * len(mask_indices[0]))
chosen = rng.choice(len(mask_indices[0]), size=n_to_mask, replace=False)

masked_layer = full_layer.copy()
masked_layer[mask_indices[0][chosen], mask_indices[1][chosen], mask_indices[2][chosen]] = np.nan
edata.layers["tem_data"] = masked_layer

edata_mf = edata.copy()
edata_simple = edata.copy()

ep.pp.simple_impute(edata_simple, layer="tem_data", strategy="mean")
ep.pp.miss_forest_impute(edata_mf, layer="tem_data")

true_vals = full_layer[mask_indices[0][chosen], mask_indices[1][chosen], mask_indices[2][chosen]]
mf_vals = edata_mf.layers["tem_data"][mask_indices[0][chosen], mask_indices[1][chosen], mask_indices[2][chosen]]
simple_vals = edata_simple.layers["tem_data"][mask_indices[0][chosen], mask_indices[1][chosen], mask_indices[2][chosen]]

print("True mean:", np.nanmean(true_vals))
print("Miss forest mean:", np.nanmean(mf_vals), "diff:", abs(np.nanmean(mf_vals) - np.nanmean(true_vals)))
print("Simple mean:", np.nanmean(simple_vals), "diff:", abs(np.nanmean(simple_vals) - np.nanmean(true_vals)))

print("True std:", np.nanstd(true_vals))
print("Miss forest std:", np.nanstd(mf_vals), "diff:", abs(np.nanstd(mf_vals) - np.nanstd(true_vals)))
print("Simple std:", np.nanstd(simple_vals), "diff:", abs(np.nanstd(simple_vals) - np.nanstd(true_vals)))

```
Output: 
```
True mean: 70.79201158141458
Miss forest mean: 70.00290934785606 diff: 0.7891022335585234
Simple mean: 71.76743450695217 diff: 0.9754229255375861
True std: 58.31532031908203
Miss forest std: 46.06704701689582 diff: 12.248273302186213
Simple std: 41.852838829183426 diff: 16.462481489898607
```

Note: I used a subset of observations (200) for this evaluation since `miss_forest_impute `got computationally too expensive and crashed (11988 observations × 37 variables × 48 timepoints which after flattening to (n_obs * n_t, n_vars) resulted in a matrix too large for IterativeImputer)