### PR TITLE
Drop leidenalg flavor from ep.tl.leiden (igraph only)

### DIFF
--- a/.github/workflows/run_notebooks.yml
+++ b/.github/workflows/run_notebooks.yml
@@ -43,7 +43,7 @@ jobs:
               run: sudo apt-get install -y libopenblas-dev
 
             - name: Install ehrapy and additional dependencies
-              run: uv pip install . 'cellrank[scvelo]' nbconvert ipykernel graphviz pypots fairlearn
+              run: uv pip install '.[leiden]' 'cellrank[scvelo]' nbconvert ipykernel graphviz pypots fairlearn
 
             - name: Install ehrdata from submodule
               run: uv pip install --reinstall --no-deps -e submodules/ehrdata

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,7 +111,6 @@ intersphinx_mapping = {
     "networkx": ("https://networkx.org/documentation/stable", None),
     "ehrdata": ("https://ehrdata.readthedocs.io/en/latest/", None),
     "holoviews": ("https://holoviews.org/", None),
-    "igraph": ("https://python.igraph.org/en/stable/", None),
 }
 nitpick_ignore = [
     ("py:class", "matplotlib.axes.Axes"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,7 +88,6 @@ myst_enable_extensions = [
 
 autodoc_mock_imports = [
     "scipy.linalg.triu",
-    "leidenalg",
 ]
 
 intersphinx_mapping = {
@@ -115,10 +114,7 @@ intersphinx_mapping = {
 }
 nitpick_ignore = [
     ("py:class", "matplotlib.axes.Axes"),
-    ("py:class", "leidenalg.RBConfigurationVertexPartition"),
-    ("py:class", "leidenalg.VertexPartition.MutableVertexPartition"),
     ("py:class", "cycler.Cycler"),
-    ("py:func", "leidenalg.find_partition"),
     ("py:class", "CAT"),
     ("py:class", "ehrapy.tools.annotate_text.CAT"),
     ("py:class", "tableone.TableOne"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,6 +111,7 @@ intersphinx_mapping = {
     "networkx": ("https://networkx.org/documentation/stable", None),
     "ehrdata": ("https://ehrdata.readthedocs.io/en/latest/", None),
     "holoviews": ("https://holoviews.org/", None),
+    "igraph": ("https://python.igraph.org/en/stable/", None),
 }
 nitpick_ignore = [
     ("py:class", "matplotlib.axes.Axes"),

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -29,6 +29,14 @@ To run causal inference with ehrapy, install the `causal` extra:
 pip install ehrapy[causal]
 ```
 
+#### leiden clustering
+
+To use :func:`ehrapy.tools.leiden`, install the `leiden` extra (which pulls in :mod:`igraph`):
+
+```console
+pip install ehrapy[leiden]
+```
+
 ## From sources
 
 The sources for ehrapy can be downloaded from the [Github repo].

--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
     from ehrdata import EHRData
-    from leidenalg.VertexPartition import MutableVertexPartition
 
     from ehrapy._types import AnyRandom
 
@@ -25,51 +24,37 @@ def leiden(
     random_state: AnyRandom = 0,
     key_added: str = "leiden",
     adjacency: spmatrix | None = None,
-    directed: bool | None = False,
     use_weights: bool = True,
     n_iterations: int = -1,
-    partition_type: type[MutableVertexPartition] | None = None,
     neighbors_key: str | None = None,
     obsp: str | None = None,
-    flavor: Literal["leidenalg", "igraph"] = "igraph",
     copy: bool = False,
-    **partition_kwargs,
+    **clustering_args,
 ) -> EHRData | None:  # pragma: no cover
     """Cluster observations into subgroups :cite:p:`Traag2019`.
 
-    Cluster observations using the Leiden algorithm :cite:p:`Traag2019`,
-    an improved version of the Louvain algorithm :cite:p:`Blondel2008`.
+    Cluster observations using the Leiden algorithm :cite:p:`Traag2019`, an improved version of the Louvain algorithm :cite:p:`Blondel2008`.
     It has been proposed for single-cell analysis by :cite:p:`Levine2015`.
     This requires having run :func:`~ehrapy.preprocessing.neighbors`.
+    Uses the :mod:`igraph` implementation (``flavor="igraph"`` in scanpy); ``leidenalg`` is not supported.
 
     Args:
         edata: Central data object.
         resolution: A parameter value controlling the coarseness of the clustering. Higher values lead to more clusters.
-                    Set to `None` if overriding `partition_type` to one that doesn't accept a `resolution_parameter`.
-        restrict_to: Restrict the clustering to the categories within the key for sample
-                     annotation, tuple needs to contain `(obs_key, list_of_categories)`.
+        restrict_to: Restrict the clustering to the categories within the key for sample annotation, tuple needs to contain `(obs_key, list_of_categories)`.
         random_state: Random seed of the initialization of the optimization.
         key_added: `edata.obs` key under which to add the cluster labels.
         adjacency: Sparse adjacency matrix of the graph, defaults to neighbors connectivities.
-        directed: Whether to treat the graph as directed or undirected.
-        use_weights: If `True`, edge weights from the graph are used in the computation
-                     (placing more emphasis on stronger edges).
+        use_weights: If `True`, edge weights from the graph are used in the computation (placing more emphasis on stronger edges).
         n_iterations: How many iterations of the Leiden clustering algorithm to perform.
-                      Positive values above 2 define the total number of iterations to perform,
+                      Positive values above 2 define the total number of iterations to perform.
                       -1 has the algorithm run until it reaches its optimal clustering.
-        partition_type: Type of partition to use.
-                        Defaults to :class:`~leidenalg.RBConfigurationVertexPartition`.
-                        For the available options, consult the documentation for
-                        :func:`~leidenalg.find_partition`.
         neighbors_key: Use neighbors connectivities as adjacency.
-                       If not specified, leiden looks .obsp['connectivities'] for connectivities
-                       (default storage place for pp.neighbors).
+                       If not specified, leiden looks .obsp['connectivities'] for connectivities (default storage place for pp.neighbors).
                        If specified, leiden looks .obsp[.uns[neighbors_key]['connectivities_key']] for connectivities.
         obsp: Use `.obsp[obsp]` as adjacency. You can't specify both `obsp` and `neighbors_key` at the same time.
-        flavor: Which package's implementation to use.
         copy: Whether to copy `edata` or modify it inplace.
-        **partition_kwargs: Any further arguments to pass to `~leidenalg.find_partition`
-                            (which in turn passes arguments to the `partition_type`).
+        **clustering_args: Any further arguments passed to :meth:`igraph.Graph.community_leiden`.
 
     Returns:
         `edata.obs[key_added]`
@@ -85,15 +70,13 @@ def leiden(
         random_state=random_state,
         key_added=key_added,
         adjacency=adjacency,
-        directed=directed,
         use_weights=use_weights,
         n_iterations=n_iterations,
-        partition_type=partition_type,
         neighbors_key=neighbors_key,
         obsp=obsp,
         copy=copy,
-        flavor=flavor,
-        **partition_kwargs,
+        flavor="igraph",
+        **clustering_args,
     )
 
 

--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -36,7 +36,7 @@ def leiden(
     Cluster observations using the Leiden algorithm :cite:p:`Traag2019`, an improved version of the Louvain algorithm :cite:p:`Blondel2008`.
     It has been proposed for single-cell analysis by :cite:p:`Levine2015`.
     This requires having run :func:`~ehrapy.preprocessing.neighbors`.
-    Uses the ``igraph`` implementation (``flavor="igraph"`` in scanpy); ``leidenalg`` is not supported.
+    Uses the :mod:`igraph` implementation (``flavor="igraph"`` in scanpy); ``leidenalg`` is not supported.
 
     Args:
         edata: Central data object.
@@ -54,7 +54,7 @@ def leiden(
                        If specified, leiden looks .obsp[.uns[neighbors_key]['connectivities_key']] for connectivities.
         obsp: Use `.obsp[obsp]` as adjacency. You can't specify both `obsp` and `neighbors_key` at the same time.
         copy: Whether to copy `edata` or modify it inplace.
-        **clustering_args: Any further arguments passed to ``igraph.Graph.community_leiden``.
+        **clustering_args: Any further arguments passed to :meth:`igraph.Graph.community_leiden`.
 
     Returns:
         `edata.obs[key_added]`

--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -36,7 +36,7 @@ def leiden(
     Cluster observations using the Leiden algorithm :cite:p:`Traag2019`, an improved version of the Louvain algorithm :cite:p:`Blondel2008`.
     It has been proposed for single-cell analysis by :cite:p:`Levine2015`.
     This requires having run :func:`~ehrapy.preprocessing.neighbors`.
-    Uses the :mod:`igraph` implementation (``flavor="igraph"`` in scanpy); ``leidenalg`` is not supported.
+    Uses the ``igraph`` implementation (``flavor="igraph"`` in scanpy); ``leidenalg`` is not supported.
 
     Args:
         edata: Central data object.
@@ -54,7 +54,7 @@ def leiden(
                        If specified, leiden looks .obsp[.uns[neighbors_key]['connectivities_key']] for connectivities.
         obsp: Use `.obsp[obsp]` as adjacency. You can't specify both `obsp` and `neighbors_key` at the same time.
         copy: Whether to copy `edata` or modify it inplace.
-        **clustering_args: Any further arguments passed to :meth:`igraph.Graph.community_leiden`.
+        **clustering_args: Any further arguments passed to ``igraph.Graph.community_leiden``.
 
     Returns:
         `edata.obs[key_added]`

--- a/ehrapy/tools/_scanpy_tl_api.py
+++ b/ehrapy/tools/_scanpy_tl_api.py
@@ -63,6 +63,11 @@ def leiden(
         `edata.uns['leiden']['params']`
         A dict with the values for the parameters `resolution`, `random_state`, and `n_iterations`.
     """
+    try:
+        import igraph
+    except ImportError as e:
+        raise ImportError("`ep.tl.leiden` requires `igraph`. Install with `pip install ehrapy[leiden]`.") from e
+
     return sc.tl.leiden(
         adata=edata,
         resolution=resolution,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ dependencies = [
     "filelock",
     "numpy>=2.0.0",
     "numba>=0.60.0",
-    "igraph",  # careful - GPL
     "fast-array-utils[sparse,accel]",
     "tslearn",
     "holoviews[recommended]",
@@ -79,6 +78,7 @@ dask = [
     "anndata[dask]",
     "dask-ml>=2025.1.0",
 ]
+leiden = ["igraph"]  # careful - GPL
 rapids12 = ["rapids-singlecell[rapids12]"]
 rapids13 = ["rapids-singlecell[rapids13]"]
 dev = [
@@ -107,10 +107,10 @@ doc = [
     "nbsphinx-link",
     "ipykernel",
     "ipython",
-    "ehrapy[dask]"
+    "ehrapy[dask,leiden]"
 ]
 test = [
-    "ehrapy[dask,causal]",
+    "ehrapy[dask,causal,leiden]",
     "pytest",
     "pytest-cov",
     "pytest-mock"
@@ -131,7 +131,7 @@ post-install-commands = [
 ]
 
 [tool.hatch.envs.docs]
-features = [ "doc", "dask", "causal" ]
+features = [ "doc", "dask", "causal", "leiden" ]
 post-install-commands = [
   "uv pip install --reinstall --no-deps -e submodules/ehrdata",
 ]
@@ -141,7 +141,7 @@ scripts.clean = "git clean -fdX -- {args:docs}"
 
 # CPU
 [tool.hatch.envs.hatch-test]
-features = [ "dask", "causal" ]
+features = [ "dask", "causal", "leiden" ]
 post-install-commands = [
   "uv pip install --reinstall --no-deps -e submodules/ehrdata",
 ]


### PR DESCRIPTION
## Summary

- Removes `flavor`, `partition_type`, and `directed` parameters from `ep.tl.leiden`; always forwards `flavor="igraph"` to `scanpy.tl.leiden`.
- Drops the `leidenalg.VertexPartition.MutableVertexPartition` `TYPE_CHECKING` import in `ehrapy/tools/_scanpy_tl_api.py`.
- Cleans up `docs/conf.py`: removes `"leidenalg"` from `autodoc_mock_imports` and removes the four leidenalg-related entries in `nitpick_ignore`.
- `igraph` is already a hard dep, so no `pip install ehrapy[leiden]` extra or runtime install hint is needed.
- Non-breaking for in-tree callers: tests, plot docstrings, and tutorial notebooks only pass `resolution` / `key_added`.

Fixes https://github.com/theislab/ehrapy/issues/1071