### PR TITLE
address pandas futurewarning

### DIFF
--- a/ehrapy/plot/_sankey.py
+++ b/ehrapy/plot/_sankey.py
@@ -69,7 +69,7 @@ def sankey_diagram(
     source_levels, target_levels = [], []
     for i in range(len(columns) - 1):
         col_from, col_to = columns[i], columns[i + 1]
-        flows = df.groupby([col_from, col_to]).size().reset_index(name="count")
+        flows = df.groupby([col_from, col_to], observed=True).size().reset_index(name="count")
         sources.extend(col_from + ": " + flows[col_from].astype("string"))
         targets.extend(col_to + ": " + flows[col_to].astype("string"))
         values.extend(flows["count"].to_numpy())

--- a/ehrapy/plot/_variable_correlation_plot.py
+++ b/ehrapy/plot/_variable_correlation_plot.py
@@ -78,8 +78,8 @@ def variable_correlations(
         alpha=alpha,
     )
 
-    corr_long = corr_df.stack().rename("correlation")
-    sig_long = sig_df.stack().rename("significant")
+    corr_long = corr_df.stack(future_stack=True).rename("correlation")
+    sig_long = sig_df.stack(future_stack=True).rename("significant")
     heatmap_df = pd.concat([corr_long, sig_long], axis=1).reset_index()
     heatmap_df.columns = ["variable1", "variable2", "correlation", "significant"]
 
@@ -194,8 +194,8 @@ def variable_dependencies(
         alpha=alpha,
     )
 
-    corr_long = corr_df.stack(dropna=False).rename("correlation")
-    sig_long = sig_df.stack().rename("significant")
+    corr_long = corr_df.stack(future_stack=True).rename("correlation")
+    sig_long = sig_df.stack(future_stack=True).rename("significant")
 
     edges_df = pd.concat([corr_long, sig_long], axis=1).reset_index()
     edges_df.columns = ["variable1", "variable2", "correlation", "significant"]

--- a/ehrapy/preprocessing/_bias.py
+++ b/ehrapy/preprocessing/_bias.py
@@ -240,7 +240,7 @@ def detect_bias(
         for comp_feature in cat_var_names:
             if sens_feature == comp_feature:
                 continue
-            value_counts = edata_df.groupby([sens_feature, comp_feature]).size().unstack(fill_value=0)
+            value_counts = edata_df.groupby([sens_feature, comp_feature], observed=True).size().unstack(fill_value=0)
             value_counts = value_counts.div(value_counts.sum(axis=1), axis=0)
 
             for sens_group in value_counts.index:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ classifiers = [
 ]
 
 dependencies = [
+    "anndata<0.12.12", # temporarily pinning because ehrdata is incompatible with newer anndata for now
     "ehrdata",
     "scanpy",
     "requests",


### PR DESCRIPTION
**PR Checklist**

- [x] This comment contains a description of changes (with reason)
- [x] Referenced issue is linked
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated

**Description of changes**

Fixes #1059 pandas `FutureWarnings` in the tests. Affected files

- `ehrapy/plot/_variable_correlation_plot.py`: Updated  `.stack()` calls to use `future_stack=True` (the new default in pandas 3.0) and removed `dropna=False`, which is not accepted when `future_stack=True`.
- `ehrapy/plot/_sankey.py`: Added `observed=True` to a `groupby` call on obs columns
- `ehrapy/preprocessing/_bias.py`: `observed=True` again

**Technical details**

`stack`: pandas 2.1 introduced a new implementation of `DataFrame.stack()` that will become the only version in 3.0. The key behavioural difference is that the new implementation never introduces spurious `NaN` values, so `dropna=False` is no longer needed. The output for our use cases is identical.

`groupby(observed=True)`: The pandas default for `observed` on categorical columns changes from `False` to `True` in pandas 3.0. With `observed=False`, all possible category combinations appear in the result even with zero counts. For our use cases here this is incorrect behaviour: zero count category pairs in the bias analysis would result in `0/0 = NaN` ratios. In a sankey diagram a zero count flow makes no sense as well, so in both cases I set `observed=True`.