### PR TITLE
Unpin numpy in run_notebooks workflow

### DIFF
--- a/.github/workflows/run_notebooks.yml
+++ b/.github/workflows/run_notebooks.yml
@@ -43,7 +43,7 @@ jobs:
               run: sudo apt-get install -y libopenblas-dev
 
             - name: Install ehrapy and additional dependencies
-              run: uv pip install '.[leiden]' 'cellrank[scvelo]' 'numpy>=2.3.2,<2.4' nbconvert ipykernel graphviz pypots fairlearn # numpy pin, upstream: https://github.com/scverse/cellrank/issues/1365
+              run: uv pip install '.[leiden]' 'cellrank[scvelo]' nbconvert ipykernel graphviz pypots fairlearn
 
             - name: Install ehrdata from submodule
               run: uv pip install --reinstall --no-deps -e submodules/ehrdata


### PR DESCRIPTION
## Unpin numpy in the `run_notebooks` workflow

Removes the temporary `'numpy>=2.3.2,<2.4'` pin (and its trailing comment) from the notebook-execution step in `.github/workflows/run_notebooks.yml`.

The pin was added as a workaround for a CellRank incompatibility with numpy >= 2.4 (upstream: scverse/cellrank#1365). CellRank has since released a compatible version, so the constraint is no longer needed.

Follow-up to the review note in https://github.com/theislab/ehrapy/pull/1081#discussion_r3473117528 ("Pin can be removed. Cellrank got a release.").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAw5BNXMpa4xRmPq47A165
