### PR TITLE
feat: 3D & lazy dask array support for ep.pp.encode

### DIFF
--- a/ehrapy/preprocessing/_encoding.py
+++ b/ehrapy/preprocessing/_encoding.py
@@ -43,10 +43,8 @@ def encode(
         1. one-hot (https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OneHotEncoder.html)
         2. label (https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.LabelEncoder.html)
 
-    For 3D longitudinal layers of shape ``(n_obs, n_vars, n_time)`` the encoder is fit on
-    values stacked across the time axis so the category space is consistent over time.
-    The encoded result keeps the time axis, and ``obs`` stores the first-timepoint value
-    of each encoded categorical column.
+    For 3D longitudinal layers of shape ``(n_obs, n_vars, n_time)`` the encoder is fit on values stacked across the time axis so the category space is consistent over time.
+    The encoded result keeps the time axis, and ``obs`` stores the first-timepoint value of each encoded categorical column.
 
     Args:
         edata: Central data object.
@@ -328,21 +326,18 @@ def _encode_3d(
 ) -> EHRData:
     """Encode categoricals of a 3D longitudinal layer.
 
-    The encoder is fit on values stacked across the time axis so the category space is
-    shared across timepoints; the encoded result preserves the ``(n_obs, n_vars_new, n_time)``
-    shape and ``obs`` stores the first-timepoint value of each encoded categorical.
+    The encoder is fit on values stacked across the time axis so the category space is shared across timepoints.
+    The encoded result preserves the ``(n_obs, n_vars_new, n_time)`` shape and ``obs`` stores the first-timepoint value of each encoded categorical.
     """
     if "encoding_mode" in edata.var.keys():
         raise NotImplementedError(
-            "Re-encoding 3D longitudinal data is not supported: the original time variation "
-            "is not preserved after the first encoding."
+            "Re-encoding 3D longitudinal data is not supported: the original time variation is not preserved after the first encoding."
         )
 
     X_3d = edata.X if layer is None else edata.layers[layer]
     n_obs, n_vars, n_time = X_3d.shape
 
-    # Reshape (n_obs, n_vars, n_time) -> (n_obs * n_time, n_vars) in patient-major order
-    # so that the first n_obs rows of the stacked block correspond to t=0, etc.
+    # Reshape (n_obs, n_vars, n_time) -> (n_obs * n_time, n_vars) in patient-major order so that the first n_obs rows of the stacked block correspond to t=0, etc.
     X_2d = X_3d.transpose(0, 2, 1).reshape(n_obs * n_time, n_vars)
     obs_repeated = edata.obs.iloc[np.repeat(np.arange(n_obs), n_time)].reset_index(drop=True)
 

--- a/ehrapy/preprocessing/_encoding.py
+++ b/ehrapy/preprocessing/_encoding.py
@@ -14,12 +14,11 @@ from ehrdata.core.constants import CATEGORICAL_TAG, FEATURE_TYPE_KEY, NUMERIC_TA
 from rich.progress import BarColumn, Progress
 from sklearn.preprocessing import LabelEncoder, OneHotEncoder
 
-from ehrapy._compat import DaskArray, _raise_array_type_not_implemented, function_2D_only
+from ehrapy._compat import DaskArray, _raise_array_type_not_implemented
 
 available_encodings = {"one-hot", "label"}
 
 
-@function_2D_only()
 def encode(
     edata: EHRData,
     autodetect: bool | dict = False,
@@ -43,6 +42,11 @@ def encode(
     Available encodings are:
         1. one-hot (https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OneHotEncoder.html)
         2. label (https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.LabelEncoder.html)
+
+    For 3D longitudinal layers of shape ``(n_obs, n_vars, n_time)`` the encoder is fit on
+    values stacked across the time axis so the category space is consistent over time.
+    The encoded result keeps the time axis, and ``obs`` stores the first-timepoint value
+    of each encoded categorical column.
 
     Args:
         edata: Central data object.
@@ -70,8 +74,6 @@ def encode(
         ...     edata, autodetect=False, encodings={"label": ["col1", "col2"], "one-hot": ["col3"]}
         ... )
     """
-    X = edata.X if layer is None else edata.layers[layer]
-
     if not isinstance(edata, EHRData):
         raise ValueError(f"Cannot encode object of type {type(edata)}. Can only encode EHRData objects!")
 
@@ -81,6 +83,22 @@ def encode(
         raise ValueError(
             f"Setting encode mode with autodetect=True only works by passing a string (encode mode name) or None not {type(encodings)}!"
         )
+
+    X = edata.X if layer is None else edata.layers[layer]
+    if X.ndim == 3 and X.shape[2] > 1:
+        return _encode_3d(edata, autodetect, encodings, layer=layer)
+
+    return _encode_2d(edata, autodetect, encodings, layer=layer)
+
+
+def _encode_2d(
+    edata: EHRData,
+    autodetect: bool | dict,
+    encodings: dict[str, list[str]] | str | None,
+    *,
+    layer: str | None,
+) -> EHRData:
+    X = edata.X if layer is None else edata.layers[layer]
 
     # Infer feature types if not already done (passing layer parameter correctly)
     if FEATURE_TYPE_KEY not in edata.var.columns:
@@ -299,6 +317,62 @@ def encode(
         encoded_edata.X = None
 
     return encoded_edata
+
+
+def _encode_3d(
+    edata: EHRData,
+    autodetect: bool | dict,
+    encodings: dict[str, list[str]] | str | None,
+    *,
+    layer: str | None,
+) -> EHRData:
+    """Encode categoricals of a 3D longitudinal layer.
+
+    The encoder is fit on values stacked across the time axis so the category space is
+    shared across timepoints; the encoded result preserves the ``(n_obs, n_vars_new, n_time)``
+    shape and ``obs`` stores the first-timepoint value of each encoded categorical.
+    """
+    if "encoding_mode" in edata.var.keys():
+        raise NotImplementedError(
+            "Re-encoding 3D longitudinal data is not supported: the original time variation "
+            "is not preserved after the first encoding."
+        )
+
+    X_3d = edata.X if layer is None else edata.layers[layer]
+    n_obs, n_vars, n_time = X_3d.shape
+
+    # Reshape (n_obs, n_vars, n_time) -> (n_obs * n_time, n_vars) in patient-major order
+    # so that the first n_obs rows of the stacked block correspond to t=0, etc.
+    X_2d = X_3d.transpose(0, 2, 1).reshape(n_obs * n_time, n_vars)
+    obs_repeated = edata.obs.iloc[np.repeat(np.arange(n_obs), n_time)].reset_index(drop=True)
+
+    temp_var = edata.var.copy()
+    temp_edata = EHRData(X=X_2d, obs=obs_repeated, var=temp_var, uns=edata.uns.copy())
+
+    encoded_temp = _encode_2d(temp_edata, autodetect=autodetect, encodings=encodings, layer=None)
+
+    # Reshape encoded X / original layer back to 3D.
+    encoded_X_2d = encoded_temp.X
+    n_vars_new = encoded_X_2d.shape[1]
+    encoded_X_3d = encoded_X_2d.reshape(n_obs, n_time, n_vars_new).transpose(0, 2, 1)
+    original_3d = encoded_temp.layers["original"].reshape(n_obs, n_time, n_vars_new).transpose(0, 2, 1)
+
+    # Take the first timepoint (rows 0, n_time, 2*n_time, ...) for the obs-side originals.
+    first_t_rows = np.arange(n_obs) * n_time
+    final_obs = encoded_temp.obs.iloc[first_t_rows].copy()
+    final_obs.index = edata.obs.index
+
+    if layer is None:
+        result = EHRData(X=encoded_X_3d, obs=final_obs, var=encoded_temp.var.copy(), uns=encoded_temp.uns.copy())
+    else:
+        result = EHRData(
+            obs=final_obs,
+            var=encoded_temp.var.copy(),
+            uns=encoded_temp.uns.copy(),
+            layers={layer: encoded_X_3d},
+        )
+    result.layers["original"] = original_3d
+    return result
 
 
 def _one_hot_encoding(

--- a/ehrapy/preprocessing/_encoding.py
+++ b/ehrapy/preprocessing/_encoding.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
+from functools import singledispatch
 from itertools import chain
 
 import ehrdata as ed
@@ -13,7 +14,7 @@ from ehrdata.core.constants import CATEGORICAL_TAG, FEATURE_TYPE_KEY, NUMERIC_TA
 from rich.progress import BarColumn, Progress
 from sklearn.preprocessing import LabelEncoder, OneHotEncoder
 
-from ehrapy._compat import function_2D_only
+from ehrapy._compat import DaskArray, _raise_array_type_not_implemented, function_2D_only
 
 available_encodings = {"one-hot", "label"}
 
@@ -406,6 +407,64 @@ def _label_encoding(
     return temp_x, temp_var_names, unencoded_var_names
 
 
+@singledispatch
+def _delete_columns(X, idx_to_delete):
+    """Drop the given column indices from `X`, preserving `X`'s array type."""
+    _raise_array_type_not_implemented(_delete_columns, type(X))
+
+
+@_delete_columns.register(np.ndarray)
+def _(X: np.ndarray, idx_to_delete) -> np.ndarray:
+    return np.delete(X, list(idx_to_delete), 1)
+
+
+@_delete_columns.register(DaskArray)
+def _(X: DaskArray, idx_to_delete) -> DaskArray:
+    idx_set = set(idx_to_delete)
+    keep = [i for i in range(X.shape[1]) if i not in idx_set]
+    return X[:, keep]
+
+
+@singledispatch
+def _prepend_columns(X, columns_to_prepend):
+    """Prepend ``columns_to_prepend`` to `X` along axis=1, preserving `X`'s array type."""
+    _raise_array_type_not_implemented(_prepend_columns, type(X))
+
+
+@_prepend_columns.register(np.ndarray)
+def _(X: np.ndarray, columns_to_prepend) -> np.ndarray:
+    return np.hstack((np.asarray(columns_to_prepend), X))
+
+
+@_prepend_columns.register(DaskArray)
+def _(X: DaskArray, columns_to_prepend) -> DaskArray:
+    import dask.array as da
+
+    if not isinstance(columns_to_prepend, DaskArray):
+        columns_to_prepend = da.from_array(np.asarray(columns_to_prepend), chunks=(X.chunks[0], -1))
+    return da.concatenate([columns_to_prepend, X], axis=1)
+
+
+@singledispatch
+def _append_columns(X, columns_to_append):
+    """Append ``columns_to_append`` to `X` along axis=1, preserving `X`'s array type."""
+    _raise_array_type_not_implemented(_append_columns, type(X))
+
+
+@_append_columns.register(np.ndarray)
+def _(X: np.ndarray, columns_to_append) -> np.ndarray:
+    return np.hstack((X, np.asarray(columns_to_append)))
+
+
+@_append_columns.register(DaskArray)
+def _(X: DaskArray, columns_to_append) -> DaskArray:
+    import dask.array as da
+
+    if not isinstance(columns_to_append, DaskArray):
+        columns_to_append = da.from_array(np.asarray(columns_to_append), chunks=(X.chunks[0], -1))
+    return da.concatenate([X, columns_to_append], axis=1)
+
+
 def _update_layer_after_encoding(
     old_layer: np.ndarray,
     new_x: np.ndarray,
@@ -444,7 +503,7 @@ def _update_layer_after_encoding(
     # get all encoded categoricals of X
     encoded_categoricals = new_x[:, :new_cat_stop_index]
     # horizontally stack all encoded categoricals and the remaining "old original values"
-    updated_layer = np.hstack((encoded_categoricals, old_layer_view))
+    updated_layer = _append_columns(encoded_categoricals, old_layer_view)
 
     try:
         logger.info("Updated the original layer after encoding.")
@@ -477,10 +536,10 @@ def _update_encoded_data(
         Encoded new X, the corresponding new var names, and the unencoded var names
     """
     idx = _get_categoricals_old_indices(var_names, categoricals)
-    # delete the original categorical column
-    del_cat_column_x = np.delete(X, list(idx), 1)
-    # create the new, encoded X
-    temp_x = np.hstack((transformed, del_cat_column_x))
+    # drop the original categorical columns
+    del_cat_column_x = _delete_columns(X, idx)
+    # prepend the transformed (numpy) categorical block to the remaining columns
+    temp_x = _prepend_columns(del_cat_column_x, transformed)
     # delete old categorical name
     var_names = [col_name for col_idx, col_name in enumerate(var_names) if col_idx not in idx]
     temp_var_names = categorical_prefixes + var_names
@@ -531,7 +590,7 @@ def _undo_encoding(
 
     transformed = _initial_encoding(edata.obs, categoricals)
     temp_x, temp_var_names = _delete_all_encodings(edata, layer=layer)
-    new_x = np.hstack((transformed, temp_x)) if temp_x is not None else transformed
+    new_x = _prepend_columns(temp_x, transformed) if temp_x is not None else transformed
     new_var_names = categoricals + temp_var_names if temp_var_names is not None else categoricals
 
     # only keep columns in obs that were stored in obs only -> delete every encoded column from obs

--- a/tests/preprocessing/test_encoding.py
+++ b/tests/preprocessing/test_encoding.py
@@ -7,8 +7,18 @@ from ehrdata.core.constants import CATEGORICAL_TAG, DEFAULT_TEM_LAYER_NAME, FEAT
 from pandas import CategoricalDtype, DataFrame
 from pandas.testing import assert_frame_equal
 
+from ehrapy._compat import DaskArray
 from ehrapy.preprocessing._encoding import _reorder_encodings, encode
-from tests.conftest import TEST_DATA_PATH
+from tests.conftest import ARRAY_TYPES_NONNUMERIC, TEST_DATA_PATH, as_dense_dask_array
+
+
+def _convert_edata_arrays(edata, array_type):
+    """Wrap ``edata.X`` and ``edata.layers['layer_2']`` with ``array_type``."""
+    edata.X = array_type(edata.X)
+    if "layer_2" in edata.layers:
+        edata.layers["layer_2"] = array_type(edata.layers["layer_2"])
+    return edata
+
 
 CURRENT_DIR = Path(__file__).parent
 _TEST_PATH = f"{TEST_DATA_PATH}/encode"
@@ -36,12 +46,19 @@ def test_duplicate_column_encoding(encode_ds_1_edata, layer):
         )
 
 
+@pytest.mark.parametrize("array_type", ARRAY_TYPES_NONNUMERIC)
 @pytest.mark.parametrize("layer", [None, "layer_2"])
-def test_autodetect_encode(encode_ds_1_edata, layer):
+def test_autodetect_encode(encode_ds_1_edata, layer, array_type):
+    _convert_edata_arrays(encode_ds_1_edata, array_type)
     # break .X to ensure its not used
     if layer is not None:
         encode_ds_1_edata.X = None
     encoded_edata = encode(encode_ds_1_edata, autodetect=True, layer=layer)
+    encoded_X = encoded_edata.X if layer is None else encoded_edata.layers[layer]
+    # dask inputs must keep the encoded result lazy
+    if array_type is as_dense_dask_array:
+        assert isinstance(encoded_X, DaskArray)
+        assert isinstance(encoded_edata.layers["original"], DaskArray)
     assert list(encoded_edata.obs.columns) == ["survival", "clinic_day"]
     assert set(encoded_edata.var_names) == {
         "ehrapycat_survival_False",
@@ -124,11 +141,16 @@ def test_autodetect_num_only(capfd, encode_ds_2_edata, layer):
     assert id(encoded_edata) == id(encode_ds_2_edata)
 
 
+@pytest.mark.parametrize("array_type", ARRAY_TYPES_NONNUMERIC)
 @pytest.mark.parametrize("layer", [None, "layer_2"])
-def test_autodetect_custom_mode(encode_ds_1_edata, layer):
+def test_autodetect_custom_mode(encode_ds_1_edata, layer, array_type):
+    _convert_edata_arrays(encode_ds_1_edata, array_type)
     if layer is not None:
         encode_ds_1_edata.X = None
     encoded_edata = encode(encode_ds_1_edata, autodetect=True, encodings="label", layer=layer)
+    encoded_X = encoded_edata.X if layer is None else encoded_edata.layers[layer]
+    if array_type is as_dense_dask_array:
+        assert isinstance(encoded_X, DaskArray)
     assert list(encoded_edata.obs.columns) == ["survival", "clinic_day"]
     assert set(encoded_edata.var_names) == {
         "ehrapycat_survival",
@@ -191,8 +213,10 @@ def test_autodetect_encode_again(encode_ds_1_edata, layer):
     assert id(encoded_edata_again) == id(encoded_edata)
 
 
+@pytest.mark.parametrize("array_type", ARRAY_TYPES_NONNUMERIC)
 @pytest.mark.parametrize("layer", [None, "layer_2"])
-def test_custom_encode(encode_ds_1_edata, layer):
+def test_custom_encode(encode_ds_1_edata, layer, array_type):
+    _convert_edata_arrays(encode_ds_1_edata, array_type)
     if layer is not None:
         encode_ds_1_edata.X = None
     encoded_edata = encode(
@@ -202,6 +226,8 @@ def test_custom_encode(encode_ds_1_edata, layer):
         layer=layer,
     )
     X = encoded_edata.X if layer is None else encoded_edata.layers[layer]
+    if array_type is as_dense_dask_array:
+        assert isinstance(X, DaskArray)
     assert X.shape == (5, 8)
     assert list(encoded_edata.obs.columns) == ["survival", "clinic_day"]
     assert "ehrapycat_survival" in list(encoded_edata.var_names)
@@ -262,8 +288,10 @@ def test_custom_encode(encode_ds_1_edata, layer):
     assert isinstance(encoded_edata.obs["clinic_day"].dtype, CategoricalDtype)
 
 
+@pytest.mark.parametrize("array_type", ARRAY_TYPES_NONNUMERIC)
 @pytest.mark.parametrize("layer", [None, "layer_2"])
-def test_custom_encode_again_single_columns_encoding(encode_ds_1_edata, layer):
+def test_custom_encode_again_single_columns_encoding(encode_ds_1_edata, layer, array_type):
+    _convert_edata_arrays(encode_ds_1_edata, array_type)
     if layer is not None:
         encode_ds_1_edata.X = None
     encoded_edata = encode(
@@ -275,6 +303,8 @@ def test_custom_encode_again_single_columns_encoding(encode_ds_1_edata, layer):
     encoded_edata = encode(encoded_edata, autodetect=False, encodings={"label": ["clinic_day"]}, layer=layer)
 
     X = encoded_edata.X if layer is None else encoded_edata.layers[layer]
+    if array_type is as_dense_dask_array:
+        assert isinstance(X, DaskArray)
     assert X.shape == (5, 5)
     assert len(encoded_edata.obs.columns) == 2
     assert set(encoded_edata.obs.columns) == {"survival", "clinic_day"}
@@ -299,8 +329,10 @@ def test_custom_encode_again_single_columns_encoding(encode_ds_1_edata, layer):
     assert isinstance(encoded_edata.obs["clinic_day"].dtype, CategoricalDtype)
 
 
+@pytest.mark.parametrize("array_type", ARRAY_TYPES_NONNUMERIC)
 @pytest.mark.parametrize("layer", [None, "layer_2"])
-def test_custom_encode_again_multiple_columns_encoding(encode_ds_1_edata, layer):
+def test_custom_encode_again_multiple_columns_encoding(encode_ds_1_edata, layer, array_type):
+    _convert_edata_arrays(encode_ds_1_edata, array_type)
     if layer is not None:
         encode_ds_1_edata.X = None
     encoded_edata = encode(
@@ -314,6 +346,8 @@ def test_custom_encode_again_multiple_columns_encoding(encode_ds_1_edata, layer)
     )
 
     X = encoded_edata_again.X if layer is None else encoded_edata_again.layers[layer]
+    if array_type is as_dense_dask_array:
+        assert isinstance(X, DaskArray)
     assert X.shape == (5, 8)
     assert len(encoded_edata_again.obs.columns) == 2
     assert set(encoded_edata_again.obs.columns) == {"survival", "clinic_day"}

--- a/tests/preprocessing/test_encoding.py
+++ b/tests/preprocessing/test_encoding.py
@@ -39,8 +39,7 @@ def test_encode_3D_edata(edata_blob_small):
 def test_encode_3D_longitudinal_one_hot(edata_mini_3D_missing_values, array_type):
     """One-hot encode a 3D layer with categorical columns.
 
-    The encoder must fit on values stacked across time so the category space is shared,
-    the time axis is preserved, and ``obs`` stores the first-timepoint value.
+    The encoder must fit on values stacked across time so the category space is shared, the time axis is preserved, and ``obs`` stores the first-timepoint value.
     """
     edata = edata_mini_3D_missing_values
     layer = DEFAULT_TEM_LAYER_NAME

--- a/tests/preprocessing/test_encoding.py
+++ b/tests/preprocessing/test_encoding.py
@@ -26,8 +26,58 @@ _TEST_PATH = f"{TEST_DATA_PATH}/encode"
 
 def test_encode_3D_edata(edata_blob_small):
     encode(edata_blob_small, autodetect=True, layer="layer_2")
-    with pytest.raises(ValueError, match=r"only supports 2D data"):
-        encode(edata_blob_small, autodetect=True, layer=DEFAULT_TEM_LAYER_NAME)
+    # 3D longitudinal layers are now supported; the encoded layer keeps its time axis.
+    n_time = edata_blob_small.layers[DEFAULT_TEM_LAYER_NAME].shape[2]
+    encoded = encode(edata_blob_small, autodetect=True, layer=DEFAULT_TEM_LAYER_NAME)
+    encoded_layer = encoded.layers[DEFAULT_TEM_LAYER_NAME]
+    assert encoded_layer.ndim == 3
+    assert encoded_layer.shape[0] == edata_blob_small.n_obs
+    assert encoded_layer.shape[2] == n_time
+
+
+@pytest.mark.parametrize("array_type", ARRAY_TYPES_NONNUMERIC)
+def test_encode_3D_longitudinal_one_hot(edata_mini_3D_missing_values, array_type):
+    """One-hot encode a 3D layer with categorical columns.
+
+    The encoder must fit on values stacked across time so the category space is shared,
+    the time axis is preserved, and ``obs`` stores the first-timepoint value.
+    """
+    edata = edata_mini_3D_missing_values
+    layer = DEFAULT_TEM_LAYER_NAME
+    n_obs, n_vars, n_time = edata.layers[layer].shape
+    edata.var_names = ["n1", "n2", "n3", "n4", "letter", "yn"]
+
+    edata.layers[layer] = array_type(edata.layers[layer])
+
+    encoded = encode(edata, autodetect=False, encodings={"one-hot": ["letter", "yn"]}, layer=layer)
+
+    encoded_layer = encoded.layers[layer]
+    if array_type is as_dense_dask_array:
+        assert isinstance(encoded_layer, DaskArray)
+        assert isinstance(encoded.layers["original"], DaskArray)
+
+    assert encoded_layer.ndim == 3
+    assert encoded_layer.shape[0] == n_obs
+    assert encoded_layer.shape[2] == n_time
+    # one-hot expansion: letter (A, B, nan) + yn (Yes, No, nan) replaces 2 cols, adds 6.
+    assert encoded_layer.shape[1] == n_vars - 2 + 6
+
+    # obs holds the first-timepoint value for each encoded categorical.
+    assert list(encoded.obs["letter"]) == ["A", "A", None, "B"] or list(encoded.obs["letter"]) == [
+        "A",
+        "A",
+        np.nan,
+        "B",
+    ]
+    assert list(encoded.obs["yn"]) == ["Yes", "Yes", "Yes", "Yes"]
+
+
+def test_encode_3D_reencode_not_supported(edata_mini_3D_missing_values):
+    edata = edata_mini_3D_missing_values
+    edata.var_names = ["n1", "n2", "n3", "n4", "letter", "yn"]
+    encoded = encode(edata, autodetect=False, encodings={"one-hot": ["letter", "yn"]}, layer=DEFAULT_TEM_LAYER_NAME)
+    with pytest.raises(NotImplementedError, match="Re-encoding 3D"):
+        encode(encoded, autodetect=False, encodings={"label": ["letter"]}, layer=DEFAULT_TEM_LAYER_NAME)
 
 
 def test_unknown_encode_mode(encode_ds_1_edata):

--- a/tests/preprocessing/test_quality_control.py
+++ b/tests/preprocessing/test_quality_control.py
@@ -233,9 +233,11 @@ def test_obs_qc_metrics_array_types(array_type, expected_error):
             _compute_obs_metrics(mtx, edata)
 
 
-def test_obs_nan_qc_metrics():
+@pytest.mark.parametrize("array_type", ARRAY_TYPES_NONNUMERIC)
+def test_obs_nan_qc_metrics(array_type):
     edata = read_csv(f"{_TEST_PATH_ENCODE}/dataset1.csv")
     edata.X[0][4] = np.nan
+    edata.X = array_type(edata.X)
     edata2 = encode(edata, encodings={"one-hot": ["clinic_day"]})
     mtx = edata2.X
     obs_metrics = _compute_obs_metrics(mtx, edata2)
@@ -259,17 +261,21 @@ def test_var_qc_metrics_array_types(array_type, expected_error):
             _compute_var_metrics(mtx, edata)
 
 
-def test_var_encoding_mode_does_not_modify_original_matrix():
+@pytest.mark.parametrize("array_type", ARRAY_TYPES_NONNUMERIC)
+def test_var_encoding_mode_does_not_modify_original_matrix(array_type):
     edata = read_csv(f"{_TEST_PATH_ENCODE}/dataset1.csv")
+    edata.X = array_type(edata.X)
     edata2 = encode(edata, encodings={"one-hot": ["clinic_day"]})
-    mtx_copy = edata2.X.copy()
+    mtx_before = np.asarray(edata2.X).copy()
     _compute_var_metrics(edata2.X, edata2)
-    assert np.array_equal(mtx_copy, edata2.X)
+    assert np.array_equal(mtx_before, np.asarray(edata2.X))
 
 
-def test_var_nan_qc_metrics():
+@pytest.mark.parametrize("array_type", ARRAY_TYPES_NONNUMERIC)
+def test_var_nan_qc_metrics(array_type):
     edata = read_csv(f"{_TEST_PATH_ENCODE}/dataset1.csv")
     edata.X[0][4] = np.nan
+    edata.X = array_type(edata.X)
     edata2 = encode(edata, encodings={"one-hot": ["clinic_day"]})
     mtx = edata2.X
     var_metrics = _compute_var_metrics(mtx, edata2)


### PR DESCRIPTION
Closes #873.

`ep.pp.encode` now accepts dask arrays and 3D longitudinal layers.

- **Dask:** Three internal array-assembly helpers (`_delete_columns`, `_prepend_columns`, `_append_columns`) are now `@singledispatch` with `np.ndarray` and `DaskArray` registrations, matching the pattern in `_normalization.py`, `_missing_data.py`, and `_imputation.py`. The dask path uses `da.concatenate` and lazy fancy indexing, so `.X` and `layers["original"]` stay lazy dask arrays end-to-end.
- **3D longitudinal:** `encode` dispatches on `X.ndim`. The 3D path reshapes `(n_obs, n_vars, n_time)` → `(n_obs·n_time, n_vars)` in patient-major order, runs the existing 2D pipeline on a temporary `EHRData` with obs repeated per timepoint, then reshapes the encoded result and the `original` layer back to 3D. The encoder fits on values stacked across time so the category space is shared across timepoints. `obs` stores the first-timepoint value of each encoded categorical. Re-encoding a previously-encoded 3D `EHRData` raises `NotImplementedError` (per-timepoint variation is not preserved after the first encoding).
- **Tests:** parametrized the main encode tests and the three quality_control tests that use encode over `ARRAY_TYPES_NONNUMERIC`. Added two 3D-specific tests for the longitudinal path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)