### PR TITLE
chore: remove unused imports, debug prints, and stale TODOs

### DIFF
--- a/ehrapy/core/meta_information.py
+++ b/ehrapy/core/meta_information.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import sys
-from datetime import datetime
-
 from rich import print
 
 from ehrapy import __version__

--- a/ehrapy/plot/_sankey.py
+++ b/ehrapy/plot/_sankey.py
@@ -262,10 +262,6 @@ def sankey_diagram_time(
         vdims=["value", "edge_color"],
     )
 
-    print(state_labels)
-    print("names")
-    print(state_names)
-
     opts_dict: dict[str, Any] = {}
 
     if hv.Store.current_backend == "bokeh":

--- a/ehrapy/plot/_survival_analysis.py
+++ b/ehrapy/plot/_survival_analysis.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import holoviews as hv
-import matplotlib.gridspec as gridspec
-import matplotlib.pyplot as plt
-import matplotlib.ticker as ticker
 import numpy as np
 import pandas as pd
 from bokeh.palettes import Category10

--- a/ehrapy/preprocessing/_imputation.py
+++ b/ehrapy/preprocessing/_imputation.py
@@ -252,6 +252,8 @@ def simple_impute(
     if var_names is None:
         var_names = edata.var_names
 
+    # TODO: warn again if qc_metrics is 3D enabled
+    # _warn_imputation_threshold(edata, var_names, threshold=warning_threshold, layer=layer)
     var_indices = edata.var_names.get_indexer(var_names).tolist()
 
     if layer is None:

--- a/ehrapy/preprocessing/_imputation.py
+++ b/ehrapy/preprocessing/_imputation.py
@@ -252,8 +252,6 @@ def simple_impute(
     if var_names is None:
         var_names = edata.var_names
 
-    # TODO: warn again if qc_metrics is 3D enabled
-    # _warn_imputation_threshold(edata, var_names, threshold=warning_threshold, layer=layer)
     var_indices = edata.var_names.get_indexer(var_names).tolist()
 
     if layer is None:


### PR DESCRIPTION
## Summary
- Drop unused imports (`sys`, `datetime` in `core/meta_information.py`; `matplotlib.gridspec`/`pyplot`/`ticker` in `plot/_survival_analysis.py`).
- Remove leftover debug `print()` calls in `plot/_sankey.py::sankey_diagram_time`.
- Delete stale TODO + commented-out `_warn_imputation_threshold` call in `preprocessing/_imputation.py::simple_impute`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)