### PR TITLE
sparse array support for  `_warn_imputation_threshold`

### DIFF
--- a/ehrapy/_types.py
+++ b/ehrapy/_types.py
@@ -10,7 +10,7 @@ from fast_array_utils.conv import to_dense
 from ehrapy._compat import as_dense_dask_array
 
 KnownTransformer = Literal["pynndescent", "sklearn"]
-CSBase = sp.csr_matrix | sp.csc_matrix
+CSBase = sp.csr_matrix | sp.csc_matrix | sp.csr_array | sp.csc_array
 RNGLike = np.random.Generator | np.random.BitGenerator
 SeedLike = int | np.integer | Sequence[int] | np.random.SeedSequence
 AnyRandom = int | np.random.RandomState | None

--- a/ehrapy/_types.py
+++ b/ehrapy/_types.py
@@ -10,7 +10,7 @@ from fast_array_utils.conv import to_dense
 from ehrapy._compat import as_dense_dask_array
 
 KnownTransformer = Literal["pynndescent", "sklearn"]
-CSBase = sp.csr_matrix | sp.csc_matrix | sp.csr_array | sp.csc_array
+CSBase = sp.csr_array | sp.csc_array
 RNGLike = np.random.Generator | np.random.BitGenerator
 SeedLike = int | np.integer | Sequence[int] | np.random.SeedSequence
 AnyRandom = int | np.random.RandomState | None

--- a/ehrapy/preprocessing/_imputation.py
+++ b/ehrapy/preprocessing/_imputation.py
@@ -24,6 +24,7 @@ from ehrapy._compat import (
 )
 from ehrapy._progress import spinner
 from ehrapy._types import CSBase
+from ehrapy.preprocessing._quality_control import _compute_missing_values
 
 if TYPE_CHECKING:
     from anndata import AnnData
