### PR TITLE
Fix invalid RST roles in installation.md leiden section

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,7 +31,7 @@ pip install ehrapy[causal]
 
 #### leiden clustering
 
-To use :func:`ehrapy.tools.leiden`, install the `leiden` extra (which pulls in :mod:`igraph`):
+To use `ehrapy.tools.leiden`, install the `leiden` extra (which pulls in `igraph`):
 
 ```console
 pip install ehrapy[leiden]


### PR DESCRIPTION
## Summary

Follow-up to #1072. `docs/installation.md` is MyST Markdown, so `:func:` and `:mod:` reStructuredText roles aren't parsed (MyST uses `{func}` / `{mod}` syntax). The references also wouldn't resolve even with correct syntax: python-igraph's `objects.inv` contains only `std:doc` and `std:label` entries, no Python domain objects.

Renders both `:func:\`ehrapy.tools.leiden\`` and `:mod:\`igraph\`` as plain inline code.

## Test plan

- [ ] RTD docs build emits no warnings for `installation.md`
- [ ] Rendered page shows `ehrapy.tools.leiden` and `igraph` as inline code rather than literal RST role syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)