### PR TITLE
Fix mcar_test crash on 3D data with a single timepoint

### DIFF
--- a/ehrapy/preprocessing/_quality_control.py
+++ b/ehrapy/preprocessing/_quality_control.py
@@ -683,9 +683,11 @@ def mcar_test(
         ...     n_observations=100, n_variables=5, missing_values=0.1, random_state=0, n_centers=1, base_timepoints=1
         ... )
         >>> ep.pp.mcar_test(edata)
-        0.327...
+        0.1416...
     """
     mtx = edata.X if layer is None else edata.layers[layer]
+    if mtx.ndim == 3:
+        mtx = mtx[:, :, 0]
 
     # float64 required: covariance estimation and linear solves need stable floating-point math
     if mtx.dtype != np.float64:

--- a/ehrapy/preprocessing/_quality_control.py
+++ b/ehrapy/preprocessing/_quality_control.py
@@ -686,6 +686,8 @@ def mcar_test(
         0.1416...
     """
     mtx = edata.X if layer is None else edata.layers[layer]
+
+    # sequeeze the array if input is inherently 2D (only 1 timepoint of shape (x,y,1)), 3D already checked by @function_2D_only()
     if mtx.ndim == 3:
         mtx = mtx[:, :, 0]
 

--- a/tests/preprocessing/test_quality_control.py
+++ b/tests/preprocessing/test_quality_control.py
@@ -488,6 +488,11 @@ def test_mcar_identification(mcar_edata):
     assert p_value > 0.05
 
 
+def test_mcar_test_multi_timepoint_3d_raises(mcar_edata):
+    with pytest.raises(ValueError, match="only supports 2D data"):
+        mcar_test(mcar_edata, layer=DEFAULT_TEM_LAYER_NAME)
+
+
 def test_mcar_test_ttest_detects_mar(mar_edata):
     result = mcar_test(mar_edata, method="ttest")
     assert result.shape == (mar_edata.n_vars, mar_edata.n_vars)


### PR DESCRIPTION
Fixes #1104
- squeeze the trailing single time axis after resolving `mtx`, mirroring what `function_2D_only()` already tolerates
- updated the docstring's expected output, which changes as a result