@@ -710,21 +711,14 @@ def _warn_imputation_threshold(
         edata.var["missing_values_pct"]
     except KeyError:
         mtx = edata.X if layer is None else edata.layers[layer]
-        if isinstance(mtx, get_args(CSBase)):
-            # compute missing pct directly for sparse without calling qc_metrics
-            n_obs = mtx.shape[0]
-            mtx_csc = (
-                mtx.tocsc() if isinstance(mtx, sp.csr_array) else mtx
-            )  # convert to csc to get per column stats easily
-            n_nan_per_col = np.array(
-                [np.sum(np.isnan(mtx_csc.data[mtx_csc.indptr[i] : mtx_csc.indptr[i + 1]])) for i in range(mtx.shape[1])]
-            )
-            missing_pct = (n_nan_per_col / n_obs) * 100
-            edata.var["missing_values_pct"] = missing_pct
+        if mtx.ndim == 3:
+            n_obs, n_vars, n_t = mtx.shape
+            mtx_2d = mtx.transpose(0, 2, 1).reshape(n_obs * n_t, n_vars)
         else:
-            from ehrapy.preprocessing import qc_metrics
+            mtx_2d = mtx
+        missing_abs = _compute_missing_values(mtx_2d, axis=0)
+        edata.var["missing_values_pct"] = (missing_abs / mtx_2d.shape[0]) * 100
 
-            qc_metrics(edata, layer=layer)
     used_var_names = set(edata.var_names) if var_names is None else set(var_names)
 
     thresholded_var_names = set(edata.var[edata.var["missing_values_pct"] > threshold].index) & set(used_var_names)

--- a/ehrapy/preprocessing/_imputation.py
+++ b/ehrapy/preprocessing/_imputation.py
@@ -695,10 +695,9 @@ def _warn_imputation_threshold(
 ) -> dict[str, int]:
     """Warns the user if the more than $threshold percent had to be imputed.
 
-    For sparse arrays (:class:`scipy.sparse.csr_array`, :class:`scipy.sparse.csc_array`),
-        missing values are assumed to be explicitly stored as NaN in the sparse structure.
-        If missing values are represented as zeros (not stored), they will not be
-        detected and the warning threshold check will be inaccurate.
+    For sparse arrays, missing values are assumed to be represented as ``np.nan``.
+    Use :func:`ehrdata.harmonize_missing_values` to convert other missing value
+    symbols to ``np.nan`` before imputing.
 
     Args:
         edata: The data object to check

--- a/ehrapy/preprocessing/_imputation.py
+++ b/ehrapy/preprocessing/_imputation.py
@@ -23,6 +23,7 @@ from ehrapy._compat import (
     use_ehrdata,
 )
 from ehrapy._progress import spinner
+from ehrapy._types import CSBase
 
 if TYPE_CHECKING:
     from anndata import AnnData
@@ -695,9 +696,9 @@ def _warn_imputation_threshold(
 ) -> dict[str, int]:
     """Warns the user if the more than $threshold percent had to be imputed.
 
-    For sparse arrays, missing values are assumed to be represented as ``np.nan``.
+    For sparse arrays, missing values are assumed to be represented as `np.nan`.
     Use :func:`ehrdata.harmonize_missing_values` to convert other missing value
-    symbols to ``np.nan`` before imputing.
+    symbols to `np.nan` before imputing.
 
     Args:
         edata: The data object to check
@@ -709,7 +710,7 @@ def _warn_imputation_threshold(
         edata.var["missing_values_pct"]
     except KeyError:
         mtx = edata.X if layer is None else edata.layers[layer]
-        if isinstance(mtx, (sp.csr_array, sp.csc_array)):
+        if isinstance(mtx, (sp.csr_array, sp.csc_array, CSBase)):
             # compute missing pct directly for sparse without calling qc_metrics
             n_obs = mtx.shape[0]
             mtx_csc = (

--- a/ehrapy/preprocessing/_imputation.py
+++ b/ehrapy/preprocessing/_imputation.py
@@ -710,7 +710,7 @@ def _warn_imputation_threshold(
         edata.var["missing_values_pct"]
     except KeyError:
         mtx = edata.X if layer is None else edata.layers[layer]
-        if isinstance(mtx, (sp.csr_array, sp.csc_array, CSBase)):
+        if isinstance(mtx, CSBase):
             # compute missing pct directly for sparse without calling qc_metrics
             n_obs = mtx.shape[0]
             mtx_csc = (

--- a/ehrapy/preprocessing/_imputation.py
+++ b/ehrapy/preprocessing/_imputation.py
@@ -732,7 +732,6 @@ def _warn_imputation_threshold(
 ) -> dict[str, int]:
     """Warns the user if the more than $threshold percent had to be imputed.
 
-    For sparse arrays, missing values are assumed to be represented as `np.nan`.
     Use :func:`ehrdata.harmonize_missing_values` to convert other missing value
     symbols to `np.nan` before imputing.
 

--- a/ehrapy/preprocessing/_imputation.py
+++ b/ehrapy/preprocessing/_imputation.py
@@ -4,7 +4,7 @@ import warnings
 from collections.abc import Iterable, Mapping, Sequence
 from functools import singledispatch
 from importlib.util import find_spec
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, get_args
 
 import numpy as np
 import pandas as pd
@@ -710,7 +710,7 @@ def _warn_imputation_threshold(
         edata.var["missing_values_pct"]
     except KeyError:
         mtx = edata.X if layer is None else edata.layers[layer]
-        if isinstance(mtx, CSBase):
+        if isinstance(mtx, get_args(CSBase)):
             # compute missing pct directly for sparse without calling qc_metrics
             n_obs = mtx.shape[0]
             mtx_csc = (

--- a/ehrapy/preprocessing/_imputation.py
+++ b/ehrapy/preprocessing/_imputation.py
@@ -704,9 +704,20 @@ def _warn_imputation_threshold(
     try:
         edata.var["missing_values_pct"]
     except KeyError:
-        from ehrapy.preprocessing import qc_metrics
+        mtx = edata.X if layer is None else edata.layers[layer]
+        if isinstance(mtx, (sp.csr_array, sp.csc_array)):
+            # compute missing pct directly for sparse without calling qc_metrics
+            n_obs = mtx.shape[0]
+            mtx_csc = (
+                mtx.tocsc() if isinstance(mtx, sp.csr_array) else mtx
+            )  # convert to csc to get per column stats easily
+            n_missing_per_col = n_obs - np.diff(mtx_csc.indptr)
+            missing_pct = (n_missing_per_col / n_obs) * 100
+            edata.var["missing_values_pct"] = missing_pct
+        else:
+            from ehrapy.preprocessing import qc_metrics
 
-        qc_metrics(edata, layer=layer)
+            qc_metrics(edata, layer=layer)
     used_var_names = set(edata.var_names) if var_names is None else set(var_names)
 
     thresholded_var_names = set(edata.var[edata.var["missing_values_pct"] > threshold].index) & set(used_var_names)

--- a/ehrapy/preprocessing/_imputation.py
+++ b/ehrapy/preprocessing/_imputation.py
@@ -695,6 +695,11 @@ def _warn_imputation_threshold(
 ) -> dict[str, int]:
     """Warns the user if the more than $threshold percent had to be imputed.
 
+    For sparse arrays (:class:`scipy.sparse.csr_array`, :class:`scipy.sparse.csc_array`),
+        missing values are assumed to be explicitly stored as NaN in the sparse structure.
+        If missing values are represented as zeros (not stored), they will not be
+        detected and the warning threshold check will be inaccurate.
+
     Args:
         edata: The data object to check
         var_names: The var names which were imputed.
@@ -711,8 +716,10 @@ def _warn_imputation_threshold(
             mtx_csc = (
                 mtx.tocsc() if isinstance(mtx, sp.csr_array) else mtx
             )  # convert to csc to get per column stats easily
-            n_missing_per_col = n_obs - np.diff(mtx_csc.indptr)
-            missing_pct = (n_missing_per_col / n_obs) * 100
+            n_nan_per_col = np.array(
+                [np.sum(np.isnan(mtx_csc.data[mtx_csc.indptr[i] : mtx_csc.indptr[i + 1]])) for i in range(mtx.shape[1])]
+            )
+            missing_pct = (n_nan_per_col / n_obs) * 100
             edata.var["missing_values_pct"] = missing_pct
         else:
             from ehrapy.preprocessing import qc_metrics

--- a/ehrapy/preprocessing/_quality_control.py
+++ b/ehrapy/preprocessing/_quality_control.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Literal
 import array_api_compat
 import numpy as np
 import pandas as pd
+import scipy.sparse as sp
 from ehrdata._logger import logger
 from ehrdata.io import to_pandas
 
@@ -134,6 +135,23 @@ def _(mtx: DaskArray, axis) -> np.ndarray:
     import dask.array as da
 
     return da.isnull(mtx).sum(axis).compute()
+
+
+@_compute_missing_values.register(sp.csr_array)
+@_compute_missing_values.register(sp.csc_array)
+def _(mtx, axis) -> np.ndarray:
+    mtx_csc = mtx.tocsc() if isinstance(mtx, sp.csr_array) else mtx
+    n_nan_per_col = np.array(
+        [np.sum(np.isnan(mtx_csc.data[mtx_csc.indptr[i] : mtx_csc.indptr[i + 1]])) for i in range(mtx.shape[1])]
+    )
+    if axis == 0:
+        return n_nan_per_col
+    else:
+        # per row
+        mtx_csr = mtx.tocsr() if isinstance(mtx, sp.csc_array) else mtx
+        return np.array(
+            [np.sum(np.isnan(mtx_csr.data[mtx_csr.indptr[i] : mtx_csr.indptr[i + 1]])) for i in range(mtx.shape[0])]
+        )
 
 
 @singledispatch

--- a/tests/preprocessing/test_imputation.py
+++ b/tests/preprocessing/test_imputation.py
@@ -557,7 +557,11 @@ def test_explicit_impute_error(impute_edata, edata_mini_3D_missing_values):
         explicit_impute(edata_mini_3D_missing_values, replacement=[1, 2, 3], layer=DEFAULT_TEM_LAYER_NAME)
 
 
-def test_warning(impute_num_edata):
+@pytest.mark.parametrize("array_type", ARRAY_TYPES_NUMERIC)
+def test_warning(impute_num_edata, array_type):
+    impute_num_edata.X = array_type(impute_num_edata.X)
+    if isinstance(impute_num_edata.X, da.Array):
+        pytest.skip("_warn_imputation_threshold does not support Dask arrays")
     warning_results = _warn_imputation_threshold(impute_num_edata, threshold=20, var_names=None)
     assert warning_results == {"col1": 25, "col3": 50}
 


### PR DESCRIPTION
fixes #1058 
`_warn_imputation_threshold` is calling `qc_metrics` to compute missing value percentages, which does not support sparse arrays

- Refactored _warn_imputation_threshold: a sparse aware path that computes missing value percentages directly using `np.isnan` on the stored values assuming missing values are explicitly stored as NaN in the sparse structure as well
- Extended test_warning() to cover sparse arrays