### PR TITLE
fix(mcp): resolve demo data read-only error, server hangs, and cache-bridge guidance

### DIFF
--- a/.github/actions/mcp-handshake-check/action.yml
+++ b/.github/actions/mcp-handshake-check/action.yml
@@ -1,0 +1,78 @@
+name: MCP handshake check
+description: >
+  Install the wheel in dist/ with the mcp extra into a clean venv, then verify the packaged
+  server actually speaks MCP over stdio (list tools, load a demo dataset, run a preprocessing
+  call, read it back, ingest a CSV). Requires `uv build` to have already produced dist/*.whl.
+
+runs:
+  using: composite
+  steps:
+    - name: Install built wheel with the mcp extra
+      shell: bash -euo pipefail {0}
+      run: |
+        uv venv /tmp/mcp-check-venv
+        uv pip install --python /tmp/mcp-check-venv/bin/python "$(ls dist/*.whl)[mcp]"
+
+    - name: Run handshake
+      shell: bash -euo pipefail {0}
+      env:
+        EHRDATA_DOWNLOAD_MAX_RETRIES: "5"
+        EHRDATA_DOWNLOAD_RETRY_DELAY: "10"
+      run: |
+        /tmp/mcp-check-venv/bin/python - <<'PY'
+        import asyncio
+        import sys
+        import tempfile
+        from pathlib import Path
+
+        from fastmcp import Client
+        from fastmcp.client.transports import StdioTransport
+
+
+        async def main() -> None:
+            transport = StdioTransport(command=sys.executable, args=["-m", "ehrapy.mcp.server"])
+            async with Client(transport=transport) as client:
+                tools = await client.list_tools()
+                print(f"tools: {len(tools)}")
+
+                guide = (await client.call_tool("get_workflow_guide", {})).content[0].text
+                assert "run_preprocessing" in guide
+                print("get_workflow_guide: ok")
+
+                demo = (await client.call_tool("load_demo_dataset", {"dataset": "mimic_2"})).structured_content
+                edata_id = demo["edata_id"]
+                print(f"load_demo_dataset: ok ({edata_id})")
+
+                qc = (
+                    await client.call_tool(
+                        "run_preprocessing",
+                        {"function": "qc_metrics", "edata_id": edata_id, "params": {"qc_vars": []}},
+                    )
+                ).structured_content
+                assert qc["status"] == "ok"
+                print("run_preprocessing qc_metrics: ok")
+
+                obs = (
+                    await client.call_tool(
+                        "run_get",
+                        {"function": "obs_df", "edata_id": edata_id, "params": {"keys": ["age"]}},
+                    )
+                ).structured_content
+                assert obs["status"] == "ok"
+                print("run_get obs_df: ok")
+
+                with tempfile.TemporaryDirectory() as tmp:
+                    path = Path(tmp) / "patients.csv"
+                    path.write_text("patient_id,age,sex\np1,45,F\np2,62,M\n", encoding="utf-8")
+                    ing = (await client.call_tool("ingest_dataset", {"file_path": str(path)})).structured_content
+                    snap = (
+                        await client.call_tool("get_edata_snapshot", {"edata_id": ing["edata_id"]})
+                    ).structured_content
+                    assert snap["n_obs"] == 2
+                    print("ingest_dataset + snapshot: ok")
+
+            print("ALL_OK")
+
+
+        asyncio.run(main())
+        PY

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,3 +34,12 @@ jobs:
 
       - name: Check package
         run: uvx twine check --strict dist/*.whl
+
+      - name: Restore datasets cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ehrapy_data
+          key: ehrapy-data-tests-v1
+
+      - name: MCP handshake check
+        uses: ./.github/actions/mcp-handshake-check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,32 @@
-name: Release
+name: Release MCP Package
 
+# Krv-Labs fork: this fork does not publish to public PyPI (package name
+# collides with the real theislab/ehrapy). Instead, pushing a version tag
+# builds the wheel/sdist, verifies the installed ehrapy[mcp] extra actually
+# speaks MCP over stdio, and attaches the artifacts to a GitHub Release.
+# Consume from another project with:
+#   uv tool run --from "git+https://github.com/Krv-Labs/ehrapy.git@<tag>#egg=ehrapy[mcp]" ehrapy-mcp
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
 
 defaults:
   run:
     shell: bash -euo pipefail {0}
 
+permissions:
+  contents: write
+
 jobs:
   release:
-    name: Upload release to PyPI
+    name: Build, verify, and publish GitHub Release
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/ehrapy
-    permissions:
-      id-token: write
     steps:
       - uses: actions/checkout@v5
         with:
           filter: blob:none
-          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -30,5 +35,17 @@ jobs:
 
       - name: Build package
         run: uv build
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Restore datasets cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ehrapy_data
+          key: ehrapy-data-tests-v1
+
+      - name: MCP handshake check
+        uses: ./.github/actions/mcp-handshake-check
+
+      - name: Create GitHub Release with build artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${GITHUB_REF_NAME}" dist/* --generate-notes --title "${GITHUB_REF_NAME}"

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -1,9 +1,11 @@
 name: GPU tests
+# Krv-Labs fork: no cirun-aws-gpu self-hosted runner is provisioned here, so
+# this workflow can never actually pass on a pull_request -- it would just
+# show a permanent red "Triage" gate on every PR. Left as push-to-main only
+# (upstream's original scope) so this doesn't affect PR checks at all.
 on:
   push:
     branches: [main]
-  pull_request:
-    types: [labeled, opened, synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,8 @@ test2.ipynb
 test3.ipynb
 .vscode/launch.json
 .claude
+
+# Local dev environment (direnv) and uv lockfile — ehrapy is a library and does not
+# pin a lockfile; remove these entries if the fork decides to track uv.lock.
+.envrc
+uv.lock

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **Krv-Labs fork.** This is Krv Labs' fork of [theislab/ehrapy](https://github.com/theislab/ehrapy), used to develop and dogfood the `ehrapy.mcp` package ahead of an eventual upstream PR. Remove this notice when that happens.
+
 [![Build](https://github.com/theislab/ehrapy/actions/workflows/build.yml/badge.svg)](https://github.com/theislab/ehrapy/actions/workflows/build.yml)
 [![Codecov](https://codecov.io/gh/theislab/ehrapy/branch/master/graph/badge.svg)](https://codecov.io/gh/theislab/ehrapy)
 [![License](https://img.shields.io/github/license/theislab/ehrapy)](https://opensource.org/licenses/Apache2.0)

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,6 +20,7 @@ api/preprocessing_index
 api/tools_index
 api/plot_index
 api/settings_index
+api/mcp_index
 ```
 
 ```{eval-rst}

--- a/docs/api/mcp_index.md
+++ b/docs/api/mcp_index.md
@@ -1,0 +1,97 @@
+# MCP Server
+
+The `ehrapy` Model Context Protocol (MCP) server enables AI agents (Claude Desktop, Cursor, Gemini CLI, Goose, etc.) to perform exploratory electronic health record (EHR) data analysis safely and efficiently.
+
+Install with:
+
+```console
+pip install ehrapy[mcp]
+```
+
+Start with:
+
+```console
+ehrapy-mcp
+```
+
+## Tool Catalog (14 Tools)
+
+| Tool Name | Namespace / Kind | Annotations | Description |
+| --- | --- | --- | --- |
+| `get_workflow_guide` | Meta | `readOnlyHint=True` | Return structured guide for end-to-end EHR analysis workflows |
+| `get_runtime_context` | Meta | `readOnlyHint=True` | Return runtime status, active dataset handle, and loaded namespaces |
+| `list_ehrapy_functions` | Meta | `readOnlyHint=True` | List available functions in a namespace or across all namespaces |
+| `get_function_help` | Meta | `readOnlyHint=True` | Get parameter table, docstrings, choices, and synthetic example calls |
+| `ingest_dataset` | Ingestion | `readOnlyHint=False` | Read flat/wide/long CSV, TSV, or h5ad/h5ed files into a managed EHRData handle |
+| `export_edata` | Ingestion | `readOnlyHint=False` | Export an EHRData dataset to CSV, TSV, or h5ed on disk |
+| `get_edata_snapshot` | Inspection | `readOnlyHint=True` | Get lightweight overview (obs/var counts, columns, layers, uns keys) |
+| `fork_edata_handle` | Session | `readOnlyHint=False` | Fork an existing dataset handle for branching analysis |
+| `load_demo_dataset` | Demo | `readOnlyHint=False` | Load standard demo datasets (e.g., `mimic_2`) |
+| `run_preprocessing` | Dispatch | `readOnlyHint=False` | Dispatch to `ehrapy.preprocessing` (`ep.pp`) functions |
+| `run_analysis` | Dispatch | `readOnlyHint=False` | Dispatch to `ehrapy.tools` (`ep.tl`) analysis algorithms |
+| `run_get` | Dispatch | `readOnlyHint=True` | Query observations, variables, or differential results (`ep.get`) |
+| `run_plot` | Dispatch | `readOnlyHint=True` | Render quality control, clustering, survival, or embedding figures |
+| `run_io` | Dispatch | `readOnlyHint=False` | Read and write datasets with `ehrdata.io` |
+
+## Result Status Values
+
+Every tool returns dual-channel output: a small JSON envelope in `structured_content` and
+Markdown (plus any image) in `content`. The envelope's `status` field is one of:
+
+| `status` | Meaning |
+| --- | --- |
+| `ok` | The call succeeded. |
+| `ok_empty` | The call succeeded but returned no rows/columns; `agent_action` explains how to narrow or widen the query. |
+| `ok_no_figure` | A `run_plot` call succeeded but produced no renderable figure; `agent_action` explains what to fit or check first. |
+| `error` | The call failed. `error_code` names the failure class and `agent_action` gives the next step. |
+
+Failures always carry a specific `error_code` — `UNKNOWN_FUNCTION`, `UNKNOWN_NAMESPACE`,
+`UNKNOWN_ARGUMENT`, `EDATA_ID_UNKNOWN`, `NO_ACTIVE_DATASET`, `INVALID_INPUT`,
+`INVALID_VALUE`, `DEPENDENCY_MISSING`, `FILE_NOT_FOUND`, `HOST_PATH_NOT_VISIBLE`,
+`PATH_NOT_ALLOWED`, `READ_ONLY_MODE`, and so on — never a bare generic code.
+
+### Passing function arguments
+
+Function keyword arguments belong inside `params`. If they are passed at the top level
+instead, tools that accept a `params` dict fold them in and report the fold back via
+`folded_arguments`; tools without a `params` dict reject the call with `UNKNOWN_ARGUMENT`.
+
+### Plot rendering notes
+
+Most figures render through matplotlib. A few ehrapy plots return holoviews objects; these
+are exported by trying the matplotlib backend and then bokeh. `love_plot` currently renders
+only under bokeh, whose PNG export requires the optional `selenium` package — without it the
+call returns an `error` naming the missing dependency rather than reporting a false success.
+
+## Workflows & Prompts
+
+The MCP server provides 3 pre-built MCP Prompts for guiding agent workflows:
+
+- `ehrapy-explore`: Complete exploratory data analysis and quality control workflow.
+- `ehrapy-clustering`: Full unsupervised clustering, dimensionality reduction, and biomarker ranking.
+- `ehrapy-survival`: Kaplan-Meier and Cox proportional hazards survival analysis.
+
+## 3-Tier Result Serialization
+
+Tool outputs are returned as dual-channel `ToolResult` objects containing both human/LLM-readable Markdown `content` and typed `structured_content`:
+
+1. **Tier 1 (Pass-through):** Small tables (<= 2,500 chars) are rendered as complete Markdown tables.
+2. **Tier 2 (Column Profile):** Larger tables are summarized as column profiles (ranked by missingness, variance, and relevance).
+3. **Tier 3 (Row Samples):** Passing `response_format="detailed"` includes head, tail, and deterministic random samples.
+4. **Plots & Visualizations:** Matplotlib figures are automatically rendered to PNG and returned as multimodal image blocks alongside summary text.
+
+```{eval-rst}
+.. module:: ehrapy.mcp
+    :no-index:
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: mcp
+    :nosignatures:
+
+    mcp.main
+    mcp.catalog_summary
+    mcp.list_namespaces
+    mcp.list_functions
+```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Use {func}`ep.pp.miss_forest_impute <ehrapy.preprocessing.miss_forest_impute>` instead, which is MICE via {class}`~sklearn.impute.IterativeImputer` with a tree ensemble.
   For a LightGBM backend, pass `IterativeImputer(estimator=LGBMRegressor(...))` directly.
 
+### 🚀 Features
+
+* Add an optional FastMCP layer (`ehrapy.mcp`) that exposes the ehrapy API to agents via `ehrapy-mcp`
+
 ## v0.15.0
 <!--
 anndata 0.13.0 has been released and is now supported.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -29,6 +29,37 @@ To use `ehrapy.tools.leiden`, install the `leiden` extra (which pulls in `igraph
 pip install ehrapy[leiden]
 ```
 
+#### MCP server
+
+To expose ehrapy to MCP clients (Cursor, Claude Desktop, Gemini CLI, etc.), install the `mcp` extra:
+
+```console
+pip install ehrapy[mcp]
+```
+
+Then start the server with `ehrapy-mcp` or `python -m ehrapy.mcp`.
+
+##### Data at rest & Security
+
+The ehrapy MCP server operates with safe data-handling defaults:
+
+- **User-scoped Cache:** Datasets ingested or manipulated through MCP are persisted in a user-scoped cache directory (`platformdirs.user_cache_dir("ehrapy-mcp")`, e.g. `~/.cache/ehrapy-mcp` on Linux or `~/Library/Caches/ehrapy-mcp` on macOS).
+- **Filesystem Permissions:** The cache directory tree is strictly created with POSIX `0o700` permissions (readable and writable only by the owner).
+- **Plot Artifacts:** `run_plot` writes rendered PNGs to `<cache>/plots`. It is annotated `readOnlyHint: true` because it does not modify the dataset, but it is not free of side effects on disk.
+- **Filesystem Confinement:** Set `EHRAPY_MCP_ALLOWED_ROOTS` (colon-separated paths) to restrict file ingestion and export to specific directory trees. Any path traversal or access outside these roots will be rejected.
+- **Read-Only Mode:** Set `EHRAPY_MCP_READ_ONLY=1` to block agent-directed writes to the host filesystem — `export_edata` and `run_io(function="write_*")` are rejected with `READ_ONLY_MODE`.
+  This is *not* a no-disk-writes mode: the server still writes its own working state, namely cached datasets under the MCP cache directory (including patient-derived data loaded via `load_demo_dataset` or `ingest_dataset`) and rendered PNG artifacts under `<cache>/plots`. To constrain where that state lands, set `EHRAPY_MCP_CACHE_DIR`; to guarantee no writes at all, run the server on a read-only filesystem or an ephemeral container.
+- **In-Memory LRU Cache:** An LRU cache holds active dataset objects in memory (default capacity: 3 datasets, configurable via `EHRAPY_MCP_CACHE_ENTRIES`) to minimize disk I/O.
+- **Automatic TTL Purge:** Datasets older than a specified threshold (e.g. 7 days) can be automatically evicted from disk using the registry purge mechanism.
+
+| Environment Variable | Description | Default |
+| --- | --- | --- |
+| `EHRAPY_MCP_ALLOWED_ROOTS` | Colon-separated directory roots allowed for ingestion and export | *(unrestricted)* |
+| `EHRAPY_MCP_READ_ONLY` | Set to `1` or `true` to reject agent-directed exports and `write_*` I/O (the internal dataset/plot cache is still written) | `0` |
+| `EHRAPY_MCP_CACHE_DIR` | Custom path for the MCP dataset cache | Platform user cache dir |
+| `EHRAPY_MCP_CACHE_ENTRIES` | Maximum number of EHRData objects kept in memory LRU | `3` |
+| `EHRAPY_MCP_MAX_RESULT_CHARS` | Hard character cap for serialized Markdown results | `10000` |
+
 ## From sources
 
 The sources for ehrapy can be downloaded from the [Github repo].

--- a/ehrapy/__init__.py
+++ b/ehrapy/__init__.py
@@ -19,3 +19,12 @@ from ehrapy import preprocessing as pp
 from ehrapy import tools as tl
 from ehrapy._settings import settings
 from ehrapy.core.meta_information import print_versions
+
+
+def __getattr__(name: str):
+    """Lazy-load optional layers such as ``ehrapy.mcp``."""
+    if name == "mcp":
+        import importlib
+
+        return importlib.import_module("ehrapy.mcp")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/ehrapy/mcp/__init__.py
+++ b/ehrapy/mcp/__init__.py
@@ -1,0 +1,19 @@
+"""MCP server layer for ehrapy.
+
+Install the optional extra with ``pip install ehrapy[mcp]``.
+Start the server with ``ehrapy-mcp`` or ``python -m ehrapy.mcp``.
+"""
+
+from __future__ import annotations
+
+from ehrapy.mcp.catalog import catalog_summary, list_functions, list_namespaces
+
+
+def main() -> None:
+    """Run the ehrapy FastMCP server."""
+    from ehrapy.mcp.server import main as run_server
+
+    run_server()
+
+
+__all__ = ["catalog_summary", "list_functions", "list_namespaces", "main"]

--- a/ehrapy/mcp/__main__.py
+++ b/ehrapy/mcp/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for ``python -m ehrapy.mcp``."""
+
+from ehrapy.mcp.server import main
+
+if __name__ == "__main__":
+    main()

--- a/ehrapy/mcp/catalog.py
+++ b/ehrapy/mcp/catalog.py
@@ -1,0 +1,308 @@
+"""Catalog of dispatchable ehrapy / ehrdata functions."""
+
+from __future__ import annotations
+
+import inspect
+import re
+import typing
+from typing import TYPE_CHECKING, Any
+
+import docstring_parser
+import ehrdata.dt as ed_dt
+import ehrdata.io as ed_io
+
+import ehrapy as ep
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# scanpy-derived tools not listed in ep.tools.__all__
+_EXTRA_TOOLS = ("leiden", "dendrogram", "dpt", "paga", "ingest")
+
+# classes exported in __all__ but not invokable as functions
+_SKIP_TOOLS = frozenset({"CausalEstimate", "CohortTracker", "Literal"})
+
+# plot module imports many names; skip non-functions
+_SKIP_PLOT = frozenset({"Colormaps", "LinearSegmentedColormap", "hv"})
+
+
+def _plot_functions() -> list[str]:
+    names: list[str] = []
+    for name in dir(ep.plot):
+        if name.startswith("_") or name in _SKIP_PLOT:
+            continue
+        obj = getattr(ep.plot, name)
+        if inspect.isfunction(obj):
+            names.append(name)
+    return sorted(names)
+
+
+def _tools_functions() -> list[str]:
+    names = [n for n in ep.tools.__all__ if n not in _SKIP_TOOLS]
+    for extra in _EXTRA_TOOLS:
+        if extra not in names and hasattr(ep.tools, extra):
+            names.append(extra)
+    return sorted(names)
+
+
+NAMESPACES: dict[str, dict[str, Any]] = {
+    "preprocessing": {
+        "module": ep.preprocessing,
+        "functions": list(ep.preprocessing.__all__),
+        "kind": "edata",
+        "description": "Quality control, encoding, imputation, normalization, filtering, PCA, neighbors (ep.pp.*)",
+    },
+    "analysis": {
+        "module": ep.tools,
+        "functions": _tools_functions(),
+        "kind": "edata",
+        "description": "Analysis: survival, causal, embedding, clustering, feature ranking (ep.tl.*)",
+    },
+    "get": {
+        "module": ep.get,
+        "functions": list(ep.get.__all__),
+        "kind": "get",
+        "description": "Read obs/var tables and ranked feature results (ep.get.*)",
+    },
+    "plot": {
+        "module": ep.plot,
+        "functions": _plot_functions(),
+        "kind": "plot",
+        "description": "Visualization; renders PNG plots (ep.pl.*)",
+    },
+    "io": {
+        "module": ed_io,
+        "functions": [
+            "read_csv",
+            "read_h5ad",
+            "read_h5ed",
+            "read_zarr",
+            "from_pandas",
+            "write_h5ad",
+            "write_h5ed",
+            "write_zarr",
+            "to_pandas",
+        ],
+        "kind": "io",
+        "description": "Load/save EHRData from files (ehrdata.io.*)",
+    },
+    "demo": {
+        "module": ed_dt,
+        "functions": list(ed_dt.__all__),
+        "kind": "demo",
+        "description": "Built-in demo cohorts (ehrdata.dt.*)",
+    },
+}
+
+_NAMESPACE_ALIASES = {
+    "tools": "analysis",
+    "dt": "demo",
+}
+
+
+def _canonical_namespace(namespace: str) -> str:
+    return _NAMESPACE_ALIASES.get(namespace, namespace)
+
+
+def list_namespaces() -> list[str]:
+    """Return sorted dispatch namespace names."""
+    return sorted(NAMESPACES)
+
+
+def list_functions(namespace: str) -> list[str]:
+    """Return function names in a dispatch namespace."""
+    canonical = _canonical_namespace(namespace)
+    spec = NAMESPACES.get(canonical)
+    if spec is None:
+        raise KeyError(namespace)
+    return list(spec["functions"])
+
+
+def get_callable(namespace: str, function: str) -> Callable[..., Any]:
+    """Resolve a namespaced ehrapy/ehrdata callable."""
+    canonical = _canonical_namespace(namespace)
+    spec = NAMESPACES.get(canonical)
+    if spec is None:
+        raise KeyError(f"Unknown namespace '{namespace}'")
+    if function not in spec["functions"]:
+        raise KeyError(f"Unknown function '{function}' in namespace '{namespace}'")
+    return getattr(spec["module"], function)
+
+
+def get_namespace_kind(namespace: str) -> str:
+    """Return the dispatch kind for a namespace."""
+    canonical = _canonical_namespace(namespace)
+    return NAMESPACES[canonical]["kind"]
+
+
+def _extract_choices(param_name: str, ann: Any, desc: str | None) -> list[str] | None:
+    origin = typing.get_origin(ann)
+    if origin is typing.Literal:
+        return [str(a) for a in typing.get_args(ann)]
+    if hasattr(ann, "__args__"):
+        for arg in ann.__args__:
+            if typing.get_origin(arg) is typing.Literal:
+                return [str(a) for a in typing.get_args(arg)]
+    if desc:
+        if (
+            param_name in ("backend", "mode", "method", "metric", "flavor", "strategy", "how", "which")
+            or "choose from" in desc.lower()
+            or "one of" in desc.lower()
+        ):
+            quoted = re.findall(r"['\"]([a-zA-Z0-9_\-]+)['\"]", desc)
+            if quoted:
+                seen = set()
+                res = []
+                for q in quoted:
+                    if q not in seen and q not in ("None", "True", "False", "strategy"):
+                        seen.add(q)
+                        res.append(q)
+                if res:
+                    return res
+    return None
+
+
+def _synthesize_example_call(namespace: str, function: str, params: list[dict[str, Any]]) -> str:
+    canonical = _canonical_namespace(namespace)
+    if canonical == "demo":
+        return f"load_demo_dataset(dataset='{function}')"
+
+    tool_map = {
+        "preprocessing": "run_preprocessing",
+        "analysis": "run_analysis",
+        "get": "run_get",
+        "plot": "run_plot",
+        "io": "run_io",
+    }
+    tool_name = tool_map.get(canonical, "run_preprocessing")
+
+    sample_params: dict[str, Any] = {}
+    for p in params:
+        name = p["name"]
+        if name in ("edata", "copy", "kwargs", "inplace", "in_place"):
+            continue
+        if p.get("choices"):
+            sample_params[name] = p["choices"][0]
+        elif name in ("n_neighbours", "n_neighbors"):
+            sample_params[name] = 5
+        elif name == "keys":
+            sample_params[name] = ["age"]
+        elif name == "groupby":
+            sample_params[name] = "leiden"
+        elif name == "qc_vars":
+            sample_params[name] = []
+        elif len(sample_params) < 1 and "default" not in p:
+            sample_params[name] = "..."
+        if len(sample_params) >= 2:
+            break
+
+    if sample_params:
+        params_str = ", ".join(f"'{k}': {repr(v) if v != '...' else '...'}" for k, v in sample_params.items())
+        return f"{tool_name}(function='{function}', params={{{params_str}}})"
+    return f"{tool_name}(function='{function}')"
+
+
+def function_help(namespace: str, function: str) -> dict[str, Any]:
+    """Return signature metadata, numpydoc parameter descriptions, choices, and example call."""
+    canonical = _canonical_namespace(namespace)
+    fn = get_callable(canonical, function)
+    sig = inspect.signature(fn)
+    raw_doc = inspect.getdoc(fn) or ""
+
+    parsed = docstring_parser.parse(raw_doc)
+    doc_params = {p.arg_name: p.description for p in parsed.params if p.arg_name}
+
+    params_info: list[dict[str, Any]] = []
+    for name, param in sig.parameters.items():
+        entry: dict[str, Any] = {"name": name}
+        if param.default is not inspect.Parameter.empty:
+            entry["default"] = repr(param.default)
+        if param.annotation is not inspect.Parameter.empty:
+            entry["annotation"] = str(param.annotation)
+
+        desc = doc_params.get(name) or ""
+        # Clean up whitespace in description
+        desc_clean = " ".join(desc.split())
+        if desc_clean:
+            entry["description"] = desc_clean
+
+        choices = _extract_choices(name, param.annotation, desc)
+        if choices:
+            entry["choices"] = choices
+
+        params_info.append(entry)
+
+    # First example
+    example_text = ""
+    for ex in parsed.examples:
+        snippet = (ex.snippet or ex.description or "").strip()
+        if snippet:
+            example_text = snippet[:600]
+            break
+
+    example_call = _synthesize_example_call(canonical, function, params_info)
+    short_doc = (parsed.short_description or raw_doc.split("\n\n")[0])[:400]
+
+    return {
+        "namespace": canonical,
+        "function": function,
+        "kind": get_namespace_kind(canonical),
+        "parameters": params_info,
+        "short_description": short_doc,
+        "example_snippet": example_text,
+        "example_call": example_call,
+    }
+
+
+def function_help_markdown(namespace: str, function: str) -> str:
+    """Render function help as compact Markdown under 2,500 chars."""
+    info = function_help(namespace, function)
+    canonical = info["namespace"]
+    fn_name = info["function"]
+
+    lines: list[str] = []
+    lines.append(f"### `{canonical}.{fn_name}`")
+    if info.get("short_description"):
+        lines.append(f"{info['short_description']}\n")
+
+    lines.append("| Parameter | Type | Default | Choices | Description |")
+    lines.append("|---|---|---|---|---|")
+
+    for p in info["parameters"]:
+        p_name = p["name"]
+        p_type = p.get("annotation", "—")
+        if len(p_type) > 25:
+            p_type = p_type[:22] + "..."
+        p_default = p.get("default", "—")
+        p_choices = ", ".join(p["choices"]) if p.get("choices") else "—"
+        p_desc = p.get("description", "")
+        if len(p_desc) > 80:
+            p_desc = p_desc[:77] + "..."
+        # escape pipes
+        p_desc = p_desc.replace("|", "\\|")
+        lines.append(f"| `{p_name}` | {p_type} | {p_default} | {p_choices} | {p_desc} |")
+
+    if info.get("example_snippet"):
+        lines.append("\n**Example:**")
+        lines.append(f"```python\n{info['example_snippet']}\n```")
+
+    lines.append(f"\n**Example call:**\n`{info['example_call']}`")
+
+    md = "\n".join(lines)
+    if len(md) > 2500:
+        # Truncate descriptions if needed
+        md = md[:2450] + "\n... [Help truncated]"
+    return md
+
+
+def catalog_summary() -> dict[str, Any]:
+    """Summarize every dispatch namespace and its functions."""
+    return {
+        ns: {
+            "kind": spec["kind"],
+            "count": len(spec["functions"]),
+            "description": spec["description"],
+            "functions": spec["functions"],
+        }
+        for ns, spec in NAMESPACES.items()
+    }

--- a/ehrapy/mcp/catalog.py
+++ b/ehrapy/mcp/catalog.py
@@ -135,31 +135,44 @@ def get_namespace_kind(namespace: str) -> str:
     return NAMESPACES[canonical]["kind"]
 
 
-def _extract_choices(param_name: str, ann: Any, desc: str | None) -> list[str] | None:
-    origin = typing.get_origin(ann)
-    if origin is typing.Literal:
+def _literal_choices(ann: Any) -> list[str] | None:
+    """Return string choices if ``ann`` is (or wraps, e.g. via Optional/Union) a typing.Literal."""
+    if typing.get_origin(ann) is typing.Literal:
         return [str(a) for a in typing.get_args(ann)]
     if hasattr(ann, "__args__"):
         for arg in ann.__args__:
             if typing.get_origin(arg) is typing.Literal:
                 return [str(a) for a in typing.get_args(arg)]
-    if desc:
-        if (
-            param_name in ("backend", "mode", "method", "metric", "flavor", "strategy", "how", "which")
-            or "choose from" in desc.lower()
-            or "one of" in desc.lower()
-        ):
-            quoted = re.findall(r"['\"]([a-zA-Z0-9_\-]+)['\"]", desc)
-            if quoted:
-                seen = set()
-                res = []
-                for q in quoted:
-                    if q not in seen and q not in ("None", "True", "False", "strategy"):
-                        seen.add(q)
-                        res.append(q)
-                if res:
-                    return res
     return None
+
+
+_CHOICE_LIKE_PARAM_NAMES = frozenset({"backend", "mode", "method", "metric", "flavor", "strategy", "how", "which"})
+_CHOICE_STOPWORDS = frozenset({"None", "True", "False", "strategy"})
+
+
+def _looks_like_choice_param(param_name: str, desc: str) -> bool:
+    return param_name in _CHOICE_LIKE_PARAM_NAMES or "choose from" in desc.lower() or "one of" in desc.lower()
+
+
+def _quoted_choices(desc: str) -> list[str]:
+    """Extract unique quoted tokens from a docstring description, dropping known stopwords."""
+    seen: set[str] = set()
+    res: list[str] = []
+    for q in re.findall(r"['\"]([a-zA-Z0-9_\-]+)['\"]", desc):
+        if q not in seen and q not in _CHOICE_STOPWORDS:
+            seen.add(q)
+            res.append(q)
+    return res
+
+
+def _extract_choices(param_name: str, ann: Any, desc: str | None) -> list[str] | None:
+    """Infer valid choices for a parameter from its Literal annotation or docstring text."""
+    literal_choices = _literal_choices(ann)
+    if literal_choices is not None:
+        return literal_choices
+    if not desc or not _looks_like_choice_param(param_name, desc):
+        return None
+    return _quoted_choices(desc) or None
 
 
 def _synthesize_example_call(namespace: str, function: str, params: list[dict[str, Any]]) -> str:
@@ -202,6 +215,36 @@ def _synthesize_example_call(namespace: str, function: str, params: list[dict[st
     return f"{tool_name}(function='{function}')"
 
 
+def _param_info_entry(name: str, param: inspect.Parameter, doc_params: dict[str, str | None]) -> dict[str, Any]:
+    """Build the help-payload entry for a single function parameter."""
+    entry: dict[str, Any] = {"name": name}
+    if param.default is not inspect.Parameter.empty:
+        entry["default"] = repr(param.default)
+    if param.annotation is not inspect.Parameter.empty:
+        entry["annotation"] = str(param.annotation)
+
+    desc = doc_params.get(name) or ""
+    # Clean up whitespace in description
+    desc_clean = " ".join(desc.split())
+    if desc_clean:
+        entry["description"] = desc_clean
+
+    choices = _extract_choices(name, param.annotation, desc)
+    if choices:
+        entry["choices"] = choices
+
+    return entry
+
+
+def _first_example_snippet(parsed: Any) -> str:
+    """Return the first non-empty example snippet from a parsed docstring, or ''."""
+    for ex in parsed.examples:
+        snippet = (ex.snippet or ex.description or "").strip()
+        if snippet:
+            return snippet[:600]
+    return ""
+
+
 def function_help(namespace: str, function: str) -> dict[str, Any]:
     """Return signature metadata, numpydoc parameter descriptions, choices, and example call."""
     canonical = _canonical_namespace(namespace)
@@ -212,33 +255,7 @@ def function_help(namespace: str, function: str) -> dict[str, Any]:
     parsed = docstring_parser.parse(raw_doc)
     doc_params = {p.arg_name: p.description for p in parsed.params if p.arg_name}
 
-    params_info: list[dict[str, Any]] = []
-    for name, param in sig.parameters.items():
-        entry: dict[str, Any] = {"name": name}
-        if param.default is not inspect.Parameter.empty:
-            entry["default"] = repr(param.default)
-        if param.annotation is not inspect.Parameter.empty:
-            entry["annotation"] = str(param.annotation)
-
-        desc = doc_params.get(name) or ""
-        # Clean up whitespace in description
-        desc_clean = " ".join(desc.split())
-        if desc_clean:
-            entry["description"] = desc_clean
-
-        choices = _extract_choices(name, param.annotation, desc)
-        if choices:
-            entry["choices"] = choices
-
-        params_info.append(entry)
-
-    # First example
-    example_text = ""
-    for ex in parsed.examples:
-        snippet = (ex.snippet or ex.description or "").strip()
-        if snippet:
-            example_text = snippet[:600]
-            break
+    params_info = [_param_info_entry(name, param, doc_params) for name, param in sig.parameters.items()]
 
     example_call = _synthesize_example_call(canonical, function, params_info)
     short_doc = (parsed.short_description or raw_doc.split("\n\n")[0])[:400]
@@ -249,7 +266,7 @@ def function_help(namespace: str, function: str) -> dict[str, Any]:
         "kind": get_namespace_kind(canonical),
         "parameters": params_info,
         "short_description": short_doc,
-        "example_snippet": example_text,
+        "example_snippet": _first_example_snippet(parsed),
         "example_call": example_call,
     }
 

--- a/ehrapy/mcp/dispatch.py
+++ b/ehrapy/mcp/dispatch.py
@@ -25,7 +25,7 @@ from ehrapy.mcp.errors import (
     path_access_error,
     unknown_handle_error,
 )
-from ehrapy.mcp.policy import PathNotAllowedError, ReadOnlyModeError, check_path_allowed
+from ehrapy.mcp.policy import SecurityPolicyError, check_path_allowed
 from ehrapy.mcp.registry import registry
 from ehrapy.mcp.serialization import serialize_result
 from ehrapy.mcp.session import get_session
@@ -33,6 +33,8 @@ from ehrapy.mcp.steering import get_suggested_next
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from ehrapy.mcp.session import _EHRapySession
 
 SLOW_FUNCTIONS = frozenset(
     {
@@ -119,6 +121,32 @@ def clear_fitter_cache() -> None:
     _FITTER_CACHE.clear()
 
 
+def _resolve_plot_fitter(
+    edata: Any,
+    edata_id: str | None,
+    function: str,
+    bind_name: str,
+    source_fn: str,
+    required_attr: str | None,
+) -> Any:
+    """Resolve the fitted object a plot function should bind, raising if none is available."""
+    fitted = get_fitter(edata_id or "", source_fn)
+    if not _usable_fitter(fitted, required_attr) and hasattr(edata, "uns"):
+        # Fall back to a copy persisted in uns, but only if it is the fitted
+        # object rather than a summary table stored under the same key.
+        candidate = edata.uns.get(source_fn)
+        fitted = candidate if _usable_fitter(candidate, required_attr) else None
+    if not _usable_fitter(fitted, required_attr):
+        raise ValueError(
+            f"No fitted result available for plot '{function}'. "
+            f"Run run_analysis(function='{source_fn}', ...) on this handle first "
+            f"(re-run it if the dataset has been transformed since)."
+        )
+    if bind_name == "kmfs" and not isinstance(fitted, (list, tuple)):
+        fitted = [fitted]
+    return fitted
+
+
 def _build_call_params(
     fn: Callable[..., Any],
     edata: Any,
@@ -147,20 +175,7 @@ def _build_call_params(
     if kind == "plot" and function in _PLOT_FITTER_SOURCES:
         source_fn, bind_name, required_attr = _PLOT_FITTER_SOURCES[function]
         if bind_name in sig.parameters:
-            fitted = get_fitter(edata_id or "", source_fn)
-            if not _usable_fitter(fitted, required_attr) and hasattr(edata, "uns"):
-                # Fall back to a copy persisted in uns, but only if it is the fitted
-                # object rather than a summary table stored under the same key.
-                candidate = edata.uns.get(source_fn)
-                fitted = candidate if _usable_fitter(candidate, required_attr) else None
-            if not _usable_fitter(fitted, required_attr):
-                raise ValueError(
-                    f"No fitted result available for plot '{function}'. "
-                    f"Run run_analysis(function='{source_fn}', ...) on this handle first "
-                    f"(re-run it if the dataset has been transformed since)."
-                )
-            if bind_name == "kmfs" and not isinstance(fitted, (list, tuple)):
-                fitted = [fitted]
+            fitted = _resolve_plot_fitter(edata, edata_id, function, bind_name, source_fn, required_attr)
             return {bind_name: fitted, **params}
 
     return {first_param: edata, **params}
@@ -169,6 +184,470 @@ def _build_call_params(
 def _inject_edata(fn: Callable[..., Any], edata: Any, params: dict[str, Any], **kwargs: Any) -> Any:
     """Call ``fn`` with edata (or a fitted model) bound to its first parameter."""
     return fn(**_build_call_params(fn, edata, params, **kwargs))
+
+
+# --- Shared helpers for the dispatch branches below --------------------------------------
+#
+# Every branch assembles the same "suggested_next" affordance and a subset share path-policy
+# checks or provenance bookkeeping; factored out here so each branch reads as its own logic
+# rather than repeating this scaffolding.
+
+
+def _suggestion_lines(suggestions: list[dict[str, str]]) -> list[str]:
+    """Format suggested-next-call entries as markdown bullet lines."""
+    return [f"- `{s['call']}` — {s['reason']}" for s in suggestions]
+
+
+def _apply_suggestions(struct: dict[str, Any], suggestions: list[dict[str, str]]) -> None:
+    """Attach a ``suggested_next`` field to ``struct`` when suggestions exist."""
+    if suggestions:
+        struct["suggested_next"] = [s["call"] for s in suggestions]
+
+
+def _content_with_suggestions(content_payload: Any, suggestions: list[dict[str, str]]) -> str:
+    """Render a result payload as markdown text, appending suggested-next calls."""
+    md_content = content_payload if isinstance(content_payload, str) else "\n".join(str(c) for c in content_payload)
+    if suggestions:
+        md_content += "\n".join(["\n\n**Suggested next:**", *_suggestion_lines(suggestions)])
+    return md_content
+
+
+def _policy_error(tool_name: str, exc: SecurityPolicyError) -> ToolResult:
+    """Translate a path/read-only policy violation into an MCP error result."""
+    return mcp_error(tool_name, str(exc), error_code=exc.error_code, agent_action=exc.agent_action)
+
+
+def _resolve_path_param(params: dict[str, Any], *, for_write: bool, operation: str = "write") -> str | None:
+    """Resolve and rewrite a filename/path/file_path param against the path policy."""
+    raw = params.get("filename") or params.get("path") or params.get("file_path")
+    if raw:
+        checked = check_path_allowed(raw, for_write=for_write, operation=operation)
+        for k in ("filename", "path", "file_path"):
+            if k in params:
+                params[k] = str(checked)
+    return raw
+
+
+async def _report_progress_if_slow(
+    ctx: Context | None, function: str, *, progress: int, info: str | None = None
+) -> None:
+    """Report MCP progress for long-running functions; a no-op for fast ones or without a ctx."""
+    if ctx is None or function not in SLOW_FUNCTIONS:
+        return
+    try:
+        if info is not None:
+            await ctx.info(info)
+        await ctx.report_progress(progress=progress, total=100)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _record_op_log(edata: Any, namespace: str, function: str, params: dict[str, Any]) -> None:
+    """Append a provenance entry to edata.uns for this dispatched call (T19)."""
+    import json
+
+    ops = edata.uns.setdefault("ehrapy_mcp_ops", [])
+    ops.append(
+        json.dumps(
+            {
+                "namespace": namespace,
+                "function": function,
+                "params": {
+                    str(k): (v if isinstance(v, (int, float, str, bool, list)) else str(v)) for k, v in params.items()
+                },
+                "timestamp": time.time(),
+            }
+        )
+    )
+
+
+def _maybe_cache_fitter(handle: str, function: str, res: Any) -> None:
+    """Stamp a freshly produced fitter so a later plot call can bind it (see cache_fitter)."""
+    if res is not None and function in {src for src, _, _ in _PLOT_FITTER_SOURCES.values()}:
+        cache_fitter(handle, function, res)
+
+
+# --- Dispatch branches, one per namespace kind --------------------------------------------
+
+
+async def _dispatch_demo(
+    fn: Callable[..., Any],
+    namespace: str,
+    function: str,
+    params: dict[str, Any],
+    session: _EHRapySession,
+    tool_name: str,
+    ctx: Context | None,
+) -> ToolResult:
+    """Load a demo dataset and cache it under a new handle."""
+    try:
+        edata = fn(**params)
+        record = save_edata(edata, name=function, fmt="demo")
+        session.set_latest_edata_id(record.edata_id)
+
+        suggestions = get_suggested_next(namespace, function)
+        struct: dict[str, Any] = {
+            "status": "ok",
+            "edata_id": record.edata_id,
+            "name": record.name,
+            "n_obs": edata.n_obs,
+            "n_vars": edata.n_vars,
+            "namespace": namespace,
+            "function": function,
+        }
+        _apply_suggestions(struct, suggestions)
+
+        md_lines = [
+            f"### Loaded demo dataset `{function}`",
+            f"- **Handle (edata_id):** `{record.edata_id}`",
+            f"- **Observations:** {edata.n_obs}",
+            f"- **Variables:** {edata.n_vars}",
+        ]
+        if suggestions:
+            md_lines.extend(["", "**Suggested next:**", *_suggestion_lines(suggestions)])
+
+        await _report_progress_if_slow(ctx, function, progress=100)
+
+        return ToolResult(structured_content=struct, content="\n".join(md_lines))
+    except Exception as exc:  # noqa: BLE001
+        return mcp_error(
+            tool_name,
+            f"Failed to load demo dataset '{function}': {exc}",
+            error_code="DEMO_LOAD_ERROR",
+        )
+
+
+def _dispatch_io_read(
+    fn: Callable[..., Any],
+    namespace: str,
+    function: str,
+    params: dict[str, Any],
+    session: _EHRapySession,
+    tool_name: str,
+) -> ToolResult:
+    """Read a dataset from disk via a standalone IO function and cache it."""
+    try:
+        file_arg = _resolve_path_param(params, for_write=False)
+
+        edata = fn(**params)
+        name_stem = Path(file_arg).name if file_arg else function
+        record = save_edata(edata, name=name_stem, source_path=str(file_arg) if file_arg else None)
+        session.set_latest_edata_id(record.edata_id)
+
+        suggestions = get_suggested_next(namespace, function)
+        struct = {
+            "status": "ok",
+            "edata_id": record.edata_id,
+            "name": record.name,
+            "n_obs": edata.n_obs,
+            "n_vars": edata.n_vars,
+            "namespace": namespace,
+            "function": function,
+        }
+        _apply_suggestions(struct, suggestions)
+
+        md_lines = [
+            f"### Loaded dataset from `{file_arg or function}`",
+            f"- **Handle (edata_id):** `{record.edata_id}`",
+            f"- **Observations:** {edata.n_obs}",
+            f"- **Variables:** {edata.n_vars}",
+        ]
+        if suggestions:
+            md_lines.extend(["", "**Suggested next:**", *_suggestion_lines(suggestions)])
+
+        return ToolResult(structured_content=struct, content="\n".join(md_lines))
+    except SecurityPolicyError as exc:
+        return _policy_error(tool_name, exc)
+    except FileNotFoundError:
+        return path_access_error(tool_name, str(params.get("filename") or params.get("path") or ""))
+    except Exception as exc:  # noqa: BLE001
+        return classify_exception_error(
+            tool_name, exc, namespace=namespace, function=function, fallback_code="IO_READ_ERROR"
+        )
+
+
+def _dispatch_get(
+    fn: Callable[..., Any],
+    edata: Any,
+    handle: str,
+    used_latest: bool,
+    namespace: str,
+    function: str,
+    params: dict[str, Any],
+    response_format: Literal["concise", "detailed"],
+    tool_name: str,
+) -> ToolResult:
+    """Run a read-only ``get`` function against a cached dataset."""
+    try:
+        res = _inject_edata(fn, edata, params)
+        meta, content_payload = serialize_result(
+            res,
+            response_format=response_format,
+            params=params,
+            function=function,
+            edata=edata,
+        )
+        suggestions = get_suggested_next(namespace, function)
+
+        status_val = meta.get("status", "ok")
+        struct = {
+            "status": status_val,
+            "edata_id": handle,
+            "namespace": namespace,
+            "function": function,
+            **{k: v for k, v in meta.items() if k != "status"},
+        }
+        if used_latest:
+            struct["used_latest"] = True
+        _apply_suggestions(struct, suggestions)
+
+        md_content = _content_with_suggestions(content_payload, suggestions)
+
+        return ToolResult(structured_content=struct, content=md_content)
+    except Exception as exc:  # noqa: BLE001
+        return classify_exception_error(
+            tool_name, exc, namespace=namespace, function=function, fallback_code="GET_ERROR"
+        )
+
+
+def _inject_plot_defaults(sig: inspect.Signature, params: dict[str, Any]) -> None:
+    """Default a plot call to a non-interactive, figure-returning invocation."""
+    # Inject show=False if function accepts show
+    if "show" in sig.parameters and "show" not in params:
+        params["show"] = False
+    # Prefer an explicit figure handle over scraping plt.gcf() (origin fix #4).
+    if "return_fig" in sig.parameters and "return_fig" not in params:
+        params["return_fig"] = True
+
+
+def _dispatch_plot(
+    fn: Callable[..., Any],
+    edata: Any,
+    handle: str,
+    used_latest: bool,
+    namespace: str,
+    function: str,
+    params: dict[str, Any],
+    tool_name: str,
+) -> ToolResult:
+    """Run a plot function against a cached dataset and render the resulting figure."""
+    try:
+        _inject_plot_defaults(inspect.signature(fn), params)
+
+        plt.close("all")
+        res = _inject_edata(fn, edata, params, edata_id=handle, function=function, kind="plot")
+        if res is None and plt.get_fignums():
+            res = plt.gcf()
+
+        meta, content_payload = serialize_result(
+            res,
+            plots_dir=registry.plots_dir(),
+            params=params,
+            function=function,
+            edata=edata,
+        )
+        plt.close("all")
+
+        suggestions = get_suggested_next(namespace, function)
+        rendered = meta.get("type") == "figure"
+        struct = {
+            "status": "ok" if rendered else "ok_no_figure",
+            "edata_id": handle,
+            "namespace": namespace,
+            "function": function,
+            **meta,
+        }
+        if not rendered:
+            # A plot call that produced no image previously reported a bare "ok",
+            # leaving the agent to assume a figure existed.
+            struct["agent_action"] = (
+                f"'{function}' returned {meta.get('type', 'no renderable figure')} rather than a figure. "
+                "Check that the required inputs were fitted first, or call "
+                f"get_function_help(namespace='{namespace}', function='{function}')."
+            )
+        if used_latest:
+            struct["used_latest"] = True
+        _apply_suggestions(struct, suggestions)
+
+        content_blocks: list[Any] = list(content_payload) if isinstance(content_payload, list) else [content_payload]
+        if suggestions:
+            content_blocks.append("\n".join(["\n\n**Suggested next:**", *_suggestion_lines(suggestions)]))
+
+        return ToolResult(structured_content=struct, content=content_blocks)
+    except Exception as exc:  # noqa: BLE001
+        plt.close("all")
+        return classify_exception_error(
+            tool_name, exc, namespace=namespace, function=function, fallback_code="PLOT_ERROR"
+        )
+
+
+def _dispatch_to_pandas(
+    fn: Callable[..., Any],
+    edata: Any,
+    handle: str,
+    used_latest: bool,
+    namespace: str,
+    function: str,
+    params: dict[str, Any],
+    response_format: Literal["concise", "detailed"],
+) -> ToolResult:
+    """Convert a cached dataset to a pandas DataFrame and serialize it."""
+    df = fn(edata, **params)
+    meta, content_payload = serialize_result(
+        df,
+        response_format=response_format,
+        params=params,
+        function=function,
+        edata=edata,
+    )
+    struct = {
+        "status": "ok",
+        "edata_id": handle,
+        "namespace": namespace,
+        "function": function,
+        **meta,
+    }
+    if used_latest:
+        struct["used_latest"] = True
+    return ToolResult(
+        structured_content=struct,
+        content=(content_payload if isinstance(content_payload, str) else str(content_payload)),
+    )
+
+
+def _dispatch_io_write(
+    fn: Callable[..., Any],
+    edata: Any,
+    handle: str,
+    used_latest: bool,
+    namespace: str,
+    function: str,
+    params: dict[str, Any],
+    response_format: Literal["concise", "detailed"],
+    tool_name: str,
+) -> ToolResult:
+    """Run an IO export/write function (or ``to_pandas``) against a cached dataset."""
+    try:
+        if function == "to_pandas":
+            return _dispatch_to_pandas(fn, edata, handle, used_latest, namespace, function, params, response_format)
+
+        # write functions
+        target_path = _resolve_path_param(params, for_write=True, operation=function)
+        fn(edata, **params)
+        struct = {
+            "status": "ok",
+            "edata_id": handle,
+            "namespace": namespace,
+            "function": function,
+            "target_path": str(target_path) if target_path else None,
+        }
+        if used_latest:
+            struct["used_latest"] = True
+        md = f"Dataset `{handle}` successfully exported to `{target_path}`."
+        return ToolResult(structured_content=struct, content=md)
+    except SecurityPolicyError as exc:
+        return _policy_error(tool_name, exc)
+    except Exception as exc:  # noqa: BLE001
+        return classify_exception_error(
+            tool_name, exc, namespace=namespace, function=function, fallback_code="IO_ERROR"
+        )
+
+
+async def _dispatch_edata(
+    fn: Callable[..., Any],
+    edata: Any,
+    handle: str,
+    used_latest: bool,
+    kind: str,
+    namespace: str,
+    function: str,
+    params: dict[str, Any],
+    response_format: Literal["concise", "detailed"],
+    session: _EHRapySession,
+    tool_name: str,
+    ctx: Context | None,
+) -> ToolResult:
+    """Run a mutating preprocessing/analysis function and persist the result."""
+    try:
+        res = _inject_edata(fn, edata, params, edata_id=handle, function=function, kind=kind)
+        if hasattr(res, "n_obs") and hasattr(res, "n_vars"):
+            # Function returned a modified copy
+            edata = res
+
+        _record_op_log(edata, namespace, function, params)
+
+        # Persist dataset write-through
+        persist_edata(handle, edata)
+        session.set_latest_edata_id(handle)
+
+        # Stamp the fitter with the post-write mtime, so it stays valid until the
+        # next transformation of this handle rather than invalidating immediately.
+        _maybe_cache_fitter(handle, function, res)
+
+        meta, content_payload = serialize_result(
+            res,
+            response_format=response_format,
+            params=params,
+            function=function,
+            edata=edata,
+        )
+        suggestions = get_suggested_next(namespace, function)
+
+        struct = {
+            "status": "ok",
+            "edata_id": handle,
+            "n_obs": edata.n_obs,
+            "n_vars": edata.n_vars,
+            "namespace": namespace,
+            "function": function,
+            **meta,
+        }
+        if used_latest:
+            struct["used_latest"] = True
+        _apply_suggestions(struct, suggestions)
+
+        md_content = _content_with_suggestions(content_payload, suggestions)
+
+        await _report_progress_if_slow(ctx, function, progress=100)
+
+        return ToolResult(structured_content=struct, content=md_content)
+    except TypeError as exc:
+        return mcp_error(
+            tool_name,
+            f"Invalid parameter for {namespace}.{function}: {exc}",
+            error_code="INVALID_PARAMETER",
+            agent_action=f"Call get_function_help(namespace='{namespace}', function='{function}') to inspect valid parameters.",
+        )
+    except ValueError as exc:
+        return mcp_error(
+            tool_name,
+            f"Value error in {namespace}.{function}: {exc}",
+            error_code="INVALID_VALUE",
+            agent_action=f"Inspect data or parameters for {namespace}.{function}.",
+        )
+    except Exception as exc:  # noqa: BLE001
+        return classify_exception_error(tool_name, exc, namespace=namespace, function=function)
+
+
+def _resolve_handle(edata_id: str | None, session: _EHRapySession) -> tuple[str | None, bool]:
+    """Return (handle, used_latest): the explicit handle, or the session's latest."""
+    if edata_id is not None:
+        return edata_id, False
+    return session.get_latest_edata_id(), True
+
+
+def _load_dispatch_edata(handle: str, tool_name: str) -> tuple[Any, ToolResult | None]:
+    """Load a cached dataset, returning (edata, None) or (None, error result)."""
+    try:
+        return load_edata(handle), None
+    except (KeyError, FileNotFoundError):
+        return None, unknown_handle_error(tool_name, "edata_id", handle)
+    except Exception as exc:  # noqa: BLE001
+        return None, mcp_error(
+            tool_name,
+            f"Failed to load dataset '{handle}': {exc}",
+            error_code="DATASET_LOAD_ERROR",
+        )
 
 
 async def run_dispatch(
@@ -185,13 +664,7 @@ async def run_dispatch(
     tool_name = f"run_{namespace}" if namespace != "demo" else "load_demo_dataset"
     session = get_session(ctx)
 
-    # Progress reporting for slow functions
-    if ctx is not None and function in SLOW_FUNCTIONS:
-        try:
-            await ctx.info(f"Starting {namespace}.{function}...")
-            await ctx.report_progress(progress=0, total=100)
-        except Exception:  # noqa: BLE001
-            pass
+    await _report_progress_if_slow(ctx, function, progress=0, info=f"Starting {namespace}.{function}...")
 
     # Resolve callable
     try:
@@ -207,118 +680,14 @@ async def run_dispatch(
 
     # 1. Demo datasets
     if kind == "demo":
-        try:
-            edata = fn(**params)
-            record = save_edata(edata, name=function, fmt="demo")
-            session.set_latest_edata_id(record.edata_id)
-
-            suggestions = get_suggested_next(namespace, function)
-            struct: dict[str, Any] = {
-                "status": "ok",
-                "edata_id": record.edata_id,
-                "name": record.name,
-                "n_obs": edata.n_obs,
-                "n_vars": edata.n_vars,
-                "namespace": namespace,
-                "function": function,
-            }
-            if suggestions:
-                struct["suggested_next"] = [s["call"] for s in suggestions]
-
-            md_lines = [
-                f"### Loaded demo dataset `{function}`",
-                f"- **Handle (edata_id):** `{record.edata_id}`",
-                f"- **Observations:** {edata.n_obs}",
-                f"- **Variables:** {edata.n_vars}",
-            ]
-            if suggestions:
-                md_lines.extend(["", "**Suggested next:**"])
-                for s in suggestions:
-                    md_lines.append(f"- `{s['call']}` — {s['reason']}")
-
-            if ctx is not None and function in SLOW_FUNCTIONS:
-                try:
-                    await ctx.report_progress(progress=100, total=100)
-                except Exception:  # noqa: BLE001
-                    pass
-
-            return ToolResult(structured_content=struct, content="\n".join(md_lines))
-        except Exception as exc:  # noqa: BLE001
-            return mcp_error(
-                tool_name,
-                f"Failed to load demo dataset '{function}': {exc}",
-                error_code="DEMO_LOAD_ERROR",
-            )
+        return await _dispatch_demo(fn, namespace, function, params, session, tool_name, ctx)
 
     # 2. IO read functions (standalone ingestion)
     if kind == "io" and function.startswith("read_"):
-        try:
-            file_arg = params.get("filename") or params.get("path") or params.get("file_path")
-            if file_arg:
-                checked_path = check_path_allowed(file_arg, for_write=False)
-                # Update param with resolved path string
-                for k in ("filename", "path", "file_path"):
-                    if k in params:
-                        params[k] = str(checked_path)
-
-            edata = fn(**params)
-            name_stem = Path(file_arg).name if file_arg else function
-            record = save_edata(edata, name=name_stem, source_path=str(file_arg) if file_arg else None)
-            session.set_latest_edata_id(record.edata_id)
-
-            suggestions = get_suggested_next(namespace, function)
-            struct = {
-                "status": "ok",
-                "edata_id": record.edata_id,
-                "name": record.name,
-                "n_obs": edata.n_obs,
-                "n_vars": edata.n_vars,
-                "namespace": namespace,
-                "function": function,
-            }
-            if suggestions:
-                struct["suggested_next"] = [s["call"] for s in suggestions]
-
-            md_lines = [
-                f"### Loaded dataset from `{file_arg or function}`",
-                f"- **Handle (edata_id):** `{record.edata_id}`",
-                f"- **Observations:** {edata.n_obs}",
-                f"- **Variables:** {edata.n_vars}",
-            ]
-            if suggestions:
-                md_lines.extend(["", "**Suggested next:**"])
-                for s in suggestions:
-                    md_lines.append(f"- `{s['call']}` — {s['reason']}")
-
-            return ToolResult(structured_content=struct, content="\n".join(md_lines))
-        except PathNotAllowedError as exc:
-            return mcp_error(
-                tool_name,
-                str(exc),
-                error_code=exc.error_code,
-                agent_action=exc.agent_action,
-            )
-        except ReadOnlyModeError as exc:
-            return mcp_error(
-                tool_name,
-                str(exc),
-                error_code=exc.error_code,
-                agent_action=exc.agent_action,
-            )
-        except FileNotFoundError:
-            return path_access_error(tool_name, str(params.get("filename") or params.get("path") or ""))
-        except Exception as exc:  # noqa: BLE001
-            return classify_exception_error(
-                tool_name, exc, namespace=namespace, function=function, fallback_code="IO_READ_ERROR"
-            )
+        return _dispatch_io_read(fn, namespace, function, params, session, tool_name)
 
     # For all other operations, resolve the active dataset handle
-    used_latest = False
-    handle = edata_id
-    if handle is None:
-        handle = session.get_latest_edata_id()
-        used_latest = True
-
+    handle, used_latest = _resolve_handle(edata_id, session)
     if handle is None:
         return mcp_error(
             tool_name,
@@ -327,282 +696,28 @@ async def run_dispatch(
             agent_action="Load a dataset with load_demo_dataset(dataset='mimic_2') or ingest_dataset(file_path=...).",
         )
 
-    # Load dataset
-    try:
-        edata = load_edata(handle)
-    except (KeyError, FileNotFoundError):
-        return unknown_handle_error(tool_name, "edata_id", handle)
-    except Exception as exc:  # noqa: BLE001
-        return mcp_error(
-            tool_name,
-            f"Failed to load dataset '{handle}': {exc}",
-            error_code="DATASET_LOAD_ERROR",
-        )
+    edata, error = _load_dispatch_edata(handle, tool_name)
+    if error is not None:
+        return error
 
     # 3. Read-Only get namespace (T1)
     if kind == "get":
-        try:
-            res = _inject_edata(fn, edata, params)
-            meta, content_payload = serialize_result(
-                res,
-                response_format=response_format,
-                params=params,
-                function=function,
-                edata=edata,
-            )
-            suggestions = get_suggested_next(namespace, function)
-
-            status_val = meta.get("status", "ok")
-            struct = {
-                "status": status_val,
-                "edata_id": handle,
-                "namespace": namespace,
-                "function": function,
-                **{k: v for k, v in meta.items() if k != "status"},
-            }
-            if used_latest:
-                struct["used_latest"] = True
-            if suggestions:
-                struct["suggested_next"] = [s["call"] for s in suggestions]
-
-            md_content = (
-                content_payload if isinstance(content_payload, str) else "\n".join(str(c) for c in content_payload)
-            )
-            if suggestions:
-                sug_lines = ["\n\n**Suggested next:**"]
-                for s in suggestions:
-                    sug_lines.append(f"- `{s['call']}` — {s['reason']}")
-                md_content += "\n".join(sug_lines)
-
-            return ToolResult(structured_content=struct, content=md_content)
-        except Exception as exc:  # noqa: BLE001
-            return classify_exception_error(
-                tool_name, exc, namespace=namespace, function=function, fallback_code="GET_ERROR"
-            )
+        return _dispatch_get(fn, edata, handle, used_latest, namespace, function, params, response_format, tool_name)
 
     # 4. Plot namespace (T10)
     if kind == "plot":
-        try:
-            # Inject show=False if function accepts show
-            sig = inspect.signature(fn)
-            if "show" in sig.parameters and "show" not in params:
-                params["show"] = False
-            # Prefer an explicit figure handle over scraping plt.gcf() (origin fix #4).
-            if "return_fig" in sig.parameters and "return_fig" not in params:
-                params["return_fig"] = True
-
-            plt.close("all")
-            res = _inject_edata(fn, edata, params, edata_id=handle, function=function, kind="plot")
-            if res is None and plt.get_fignums():
-                res = plt.gcf()
-
-            meta, content_payload = serialize_result(
-                res,
-                plots_dir=registry.plots_dir(),
-                params=params,
-                function=function,
-                edata=edata,
-            )
-            plt.close("all")
-
-            suggestions = get_suggested_next(namespace, function)
-            rendered = meta.get("type") == "figure"
-            struct = {
-                "status": "ok" if rendered else "ok_no_figure",
-                "edata_id": handle,
-                "namespace": namespace,
-                "function": function,
-                **meta,
-            }
-            if not rendered:
-                # A plot call that produced no image previously reported a bare "ok",
-                # leaving the agent to assume a figure existed.
-                struct["agent_action"] = (
-                    f"'{function}' returned {meta.get('type', 'no renderable figure')} rather than a figure. "
-                    "Check that the required inputs were fitted first, or call "
-                    f"get_function_help(namespace='{namespace}', function='{function}')."
-                )
-
-            if used_latest:
-                struct["used_latest"] = True
-            if suggestions:
-                struct["suggested_next"] = [s["call"] for s in suggestions]
-
-            # Build ToolResult content blocks
-            content_blocks: list[Any] = []
-            if isinstance(content_payload, list):
-                for item in content_payload:
-                    content_blocks.append(item)
-            else:
-                content_blocks.append(content_payload)
-
-            if suggestions:
-                sug_lines = ["\n\n**Suggested next:**"]
-                for s in suggestions:
-                    sug_lines.append(f"- `{s['call']}` — {s['reason']}")
-                content_blocks.append("\n".join(sug_lines))
-
-            return ToolResult(structured_content=struct, content=content_blocks)
-        except Exception as exc:  # noqa: BLE001
-            plt.close("all")
-            return classify_exception_error(
-                tool_name, exc, namespace=namespace, function=function, fallback_code="PLOT_ERROR"
-            )
+        return _dispatch_plot(fn, edata, handle, used_latest, namespace, function, params, tool_name)
 
     # 5. IO write / export / to_pandas functions
     if kind == "io":
-        try:
-            if function == "to_pandas":
-                df = fn(edata, **params)
-                meta, content_payload = serialize_result(
-                    df,
-                    response_format=response_format,
-                    params=params,
-                    function=function,
-                    edata=edata,
-                )
-                struct = {
-                    "status": "ok",
-                    "edata_id": handle,
-                    "namespace": namespace,
-                    "function": function,
-                    **meta,
-                }
-                if used_latest:
-                    struct["used_latest"] = True
-                return ToolResult(
-                    structured_content=struct,
-                    content=(content_payload if isinstance(content_payload, str) else str(content_payload)),
-                )
-
-            # write functions
-            target_path = params.get("filename") or params.get("path") or params.get("file_path")
-            if target_path:
-                checked_path = check_path_allowed(target_path, for_write=True, operation=function)
-                for k in ("filename", "path", "file_path"):
-                    if k in params:
-                        params[k] = str(checked_path)
-
-            fn(edata, **params)
-            struct = {
-                "status": "ok",
-                "edata_id": handle,
-                "namespace": namespace,
-                "function": function,
-                "target_path": str(target_path) if target_path else None,
-            }
-            if used_latest:
-                struct["used_latest"] = True
-            md = f"Dataset `{handle}` successfully exported to `{target_path}`."
-            return ToolResult(structured_content=struct, content=md)
-        except PathNotAllowedError as exc:
-            return mcp_error(
-                tool_name,
-                str(exc),
-                error_code=exc.error_code,
-                agent_action=exc.agent_action,
-            )
-        except ReadOnlyModeError as exc:
-            return mcp_error(
-                tool_name,
-                str(exc),
-                error_code=exc.error_code,
-                agent_action=exc.agent_action,
-            )
-        except Exception as exc:  # noqa: BLE001
-            return classify_exception_error(
-                tool_name, exc, namespace=namespace, function=function, fallback_code="IO_ERROR"
-            )
+        return _dispatch_io_write(
+            fn, edata, handle, used_latest, namespace, function, params, response_format, tool_name
+        )
 
     # 6. Mutating edata namespaces (preprocessing & analysis)
     if kind == "edata":
-        try:
-            res = _inject_edata(fn, edata, params, edata_id=handle, function=function, kind=kind)
-            if hasattr(res, "n_obs") and hasattr(res, "n_vars"):
-                # Function returned a modified copy
-                edata = res
-
-            # Op-log provenance tracking (T19)
-            import json
-
-            ops = edata.uns.setdefault("ehrapy_mcp_ops", [])
-            ops.append(
-                json.dumps(
-                    {
-                        "namespace": namespace,
-                        "function": function,
-                        "params": {
-                            str(k): (v if isinstance(v, (int, float, str, bool, list)) else str(v))
-                            for k, v in params.items()
-                        },
-                        "timestamp": time.time(),
-                    }
-                )
-            )
-
-            # Persist dataset write-through
-            persist_edata(handle, edata)
-            session.set_latest_edata_id(handle)
-
-            # Stamp the fitter with the post-write mtime, so it stays valid until the
-            # next transformation of this handle rather than invalidating immediately.
-            if res is not None and function in {src for src, _, _ in _PLOT_FITTER_SOURCES.values()}:
-                cache_fitter(handle, function, res)
-
-            meta, content_payload = serialize_result(
-                res,
-                response_format=response_format,
-                params=params,
-                function=function,
-                edata=edata,
-            )
-            suggestions = get_suggested_next(namespace, function)
-
-            struct = {
-                "status": "ok",
-                "edata_id": handle,
-                "n_obs": edata.n_obs,
-                "n_vars": edata.n_vars,
-                "namespace": namespace,
-                "function": function,
-                **meta,
-            }
-            if used_latest:
-                struct["used_latest"] = True
-            if suggestions:
-                struct["suggested_next"] = [s["call"] for s in suggestions]
-
-            md_content = (
-                content_payload if isinstance(content_payload, str) else "\n".join(str(c) for c in content_payload)
-            )
-            if suggestions:
-                sug_lines = ["\n\n**Suggested next:**"]
-                for s in suggestions:
-                    sug_lines.append(f"- `{s['call']}` — {s['reason']}")
-                md_content += "\n".join(sug_lines)
-
-            if ctx is not None and function in SLOW_FUNCTIONS:
-                try:
-                    await ctx.report_progress(progress=100, total=100)
-                except Exception:  # noqa: BLE001
-                    pass
-
-            return ToolResult(structured_content=struct, content=md_content)
-        except TypeError as exc:
-            return mcp_error(
-                tool_name,
-                f"Invalid parameter for {namespace}.{function}: {exc}",
-                error_code="INVALID_PARAMETER",
-                agent_action=f"Call get_function_help(namespace='{namespace}', function='{function}') to inspect valid parameters.",
-            )
-        except ValueError as exc:
-            return mcp_error(
-                tool_name,
-                f"Value error in {namespace}.{function}: {exc}",
-                error_code="INVALID_VALUE",
-                agent_action=f"Inspect data or parameters for {namespace}.{function}.",
-            )
-        except Exception as exc:  # noqa: BLE001
-            return classify_exception_error(tool_name, exc, namespace=namespace, function=function)
+        return await _dispatch_edata(
+            fn, edata, handle, used_latest, kind, namespace, function, params, response_format, session, tool_name, ctx
+        )
 
     return mcp_error(tool_name, f"Unhandled namespace kind '{kind}'", error_code="UNHANDLED_KIND")

--- a/ehrapy/mcp/dispatch.py
+++ b/ehrapy/mcp/dispatch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import collections
 import inspect
+import os
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -270,6 +271,36 @@ def _maybe_cache_fitter(handle: str, function: str, res: Any) -> None:
 # --- Dispatch branches, one per namespace kind --------------------------------------------
 
 
+def get_tool_timeout() -> float:
+    """Return tool execution timeout in seconds (default: 120.0s)."""
+    env_val = os.environ.get("EHRAPY_MCP_TIMEOUT_SECONDS", "").strip()
+    if env_val:
+        try:
+            return max(0.01, float(env_val))
+        except ValueError:
+            pass
+    return 120.0
+
+
+def _load_demo_sync(fn: Callable[..., Any], params: dict[str, Any]) -> Any:
+    registry.ensure_demo_data_dir()
+    try:
+        return fn(**params)
+    except OSError:
+        import tempfile
+
+        import ehrdata.core.constants as ed_const
+        import ehrdata.dt.datasets as ed_datasets
+
+        import ehrapy as ep
+
+        fallback = Path(tempfile.mkdtemp(prefix="ehrapy_demo_fallback_"))
+        ed_const.DEFAULT_DATA_PATH = fallback
+        ed_datasets.DEFAULT_DATA_PATH = fallback
+        ep.settings.datasetdir = fallback
+        return fn(**params)
+
+
 async def _dispatch_demo(
     fn: Callable[..., Any],
     namespace: str,
@@ -281,7 +312,8 @@ async def _dispatch_demo(
 ) -> ToolResult:
     """Load a demo dataset and cache it under a new handle."""
     try:
-        edata = fn(**params)
+        timeout = get_tool_timeout()
+        edata = await asyncio.wait_for(asyncio.to_thread(_load_demo_sync, fn, params), timeout=timeout)
         record = save_edata(edata, name=function, fmt="demo")
         session.set_latest_edata_id(record.edata_id)
 
@@ -309,6 +341,13 @@ async def _dispatch_demo(
         await _report_progress_if_slow(ctx, function, progress=100)
 
         return ToolResult(structured_content=struct, content="\n".join(md_lines))
+    except TimeoutError:
+        return mcp_error(
+            tool_name,
+            f"Failed to load demo dataset '{function}': operation timed out after {get_tool_timeout()}s.",
+            error_code="TIMEOUT",
+            agent_action="Check network connection or load a local dataset via ingest_dataset.",
+        )
     except Exception as exc:  # noqa: BLE001
         return mcp_error(
             tool_name,
@@ -553,7 +592,7 @@ def _dispatch_io_write(
         )
 
 
-async def _dispatch_edata(
+def _dispatch_edata_sync(
     fn: Callable[..., Any],
     edata: Any,
     handle: str,
@@ -565,7 +604,6 @@ async def _dispatch_edata(
     response_format: Literal["concise", "detailed"],
     session: _EHRapySession,
     tool_name: str,
-    ctx: Context | None,
 ) -> ToolResult:
     """Run a mutating preprocessing/analysis function and persist the result."""
     try:
@@ -608,8 +646,6 @@ async def _dispatch_edata(
 
         md_content = _content_with_suggestions(content_payload, suggestions)
 
-        await _report_progress_if_slow(ctx, function, progress=100)
-
         return ToolResult(structured_content=struct, content=md_content)
     except TypeError as exc:
         return mcp_error(
@@ -627,6 +663,51 @@ async def _dispatch_edata(
         )
     except Exception as exc:  # noqa: BLE001
         return classify_exception_error(tool_name, exc, namespace=namespace, function=function)
+
+
+async def _dispatch_edata(
+    fn: Callable[..., Any],
+    edata: Any,
+    handle: str,
+    used_latest: bool,
+    kind: str,
+    namespace: str,
+    function: str,
+    params: dict[str, Any],
+    response_format: Literal["concise", "detailed"],
+    session: _EHRapySession,
+    tool_name: str,
+    ctx: Context | None,
+) -> ToolResult:
+    """Run a mutating preprocessing/analysis function and persist the result."""
+    try:
+        timeout = get_tool_timeout()
+        result = await asyncio.wait_for(
+            asyncio.to_thread(
+                _dispatch_edata_sync,
+                fn,
+                edata,
+                handle,
+                used_latest,
+                kind,
+                namespace,
+                function,
+                params,
+                response_format,
+                session,
+                tool_name,
+            ),
+            timeout=timeout,
+        )
+        await _report_progress_if_slow(ctx, function, progress=100)
+        return result
+    except TimeoutError:
+        return mcp_error(
+            tool_name,
+            f"Execution of '{namespace}.{function}' timed out after {get_tool_timeout()}s.",
+            error_code="TIMEOUT",
+            agent_action="The operation exceeded the server timeout. Try running on a smaller subset or check parameters.",
+        )
 
 
 def _resolve_handle(edata_id: str | None, session: _EHRapySession) -> tuple[str | None, bool]:
@@ -684,7 +765,18 @@ async def run_dispatch(
 
     # 2. IO read functions (standalone ingestion)
     if kind == "io" and function.startswith("read_"):
-        return _dispatch_io_read(fn, namespace, function, params, session, tool_name)
+        try:
+            return await asyncio.wait_for(
+                asyncio.to_thread(_dispatch_io_read, fn, namespace, function, params, session, tool_name),
+                timeout=get_tool_timeout(),
+            )
+        except TimeoutError:
+            return mcp_error(
+                tool_name,
+                f"Execution of '{namespace}.{function}' timed out after {get_tool_timeout()}s.",
+                error_code="TIMEOUT",
+                agent_action="The operation exceeded the server timeout.",
+            )
 
     # For all other operations, resolve the active dataset handle
     handle, used_latest = _resolve_handle(edata_id, session)
@@ -700,18 +792,58 @@ async def run_dispatch(
     if error is not None:
         return error
 
-    # 3. Read-Only get namespace (T1)
-    if kind == "get":
-        return _dispatch_get(fn, edata, handle, used_latest, namespace, function, params, response_format, tool_name)
+    timeout = get_tool_timeout()
+    try:
+        # 3. Read-Only get namespace (T1)
+        if kind == "get":
+            return await asyncio.wait_for(
+                asyncio.to_thread(
+                    _dispatch_get,
+                    fn,
+                    edata,
+                    handle,
+                    used_latest,
+                    namespace,
+                    function,
+                    params,
+                    response_format,
+                    tool_name,
+                ),
+                timeout=timeout,
+            )
 
-    # 4. Plot namespace (T10)
-    if kind == "plot":
-        return _dispatch_plot(fn, edata, handle, used_latest, namespace, function, params, tool_name)
+        # 4. Plot namespace (T10)
+        if kind == "plot":
+            return await asyncio.wait_for(
+                asyncio.to_thread(
+                    _dispatch_plot, fn, edata, handle, used_latest, namespace, function, params, tool_name
+                ),
+                timeout=timeout,
+            )
 
-    # 5. IO write / export / to_pandas functions
-    if kind == "io":
-        return _dispatch_io_write(
-            fn, edata, handle, used_latest, namespace, function, params, response_format, tool_name
+        # 5. IO write / export / to_pandas functions
+        if kind == "io":
+            return await asyncio.wait_for(
+                asyncio.to_thread(
+                    _dispatch_io_write,
+                    fn,
+                    edata,
+                    handle,
+                    used_latest,
+                    namespace,
+                    function,
+                    params,
+                    response_format,
+                    tool_name,
+                ),
+                timeout=timeout,
+            )
+    except TimeoutError:
+        return mcp_error(
+            tool_name,
+            f"Execution of '{namespace}.{function}' timed out after {timeout}s.",
+            error_code="TIMEOUT",
+            agent_action="The operation exceeded the server timeout.",
         )
 
     # 6. Mutating edata namespaces (preprocessing & analysis)

--- a/ehrapy/mcp/dispatch.py
+++ b/ehrapy/mcp/dispatch.py
@@ -1,0 +1,608 @@
+"""Dispatch engine for ehrapy/ehrdata namespaces with dual-channel output."""
+
+from __future__ import annotations
+
+import asyncio
+import collections
+import inspect
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from fastmcp import Context  # noqa: TC002
+from fastmcp.tools.tool import ToolResult
+from fastmcp.utilities.types import Image
+
+from ehrapy.mcp.catalog import get_callable, get_namespace_kind
+from ehrapy.mcp.edata_store import load_edata, persist_edata, save_edata
+from ehrapy.mcp.errors import (
+    classify_exception_error,
+    mcp_error,
+    path_access_error,
+    unknown_handle_error,
+)
+from ehrapy.mcp.policy import PathNotAllowedError, ReadOnlyModeError, check_path_allowed
+from ehrapy.mcp.registry import registry
+from ehrapy.mcp.serialization import serialize_result
+from ehrapy.mcp.session import get_session
+from ehrapy.mcp.steering import get_suggested_next
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+SLOW_FUNCTIONS = frozenset(
+    {
+        "knn_impute",
+        "miss_forest_impute",
+        "neighbors",
+        "umap",
+        "tsne",
+        "leiden",
+        "iptw",
+        "aipw",
+        "g_computation",
+        "t_learner",
+        "read_csv",
+    }
+)
+
+
+_FITTER_CACHE_CAPACITY = 8
+_FITTER_CACHE: collections.OrderedDict[tuple[str, str], Any] = collections.OrderedDict()
+
+# Plot functions whose first parameter is a fitted model/result rather than the EHRData
+# object, mapped to the run_analysis function that produces it. Ported from origin fix #5.
+# The third element is an attribute the bound object must expose; ep.tl.kaplan_meier also
+# writes a summary DataFrame to uns["kaplan_meier"], and binding that instead of the fitter
+# reproduces the exact AttributeError this mapping exists to prevent.
+_PLOT_FITTER_SOURCES: dict[str, tuple[str, str, str | None]] = {
+    # plot function -> (analysis function that fits it, parameter it binds to, required attr)
+    "kaplan_meier": ("kaplan_meier", "kmfs", "survival_function_"),
+    "love_plot": ("covariate_balance", "balance", None),
+    "propensity_overlap": ("positivity_check", "positivity", None),
+}
+
+
+def _usable_fitter(value: Any, required_attr: str | None) -> bool:
+    """Return True if ``value`` looks like the fitted object the plot expects."""
+    if value is None:
+        return False
+    if required_attr is None:
+        return True
+    if isinstance(value, (list, tuple)):
+        return bool(value) and all(hasattr(v, required_attr) for v in value)
+    return hasattr(value, required_attr)
+
+
+def _handle_mtime_ns(edata_id: str) -> int | None:
+    """Return the current cache mtime for a handle, or None if it is unknown."""
+    record = registry.get_dataset(edata_id)
+    return record.mtime_ns if record is not None else None
+
+
+def cache_fitter(edata_id: str, function: str, value: Any) -> None:
+    """Record a fitted model so a downstream plot call can bind it (bounded LRU).
+
+    Stamped with the handle's cache mtime: any later write-through to the same
+    ``edata_id`` invalidates the fitter, so a plot can never silently render a model
+    fitted against a cohort that has since been transformed.
+    """
+    key = (edata_id, function)
+    if key in _FITTER_CACHE:
+        _FITTER_CACHE.move_to_end(key)
+    _FITTER_CACHE[key] = (_handle_mtime_ns(edata_id), value)
+    while len(_FITTER_CACHE) > _FITTER_CACHE_CAPACITY:
+        _FITTER_CACHE.popitem(last=False)
+
+
+def get_fitter(edata_id: str, function: str) -> Any | None:
+    """Return a cached fitter for a handle, or None if absent or stale."""
+    key = (edata_id, function)
+    if key not in _FITTER_CACHE:
+        return None
+    cached_mtime, value = _FITTER_CACHE[key]
+    if cached_mtime != _handle_mtime_ns(edata_id):
+        # The dataset changed under the fitter; treat it as absent so the caller
+        # tells the agent to re-run the analysis.
+        del _FITTER_CACHE[key]
+        return None
+    _FITTER_CACHE.move_to_end(key)
+    return value
+
+
+def clear_fitter_cache() -> None:
+    """Clear the fitter cache (useful for testing)."""
+    _FITTER_CACHE.clear()
+
+
+def _build_call_params(
+    fn: Callable[..., Any],
+    edata: Any,
+    params: dict[str, Any],
+    *,
+    edata_id: str | None = None,
+    function: str | None = None,
+    kind: str | None = None,
+) -> dict[str, Any]:
+    """Build the kwargs for a dispatched call, binding edata or a fitted model as needed.
+
+    Most ehrapy functions take the EHRData object first. A few plot functions instead take a
+    fitted model produced by an earlier run_analysis call (ported from origin fix #5); for
+    those, bind the cached fitter -- or the copy persisted in ``edata.uns`` -- rather than
+    handing them an EHRData they cannot use.
+    """
+    sig = inspect.signature(fn)
+    param_names = list(sig.parameters.keys())
+    if not param_names:
+        return dict(params)
+
+    first_param = param_names[0]
+    if first_param in params:
+        return dict(params)
+
+    if kind == "plot" and function in _PLOT_FITTER_SOURCES:
+        source_fn, bind_name, required_attr = _PLOT_FITTER_SOURCES[function]
+        if bind_name in sig.parameters:
+            fitted = get_fitter(edata_id or "", source_fn)
+            if not _usable_fitter(fitted, required_attr) and hasattr(edata, "uns"):
+                # Fall back to a copy persisted in uns, but only if it is the fitted
+                # object rather than a summary table stored under the same key.
+                candidate = edata.uns.get(source_fn)
+                fitted = candidate if _usable_fitter(candidate, required_attr) else None
+            if not _usable_fitter(fitted, required_attr):
+                raise ValueError(
+                    f"No fitted result available for plot '{function}'. "
+                    f"Run run_analysis(function='{source_fn}', ...) on this handle first "
+                    f"(re-run it if the dataset has been transformed since)."
+                )
+            if bind_name == "kmfs" and not isinstance(fitted, (list, tuple)):
+                fitted = [fitted]
+            return {bind_name: fitted, **params}
+
+    return {first_param: edata, **params}
+
+
+def _inject_edata(fn: Callable[..., Any], edata: Any, params: dict[str, Any], **kwargs: Any) -> Any:
+    """Call ``fn`` with edata (or a fitted model) bound to its first parameter."""
+    return fn(**_build_call_params(fn, edata, params, **kwargs))
+
+
+async def run_dispatch(
+    namespace: str,
+    function: str,
+    *,
+    edata_id: str | None = None,
+    params: dict[str, Any] | None = None,
+    response_format: Literal["concise", "detailed"] = "concise",
+    ctx: Context | None = None,
+) -> ToolResult:
+    """Execute a function from an ehrapy namespace and return a dual-channel ToolResult."""
+    params = dict(params or {})
+    tool_name = f"run_{namespace}" if namespace != "demo" else "load_demo_dataset"
+    session = get_session(ctx)
+
+    # Progress reporting for slow functions
+    if ctx is not None and function in SLOW_FUNCTIONS:
+        try:
+            await ctx.info(f"Starting {namespace}.{function}...")
+            await ctx.report_progress(progress=0, total=100)
+        except Exception:  # noqa: BLE001
+            pass
+
+    # Resolve callable
+    try:
+        fn = get_callable(namespace, function)
+        kind = get_namespace_kind(namespace)
+    except KeyError as exc:
+        return mcp_error(
+            tool_name,
+            str(exc),
+            error_code="UNKNOWN_FUNCTION",
+            agent_action=f"Call list_ehrapy_functions(namespace='{namespace}') to inspect valid function names.",
+        )
+
+    # 1. Demo datasets
+    if kind == "demo":
+        try:
+            edata = fn(**params)
+            record = save_edata(edata, name=function, fmt="demo")
+            session.set_latest_edata_id(record.edata_id)
+
+            suggestions = get_suggested_next(namespace, function)
+            struct: dict[str, Any] = {
+                "status": "ok",
+                "edata_id": record.edata_id,
+                "name": record.name,
+                "n_obs": edata.n_obs,
+                "n_vars": edata.n_vars,
+                "namespace": namespace,
+                "function": function,
+            }
+            if suggestions:
+                struct["suggested_next"] = [s["call"] for s in suggestions]
+
+            md_lines = [
+                f"### Loaded demo dataset `{function}`",
+                f"- **Handle (edata_id):** `{record.edata_id}`",
+                f"- **Observations:** {edata.n_obs}",
+                f"- **Variables:** {edata.n_vars}",
+            ]
+            if suggestions:
+                md_lines.extend(["", "**Suggested next:**"])
+                for s in suggestions:
+                    md_lines.append(f"- `{s['call']}` — {s['reason']}")
+
+            if ctx is not None and function in SLOW_FUNCTIONS:
+                try:
+                    await ctx.report_progress(progress=100, total=100)
+                except Exception:  # noqa: BLE001
+                    pass
+
+            return ToolResult(structured_content=struct, content="\n".join(md_lines))
+        except Exception as exc:  # noqa: BLE001
+            return mcp_error(
+                tool_name,
+                f"Failed to load demo dataset '{function}': {exc}",
+                error_code="DEMO_LOAD_ERROR",
+            )
+
+    # 2. IO read functions (standalone ingestion)
+    if kind == "io" and function.startswith("read_"):
+        try:
+            file_arg = params.get("filename") or params.get("path") or params.get("file_path")
+            if file_arg:
+                checked_path = check_path_allowed(file_arg, for_write=False)
+                # Update param with resolved path string
+                for k in ("filename", "path", "file_path"):
+                    if k in params:
+                        params[k] = str(checked_path)
+
+            edata = fn(**params)
+            name_stem = Path(file_arg).name if file_arg else function
+            record = save_edata(edata, name=name_stem, source_path=str(file_arg) if file_arg else None)
+            session.set_latest_edata_id(record.edata_id)
+
+            suggestions = get_suggested_next(namespace, function)
+            struct = {
+                "status": "ok",
+                "edata_id": record.edata_id,
+                "name": record.name,
+                "n_obs": edata.n_obs,
+                "n_vars": edata.n_vars,
+                "namespace": namespace,
+                "function": function,
+            }
+            if suggestions:
+                struct["suggested_next"] = [s["call"] for s in suggestions]
+
+            md_lines = [
+                f"### Loaded dataset from `{file_arg or function}`",
+                f"- **Handle (edata_id):** `{record.edata_id}`",
+                f"- **Observations:** {edata.n_obs}",
+                f"- **Variables:** {edata.n_vars}",
+            ]
+            if suggestions:
+                md_lines.extend(["", "**Suggested next:**"])
+                for s in suggestions:
+                    md_lines.append(f"- `{s['call']}` — {s['reason']}")
+
+            return ToolResult(structured_content=struct, content="\n".join(md_lines))
+        except PathNotAllowedError as exc:
+            return mcp_error(
+                tool_name,
+                str(exc),
+                error_code=exc.error_code,
+                agent_action=exc.agent_action,
+            )
+        except ReadOnlyModeError as exc:
+            return mcp_error(
+                tool_name,
+                str(exc),
+                error_code=exc.error_code,
+                agent_action=exc.agent_action,
+            )
+        except FileNotFoundError:
+            return path_access_error(tool_name, str(params.get("filename") or params.get("path") or ""))
+        except Exception as exc:  # noqa: BLE001
+            return classify_exception_error(
+                tool_name, exc, namespace=namespace, function=function, fallback_code="IO_READ_ERROR"
+            )
+
+    # For all other operations, resolve the active dataset handle
+    used_latest = False
+    handle = edata_id
+    if handle is None:
+        handle = session.get_latest_edata_id()
+        used_latest = True
+
+    if handle is None:
+        return mcp_error(
+            tool_name,
+            "No dataset handle provided and no active dataset in session.",
+            error_code="NO_ACTIVE_DATASET",
+            agent_action="Load a dataset with load_demo_dataset(dataset='mimic_2') or ingest_dataset(file_path=...).",
+        )
+
+    # Load dataset
+    try:
+        edata = load_edata(handle)
+    except (KeyError, FileNotFoundError):
+        return unknown_handle_error(tool_name, "edata_id", handle)
+    except Exception as exc:  # noqa: BLE001
+        return mcp_error(
+            tool_name,
+            f"Failed to load dataset '{handle}': {exc}",
+            error_code="DATASET_LOAD_ERROR",
+        )
+
+    # 3. Read-Only get namespace (T1)
+    if kind == "get":
+        try:
+            res = _inject_edata(fn, edata, params)
+            meta, content_payload = serialize_result(
+                res,
+                response_format=response_format,
+                params=params,
+                function=function,
+                edata=edata,
+            )
+            suggestions = get_suggested_next(namespace, function)
+
+            status_val = meta.get("status", "ok")
+            struct = {
+                "status": status_val,
+                "edata_id": handle,
+                "namespace": namespace,
+                "function": function,
+                **{k: v for k, v in meta.items() if k != "status"},
+            }
+            if used_latest:
+                struct["used_latest"] = True
+            if suggestions:
+                struct["suggested_next"] = [s["call"] for s in suggestions]
+
+            md_content = (
+                content_payload if isinstance(content_payload, str) else "\n".join(str(c) for c in content_payload)
+            )
+            if suggestions:
+                sug_lines = ["\n\n**Suggested next:**"]
+                for s in suggestions:
+                    sug_lines.append(f"- `{s['call']}` — {s['reason']}")
+                md_content += "\n".join(sug_lines)
+
+            return ToolResult(structured_content=struct, content=md_content)
+        except Exception as exc:  # noqa: BLE001
+            return classify_exception_error(
+                tool_name, exc, namespace=namespace, function=function, fallback_code="GET_ERROR"
+            )
+
+    # 4. Plot namespace (T10)
+    if kind == "plot":
+        try:
+            # Inject show=False if function accepts show
+            sig = inspect.signature(fn)
+            if "show" in sig.parameters and "show" not in params:
+                params["show"] = False
+            # Prefer an explicit figure handle over scraping plt.gcf() (origin fix #4).
+            if "return_fig" in sig.parameters and "return_fig" not in params:
+                params["return_fig"] = True
+
+            plt.close("all")
+            res = _inject_edata(fn, edata, params, edata_id=handle, function=function, kind="plot")
+            if res is None and plt.get_fignums():
+                res = plt.gcf()
+
+            meta, content_payload = serialize_result(
+                res,
+                plots_dir=registry.plots_dir(),
+                params=params,
+                function=function,
+                edata=edata,
+            )
+            plt.close("all")
+
+            suggestions = get_suggested_next(namespace, function)
+            rendered = meta.get("type") == "figure"
+            struct = {
+                "status": "ok" if rendered else "ok_no_figure",
+                "edata_id": handle,
+                "namespace": namespace,
+                "function": function,
+                **meta,
+            }
+            if not rendered:
+                # A plot call that produced no image previously reported a bare "ok",
+                # leaving the agent to assume a figure existed.
+                struct["agent_action"] = (
+                    f"'{function}' returned {meta.get('type', 'no renderable figure')} rather than a figure. "
+                    "Check that the required inputs were fitted first, or call "
+                    f"get_function_help(namespace='{namespace}', function='{function}')."
+                )
+
+            if used_latest:
+                struct["used_latest"] = True
+            if suggestions:
+                struct["suggested_next"] = [s["call"] for s in suggestions]
+
+            # Build ToolResult content blocks
+            content_blocks: list[Any] = []
+            if isinstance(content_payload, list):
+                for item in content_payload:
+                    content_blocks.append(item)
+            else:
+                content_blocks.append(content_payload)
+
+            if suggestions:
+                sug_lines = ["\n\n**Suggested next:**"]
+                for s in suggestions:
+                    sug_lines.append(f"- `{s['call']}` — {s['reason']}")
+                content_blocks.append("\n".join(sug_lines))
+
+            return ToolResult(structured_content=struct, content=content_blocks)
+        except Exception as exc:  # noqa: BLE001
+            plt.close("all")
+            return classify_exception_error(
+                tool_name, exc, namespace=namespace, function=function, fallback_code="PLOT_ERROR"
+            )
+
+    # 5. IO write / export / to_pandas functions
+    if kind == "io":
+        try:
+            if function == "to_pandas":
+                df = fn(edata, **params)
+                meta, content_payload = serialize_result(
+                    df,
+                    response_format=response_format,
+                    params=params,
+                    function=function,
+                    edata=edata,
+                )
+                struct = {
+                    "status": "ok",
+                    "edata_id": handle,
+                    "namespace": namespace,
+                    "function": function,
+                    **meta,
+                }
+                if used_latest:
+                    struct["used_latest"] = True
+                return ToolResult(
+                    structured_content=struct,
+                    content=(content_payload if isinstance(content_payload, str) else str(content_payload)),
+                )
+
+            # write functions
+            target_path = params.get("filename") or params.get("path") or params.get("file_path")
+            if target_path:
+                checked_path = check_path_allowed(target_path, for_write=True, operation=function)
+                for k in ("filename", "path", "file_path"):
+                    if k in params:
+                        params[k] = str(checked_path)
+
+            fn(edata, **params)
+            struct = {
+                "status": "ok",
+                "edata_id": handle,
+                "namespace": namespace,
+                "function": function,
+                "target_path": str(target_path) if target_path else None,
+            }
+            if used_latest:
+                struct["used_latest"] = True
+            md = f"Dataset `{handle}` successfully exported to `{target_path}`."
+            return ToolResult(structured_content=struct, content=md)
+        except PathNotAllowedError as exc:
+            return mcp_error(
+                tool_name,
+                str(exc),
+                error_code=exc.error_code,
+                agent_action=exc.agent_action,
+            )
+        except ReadOnlyModeError as exc:
+            return mcp_error(
+                tool_name,
+                str(exc),
+                error_code=exc.error_code,
+                agent_action=exc.agent_action,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return classify_exception_error(
+                tool_name, exc, namespace=namespace, function=function, fallback_code="IO_ERROR"
+            )
+
+    # 6. Mutating edata namespaces (preprocessing & analysis)
+    if kind == "edata":
+        try:
+            res = _inject_edata(fn, edata, params, edata_id=handle, function=function, kind=kind)
+            if hasattr(res, "n_obs") and hasattr(res, "n_vars"):
+                # Function returned a modified copy
+                edata = res
+
+            # Op-log provenance tracking (T19)
+            import json
+
+            ops = edata.uns.setdefault("ehrapy_mcp_ops", [])
+            ops.append(
+                json.dumps(
+                    {
+                        "namespace": namespace,
+                        "function": function,
+                        "params": {
+                            str(k): (v if isinstance(v, (int, float, str, bool, list)) else str(v))
+                            for k, v in params.items()
+                        },
+                        "timestamp": time.time(),
+                    }
+                )
+            )
+
+            # Persist dataset write-through
+            persist_edata(handle, edata)
+            session.set_latest_edata_id(handle)
+
+            # Stamp the fitter with the post-write mtime, so it stays valid until the
+            # next transformation of this handle rather than invalidating immediately.
+            if res is not None and function in {src for src, _, _ in _PLOT_FITTER_SOURCES.values()}:
+                cache_fitter(handle, function, res)
+
+            meta, content_payload = serialize_result(
+                res,
+                response_format=response_format,
+                params=params,
+                function=function,
+                edata=edata,
+            )
+            suggestions = get_suggested_next(namespace, function)
+
+            struct = {
+                "status": "ok",
+                "edata_id": handle,
+                "n_obs": edata.n_obs,
+                "n_vars": edata.n_vars,
+                "namespace": namespace,
+                "function": function,
+                **meta,
+            }
+            if used_latest:
+                struct["used_latest"] = True
+            if suggestions:
+                struct["suggested_next"] = [s["call"] for s in suggestions]
+
+            md_content = (
+                content_payload if isinstance(content_payload, str) else "\n".join(str(c) for c in content_payload)
+            )
+            if suggestions:
+                sug_lines = ["\n\n**Suggested next:**"]
+                for s in suggestions:
+                    sug_lines.append(f"- `{s['call']}` — {s['reason']}")
+                md_content += "\n".join(sug_lines)
+
+            if ctx is not None and function in SLOW_FUNCTIONS:
+                try:
+                    await ctx.report_progress(progress=100, total=100)
+                except Exception:  # noqa: BLE001
+                    pass
+
+            return ToolResult(structured_content=struct, content=md_content)
+        except TypeError as exc:
+            return mcp_error(
+                tool_name,
+                f"Invalid parameter for {namespace}.{function}: {exc}",
+                error_code="INVALID_PARAMETER",
+                agent_action=f"Call get_function_help(namespace='{namespace}', function='{function}') to inspect valid parameters.",
+            )
+        except ValueError as exc:
+            return mcp_error(
+                tool_name,
+                f"Value error in {namespace}.{function}: {exc}",
+                error_code="INVALID_VALUE",
+                agent_action=f"Inspect data or parameters for {namespace}.{function}.",
+            )
+        except Exception as exc:  # noqa: BLE001
+            return classify_exception_error(tool_name, exc, namespace=namespace, function=function)
+
+    return mcp_error(tool_name, f"Unhandled namespace kind '{kind}'", error_code="UNHANDLED_KIND")

--- a/ehrapy/mcp/edata_store.py
+++ b/ehrapy/mcp/edata_store.py
@@ -1,0 +1,161 @@
+"""Load and persist EHRData objects by edata_id with in-memory LRU caching."""
+
+from __future__ import annotations
+
+import collections
+import dataclasses
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ehrdata.io import read_h5ed, write_h5ed
+
+from ehrapy.mcp.registry import DatasetRecord, registry
+
+if TYPE_CHECKING:
+    from ehrdata import EHRData
+
+_DEFAULT_CACHE_ENTRIES = 3
+
+
+def _get_max_cache_entries() -> int:
+    env_val = os.environ.get("EHRAPY_MCP_CACHE_ENTRIES", "").strip()
+    if env_val:
+        try:
+            return max(1, int(env_val))
+        except ValueError:
+            pass
+    return _DEFAULT_CACHE_ENTRIES
+
+
+class _EHRDataLRUCache:
+    """In-memory LRU cache storing (mtime_ns, EHRData)."""
+
+    def __init__(self, capacity: int) -> None:
+        self.capacity = capacity
+        self._cache: collections.OrderedDict[str, tuple[int, EHRData]] = collections.OrderedDict()
+
+    def get(self, edata_id: str, mtime_ns: int) -> EHRData | None:
+        if edata_id not in self._cache:
+            return None
+        cached_mtime, edata = self._cache[edata_id]
+        if cached_mtime != mtime_ns:
+            # Stale cache entry
+            del self._cache[edata_id]
+            return None
+        self._cache.move_to_end(edata_id)
+        return edata
+
+    def put(self, edata_id: str, mtime_ns: int, edata: EHRData) -> None:
+        if edata_id in self._cache:
+            self._cache.move_to_end(edata_id)
+        self._cache[edata_id] = (mtime_ns, edata)
+        while len(self._cache) > self.capacity:
+            self._cache.popitem(last=False)
+
+    def clear(self) -> None:
+        self._cache.clear()
+
+    def __len__(self) -> int:
+        return len(self._cache)
+
+    def __contains__(self, edata_id: object) -> bool:
+        return edata_id in self._cache
+
+
+_MEMORY_CACHE = _EHRDataLRUCache(_get_max_cache_entries())
+
+
+def clear_memory_cache() -> None:
+    """Clear in-memory LRU cache (useful for testing)."""
+    _MEMORY_CACHE.clear()
+
+
+def _cache_path(edata_id: str) -> Path:
+    return registry.cache_dir() / "edata" / f"{edata_id}.h5ed"
+
+
+def save_edata(
+    edata: EHRData,
+    *,
+    name: str,
+    source_path: str | None = None,
+    fmt: str = "h5ed",
+    edata_id: str | None = None,
+    parent_id: str | None = None,
+) -> DatasetRecord:
+    """Persist EHRData to the MCP cache and register a handle."""
+    edata_id = edata_id or str(uuid.uuid4())
+    path = _cache_path(edata_id)
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    write_h5ed(edata, path)
+    stat = path.stat()
+    record = DatasetRecord(
+        edata_id=edata_id,
+        cache_path=str(path),
+        source_path=source_path,
+        name=name,
+        format=fmt,
+        size_bytes=stat.st_size,
+        mtime_ns=stat.st_mtime_ns,
+        ingested_at=time.time(),
+        n_obs=edata.n_obs,
+        n_vars=edata.n_vars,
+        parent_id=parent_id,
+    )
+    registry.store_record(record)
+    _MEMORY_CACHE.put(edata_id, record.mtime_ns, edata)
+    return record
+
+
+def load_edata(edata_id: str) -> EHRData:
+    """Load cached EHRData for an ``edata_id`` with LRU cache lookup."""
+    record = registry.get_dataset(edata_id)
+    if record is None:
+        raise KeyError(edata_id)
+    cache = Path(record.cache_path)
+    if not cache.is_file():
+        raise FileNotFoundError(record.cache_path)
+
+    # Check in-memory cache
+    cached = _MEMORY_CACHE.get(edata_id, record.mtime_ns)
+    if cached is not None:
+        return cached
+
+    # Disk read on miss / staleness
+    edata = read_h5ed(cache)
+    _MEMORY_CACHE.put(edata_id, record.mtime_ns, edata)
+    return edata
+
+
+def fork_edata(edata_id: str, *, name: str | None = None) -> DatasetRecord:
+    """Copy cached EHRData to a new handle."""
+    edata = load_edata(edata_id)
+    parent = registry.get_dataset(edata_id)
+    label = name or f"{parent.name if parent else edata_id}-fork"
+    # Make a copy of the EHRData object for the fork
+    edata_copy = edata.copy()
+    return save_edata(edata_copy, name=label, parent_id=edata_id)
+
+
+def persist_edata(edata_id: str, edata: EHRData) -> DatasetRecord:
+    """Overwrite the cached EHRData for an existing handle (write-through)."""
+    record = registry.get_dataset(edata_id)
+    if record is None:
+        return save_edata(edata, name=f"edata-{edata_id[:8]}")
+    cache_path = Path(record.cache_path)
+    write_h5ed(edata, cache_path)
+    stat = cache_path.stat()
+    updated = dataclasses.replace(
+        record,
+        n_obs=edata.n_obs,
+        n_vars=edata.n_vars,
+        size_bytes=stat.st_size,
+        mtime_ns=stat.st_mtime_ns,
+        ingested_at=time.time(),
+    )
+    registry.store_record(updated)
+    _MEMORY_CACHE.put(edata_id, updated.mtime_ns, edata)
+    return updated

--- a/ehrapy/mcp/errors.py
+++ b/ehrapy/mcp/errors.py
@@ -9,9 +9,14 @@ from fastmcp.tools.tool import ToolResult
 _SANDBOX_PATH_PREFIXES = (
     "/home/claude",
     "/mnt/",
-    "/workspace/",
+    "/workspace",
     "/tmp/claude",
     "/System/Volumes/Data/home/claude",
+    "/sandbox",
+    "/tmp/sandbox",
+    "/tmp/user",
+    "/app/",
+    "/home/user",
 )
 
 
@@ -56,12 +61,19 @@ def mcp_error(
 
 def classify_path(path: str) -> dict[str, Any]:
     """Flag paths that look like agent-sandbox locations."""
+    path_str = str(path)
     matched_prefix = next(
-        (prefix for prefix in _SANDBOX_PATH_PREFIXES if path.startswith(prefix)),
+        (prefix for prefix in _SANDBOX_PATH_PREFIXES if path_str.startswith(prefix)),
         None,
     )
+    if matched_prefix is None:
+        for term in ("claude", "sandbox", "/workspace"):
+            if term in path_str.lower():
+                matched_prefix = term
+                break
+
     return {
-        "attempted_path": path,
+        "attempted_path": path_str,
         "looks_like_sandbox_path": matched_prefix is not None,
         "matched_prefix": matched_prefix,
     }
@@ -73,7 +85,7 @@ def path_access_error(
     *,
     missing_code: str = "FILE_NOT_FOUND",
     missing_reason: str = "Path does not exist on the MCP host filesystem.",
-    missing_action: str = "Provide a host-visible absolute path, or call get_runtime_context first.",
+    missing_action: str = "Provide a host-visible absolute path, or call get_runtime_context() to get cache_dir.",
     sandbox_action: str | None = None,
 ) -> ToolResult:
     """Return a path-access error ToolResult."""
@@ -81,16 +93,16 @@ def path_access_error(
     if path_context["looks_like_sandbox_path"]:
         return mcp_error(
             tool,
-            "Path is not visible to the MCP server host filesystem.",
+            f"Path '{path}' is not visible to the MCP server host filesystem (sandbox path detected).",
             error_code="HOST_PATH_NOT_VISIBLE",
             agent_action=sandbox_action
-            or "Ask the user for a host-visible absolute path, or call get_runtime_context first.",
+            or "File is in a sandboxed client path. Call get_runtime_context() to find cache_dir, copy the file into cache_dir, and retry with the cache_dir path.",
             details={"path_context": path_context},
         )
 
     return mcp_error(
         tool,
-        missing_reason,
+        f"File not found: '{path}'. {missing_reason}",
         error_code=missing_code,
         agent_action=missing_action,
         details={"path_context": path_context},

--- a/ehrapy/mcp/errors.py
+++ b/ehrapy/mcp/errors.py
@@ -1,0 +1,209 @@
+"""Structured MCP error envelopes with dual-channel (JSON + Markdown) output."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp.tools.tool import ToolResult
+
+_SANDBOX_PATH_PREFIXES = (
+    "/home/claude",
+    "/mnt/",
+    "/workspace/",
+    "/tmp/claude",
+    "/System/Volumes/Data/home/claude",
+)
+
+
+def format_error_markdown(reason: str, *, error_code: str | None = None, agent_action: str | None = None) -> str:
+    """Render a clean 2-line Markdown block for error results."""
+    title = f"# Error: {error_code}" if error_code else "# Error"
+    lines = [title, "", reason]
+    if agent_action:
+        lines.extend(["", f"**Action:** {agent_action}"])
+    return "\n".join(lines)
+
+
+def mcp_error(
+    tool: str,
+    reason: str,
+    *,
+    error_code: str | None = None,
+    agent_action: str | None = None,
+    details: dict[str, Any] | None = None,
+    metrics: dict[str, Any] | None = None,
+    is_error: bool = False,
+) -> ToolResult:
+    """Return a dual-channel error ToolResult."""
+    # Truncate reason at 300 chars to avoid leaking huge internal tracebacks
+    clean_reason = reason[:300] if len(reason) > 300 else reason
+    struct: dict[str, Any] = {
+        "status": "error",
+        "tool": tool,
+        "reason": clean_reason,
+        "error_code": error_code or "EXECUTION_ERROR",
+    }
+    if agent_action:
+        struct["agent_action"] = agent_action
+    if details:
+        struct["details"] = details
+    if metrics:
+        struct["metrics"] = metrics
+
+    md = format_error_markdown(clean_reason, error_code=error_code, agent_action=agent_action)
+    return ToolResult(content=md, structured_content=struct, is_error=is_error)
+
+
+def classify_path(path: str) -> dict[str, Any]:
+    """Flag paths that look like agent-sandbox locations."""
+    matched_prefix = next(
+        (prefix for prefix in _SANDBOX_PATH_PREFIXES if path.startswith(prefix)),
+        None,
+    )
+    return {
+        "attempted_path": path,
+        "looks_like_sandbox_path": matched_prefix is not None,
+        "matched_prefix": matched_prefix,
+    }
+
+
+def path_access_error(
+    tool: str,
+    path: str,
+    *,
+    missing_code: str = "FILE_NOT_FOUND",
+    missing_reason: str = "Path does not exist on the MCP host filesystem.",
+    missing_action: str = "Provide a host-visible absolute path, or call get_runtime_context first.",
+    sandbox_action: str | None = None,
+) -> ToolResult:
+    """Return a path-access error ToolResult."""
+    path_context = classify_path(path)
+    if path_context["looks_like_sandbox_path"]:
+        return mcp_error(
+            tool,
+            "Path is not visible to the MCP server host filesystem.",
+            error_code="HOST_PATH_NOT_VISIBLE",
+            agent_action=sandbox_action
+            or "Ask the user for a host-visible absolute path, or call get_runtime_context first.",
+            details={"path_context": path_context},
+        )
+
+    return mcp_error(
+        tool,
+        missing_reason,
+        error_code=missing_code,
+        agent_action=missing_action,
+        details={"path_context": path_context},
+    )
+
+
+def unknown_handle_error(tool: str, handle_name: str, handle_value: str) -> ToolResult:
+    """Return an unknown-handle error ToolResult."""
+    return mcp_error(
+        tool,
+        f"Unknown {handle_name} '{handle_value}'.",
+        error_code=f"{handle_name.upper()}_UNKNOWN",
+        agent_action=f"Create or retrieve a valid {handle_name} (e.g. via load_demo_dataset or ingest_dataset) before retrying.",
+        details={handle_name: handle_value},
+    )
+
+
+def unknown_argument_error(tool: str, extra_keys: set[str], valid_keys: set[str]) -> ToolResult:
+    """Return UNKNOWN_ARGUMENT error ToolResult."""
+    extra_str = ", ".join(sorted(extra_keys))
+    valid_str = ", ".join(sorted(valid_keys))
+    return mcp_error(
+        tool,
+        f"Unknown argument(s): {extra_str}. Valid arguments for {tool}: {valid_str}.",
+        error_code="UNKNOWN_ARGUMENT",
+        agent_action="Rename the argument and retry. Function kwargs go inside `params`.",
+        details={
+            "unknown_arguments": sorted(extra_keys),
+            "valid_arguments": sorted(valid_keys),
+        },
+    )
+
+
+def classify_exception_error(
+    tool: str,
+    exc: Exception,
+    *,
+    namespace: str | None = None,
+    function: str | None = None,
+    fallback_code: str = "EXECUTION_ERROR",
+    fallback_action: str | None = None,
+) -> ToolResult:
+    """Classify an exception into a structured error ToolResult with a specific error_code.
+
+    Ported from origin fix #6. Every branch yields a non-generic ``error_code`` and an
+    ``agent_action``, so an agent that hits a failure always has a next move.
+    """
+    exc_type = type(exc).__name__
+    exc_msg = str(exc)
+    details: dict[str, Any] = {"exception_type": exc_type}
+    if namespace:
+        details["namespace"] = namespace
+    if function:
+        details["function"] = function
+
+    help_action = (
+        f"Call get_function_help(namespace='{namespace}', function='{function}') to inspect expected parameters."
+        if namespace and function
+        else "Inspect the tool parameters and retry."
+    )
+
+    if isinstance(exc, (ImportError, ModuleNotFoundError)) or "Install with" in exc_msg:
+        return mcp_error(
+            tool,
+            exc_msg,
+            error_code="DEPENDENCY_MISSING",
+            agent_action="Install the required optional dependency or ehrapy extra, then retry.",
+            details=details,
+        )
+
+    if isinstance(exc, TypeError):
+        return mcp_error(tool, exc_msg, error_code="INVALID_INPUT", agent_action=help_action, details=details)
+
+    if isinstance(exc, FileNotFoundError):
+        return mcp_error(
+            tool,
+            exc_msg,
+            error_code="FILE_NOT_FOUND",
+            agent_action="Verify the file path exists on the MCP host filesystem.",
+            details=details,
+        )
+
+    if isinstance(exc, KeyError):
+        return mcp_error(
+            tool,
+            exc_msg,
+            error_code="FUNCTION_UNKNOWN" if "Unknown" in exc_msg else "KEY_NOT_FOUND",
+            agent_action=("Check the requested key or column name against get_edata_snapshot() for available columns."),
+            details=details,
+        )
+
+    if isinstance(exc, AttributeError):
+        return mcp_error(
+            tool,
+            exc_msg,
+            error_code="INVALID_INPUT",
+            agent_action=help_action,
+            details=details,
+        )
+
+    if isinstance(exc, ValueError):
+        return mcp_error(
+            tool,
+            exc_msg,
+            error_code="INVALID_VALUE",
+            agent_action=fallback_action or help_action,
+            details=details,
+        )
+
+    return mcp_error(
+        tool,
+        exc_msg,
+        error_code=fallback_code,
+        agent_action=fallback_action or help_action,
+        details=details,
+    )

--- a/ehrapy/mcp/policy.py
+++ b/ehrapy/mcp/policy.py
@@ -1,0 +1,84 @@
+"""Security policy and filesystem confinement for ehrapy MCP."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+class SecurityPolicyError(Exception):
+    """Base exception for security policy violations."""
+
+    def __init__(self, message: str, *, error_code: str, agent_action: str | None = None) -> None:
+        super().__init__(message)
+        self.error_code = error_code
+        self.agent_action = agent_action
+
+
+class PathNotAllowedError(SecurityPolicyError):
+    """Raised when an accessed path is outside EHRAPY_MCP_ALLOWED_ROOTS."""
+
+    def __init__(self, path: str, allowed_roots: list[Path]) -> None:
+        roots_str = ", ".join(str(r) for r in allowed_roots)
+        super().__init__(
+            f"Path '{path}' is outside allowed roots: {roots_str}",
+            error_code="PATH_NOT_ALLOWED",
+            agent_action=f"Provide a path within one of the allowed roots: {roots_str}",
+        )
+        self.path = path
+        self.allowed_roots = allowed_roots
+
+
+class ReadOnlyModeError(SecurityPolicyError):
+    """Raised when a write operation is attempted in read-only mode."""
+
+    def __init__(self, operation: str = "write") -> None:
+        super().__init__(
+            f"Operation '{operation}' is prohibited: server is in read-only mode (EHRAPY_MCP_READ_ONLY=1).",
+            error_code="READ_ONLY_MODE",
+            agent_action="Read-only mode is active. Write/export operations are blocked.",
+        )
+
+
+def is_read_only_mode() -> bool:
+    """Return True if EHRAPY_MCP_READ_ONLY is set to 1, true, or yes."""
+    val = os.environ.get("EHRAPY_MCP_READ_ONLY", "").strip().lower()
+    return val in {"1", "true", "yes"}
+
+
+def get_allowed_roots() -> list[Path] | None:
+    """Return configured allowed roots or None if confinement is not enabled."""
+    val = os.environ.get("EHRAPY_MCP_ALLOWED_ROOTS", "").strip()
+    if not val:
+        return None
+    roots: list[Path] = []
+    for part in val.split(":"):
+        part = part.strip()
+        if part:
+            roots.append(Path(part).expanduser().resolve())
+    return roots if roots else None
+
+
+def check_path_allowed(path: str | Path, *, for_write: bool = False, operation: str = "write") -> Path:
+    """Validate a path against read-only mode and allowed roots.
+
+    Returns the resolved Path if allowed.
+    """
+    if for_write and is_read_only_mode():
+        raise ReadOnlyModeError(operation)
+
+    target = Path(path).expanduser().resolve()
+    allowed_roots = get_allowed_roots()
+    if allowed_roots is not None:
+        allowed = False
+        for root in allowed_roots:
+            try:
+                target.relative_to(root)
+                allowed = True
+                break
+            except ValueError:
+                continue
+        if not allowed:
+            raise PathNotAllowedError(str(path), allowed_roots)
+
+    return target

--- a/ehrapy/mcp/prompts.py
+++ b/ehrapy/mcp/prompts.py
@@ -48,8 +48,12 @@ WORKFLOW_PROMPT = """# ehrapy MCP Server — Agent Guide
 2. `run_analysis(function='covariate_balance')` → Assess balance
 3. `run_plot(function='love_plot')` → Render Love plot
 
-## Host vs. Sandbox Filesystem Paths
-All file paths passed to `ingest_dataset` or `export_edata` must refer to absolute, host-visible paths. Sandboxed agent paths (e.g. `/workspace`, `/home/claude`) are not accessible directly to the MCP host.
+## Host vs. Sandbox Filesystem Paths (Cache-Bridge Pattern)
+All file paths passed to `ingest_dataset` or `export_edata` must refer to absolute, host-visible paths. Sandboxed agent paths (e.g. `/workspace`, `/home/claude`) are not directly accessible to the MCP host.
+When operating in a sandboxed client environment:
+1. Call `get_runtime_context()` to obtain the host `cache_dir`.
+2. Copy or write your dataset file into that `cache_dir`.
+3. Call `ingest_dataset(file_path=f"{cache_dir}/filename.csv")` to load it.
 """
 
 SERVER_INSTRUCTIONS = """ehrapy MCP server provides clinical data analysis tools built on ehrapy and ehrdata.

--- a/ehrapy/mcp/prompts.py
+++ b/ehrapy/mcp/prompts.py
@@ -1,0 +1,59 @@
+"""Workflow guides, system prompts, and MCP prompt templates for ehrapy."""
+
+from __future__ import annotations
+
+WORKFLOW_PROMPT = """# ehrapy MCP Server — Agent Guide
+
+## Core Principles
+1. **Handle-Based Cohort State:** Datasets are tracked by string identifiers (`edata_id`). Tools implicitly default to the most recently created or modified handle (`used_latest: true`), but explicitly passing `edata_id` is recommended for multi-cohort workflows.
+2. **Dual-Channel Output:** Tools return structured metadata in `structured_content` (status, edata_id, dimensions, suggested_next) and formatted Markdown/tables/images in `content`.
+3. **Smart Serialization:** Tabular results default to concise column profiles with information ranking. Set `response_format='detailed'` only when you specifically need sample rows.
+4. **Non-Destructive Branching:** Use `fork_edata_handle` to preserve intermediate cohort states before irreversible transformations.
+
+## Tool Namespaces
+- `preprocessing` (`ep.pp.*`): Quality control (`qc_metrics`), encoding (`encode`), imputation (`knn_impute`, `miss_forest_impute`), normalization (`scale`, `minmax_scale`), PCA (`pca`), neighbor graph (`neighbors`).
+- `analysis` (`ep.tl.*`): Survival analysis (`kaplan_meier`, `cox_ph`), causal inference (`iptw`, `aipw`, `g_computation`), embeddings (`umap`, `tsne`), clustering (`leiden`), differential feature ranking (`rank_features_groups`).
+- `get` (`ep.get.*`): Read-only data extraction (`obs_df`, `var_df`, `rank_features_groups_df`).
+- `plot` (`ep.plot.*`): Visualizations returning PNG image artifacts and file paths.
+- `io` (`ehrdata.io.*`): Loading and saving files from/to disk (`read_csv`, `read_h5ed`, `to_pandas`).
+- `demo` (`ehrdata.dt.*`): Built-in demonstration datasets (`mimic_2`, `physionet2012`).
+
+## Standard Workflow Sequences
+
+### 1. Exploratory Data Analysis & Quality Control
+1. `load_demo_dataset(dataset='mimic_2')` or `ingest_dataset(file_path=...)`
+2. `get_edata_snapshot()` → Inspect variables, observations, layers
+3. `run_preprocessing(function='qc_metrics')` → Missingness and quality metrics
+4. `run_plot(function='missing_values_matrix')` → Visualize missingness patterns
+
+### 2. Dimension Reduction & Subtyping
+1. `run_preprocessing(function='encode', params={'autodetect': True})` → Encode categorical features (`autodetect` is required; a bare `encode` call errors)
+2. `run_preprocessing(function='knn_impute')` → Impute missing numerical values
+3. `run_preprocessing(function='pca')` → Principal component analysis
+4. `run_preprocessing(function='neighbors')` → Compute neighborhood graph
+5. `run_analysis(function='umap')` → Generate UMAP coordinates
+6. `run_analysis(function='leiden')` → Cluster patients into sub-phenotypes
+7. `run_plot(function='umap', params={'color': 'leiden'})` → Visualize patient clusters
+8. `run_analysis(function='rank_features_groups', params={'groupby': 'leiden'})` → Differentiating features
+9. `run_get(function='rank_features_groups_df')` → Tabular differential features
+
+### 3. Survival Analysis
+1. `run_analysis(function='kaplan_meier', params={'duration_col': 'mort_day_censored', 'event_col': 'censor_flg', 'groupby': 'service_unit'})`
+2. `run_plot(function='kaplan_meier')` → Survival curve plots
+3. `run_analysis(function='cox_ph', params={'duration_col': 'mort_day_censored', 'event_col': 'censor_flg', 'covariates': ['age', 'gender_num']})`
+4. `run_plot(function='cox_ph_forestplot')` → Hazard ratios forest plot
+
+### 4. Causal Inference
+1. `run_analysis(function='iptw', params={'treatment': 'aline_flg', 'outcome': 'hosp_exp_flg', 'covariates': ['age', 'gender_num', 'weight_first']})`
+2. `run_analysis(function='covariate_balance')` → Assess balance
+3. `run_plot(function='love_plot')` → Render Love plot
+
+## Host vs. Sandbox Filesystem Paths
+All file paths passed to `ingest_dataset` or `export_edata` must refer to absolute, host-visible paths. Sandboxed agent paths (e.g. `/workspace`, `/home/claude`) are not accessible directly to the MCP host.
+"""
+
+SERVER_INSTRUCTIONS = """ehrapy MCP server provides clinical data analysis tools built on ehrapy and ehrdata.
+Operate on clinical cohorts (MIMIC-II, PhysioNet, or custom tabular files) using handle-based EHRData objects.
+Always check get_function_help for required parameters before calling unfamiliar preprocessing or analysis functions.
+Results are returned with dual-channel structured metadata and compact Markdown tables.
+"""

--- a/ehrapy/mcp/registry.py
+++ b/ehrapy/mcp/registry.py
@@ -1,0 +1,198 @@
+"""Persistent dataset registry for EHRData handles."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import platformdirs
+
+
+def _get_default_cache_dir() -> Path:
+    env_dir = os.environ.get("EHRAPY_MCP_CACHE_DIR")
+    if env_dir:
+        return Path(env_dir).expanduser().resolve()
+    return Path(platformdirs.user_cache_dir("ehrapy-mcp")).resolve()
+
+
+@dataclass
+class DatasetRecord:
+    """Metadata for a cached EHRData handle."""
+
+    edata_id: str
+    cache_path: str
+    name: str
+    format: str
+    size_bytes: int
+    mtime_ns: int
+    ingested_at: float
+    source_path: str | None = None
+    n_obs: int | None = None
+    n_vars: int | None = None
+    parent_id: str | None = None
+
+
+class MCPRegistry:
+    """Process-wide registry of cached EHRData handles."""
+
+    def __init__(self, cache_dir: Path | None = None) -> None:
+        self._cache_dir_path = cache_dir or _get_default_cache_dir()
+        self._ensure_cache_dir()
+        self._process_lock = threading.RLock()
+
+    @property
+    def _datasets_path(self) -> Path:
+        return self._cache_dir_path / "datasets.json"
+
+    @property
+    def _lock_path(self) -> Path:
+        return self._cache_dir_path / ".registry.lock"
+
+    def _ensure_cache_dir(self) -> None:
+        self._cache_dir_path.mkdir(mode=0o700, parents=True, exist_ok=True)
+        try:
+            self._cache_dir_path.chmod(0o700)
+        except OSError:
+            pass
+        for sub in ("edata", "plots"):
+            sub_path = self._cache_dir_path / sub
+            sub_path.mkdir(mode=0o700, parents=True, exist_ok=True)
+            try:
+                sub_path.chmod(0o700)
+            except OSError:
+                pass
+
+    def cache_dir(self) -> Path:
+        """Return the MCP cache root."""
+        return self._cache_dir_path
+
+    def plots_dir(self) -> Path:
+        """Return the plot artifact directory."""
+        return self._cache_dir_path / "plots"
+
+    def store_record(self, record: DatasetRecord) -> DatasetRecord:
+        """Insert or update a dataset record."""
+        with self._locked_registry():
+            datasets = self._load_datasets_unlocked()
+            datasets[record.edata_id] = asdict(record)
+            self._write_json(self._datasets_path, datasets)
+        return record
+
+    def get_dataset(self, edata_id: str) -> DatasetRecord | None:
+        """Return a dataset record by handle, if present."""
+        payload = self._load_datasets().get(edata_id)
+        if payload is None:
+            return None
+        return DatasetRecord(**payload)
+
+    def list_datasets(self) -> list[DatasetRecord]:
+        """Return all registered dataset records."""
+        return [DatasetRecord(**v) for v in self._load_datasets().values()]
+
+    def delete_record(self, edata_id: str) -> None:
+        """Remove a dataset record and its cache file if present."""
+        with self._locked_registry():
+            datasets = self._load_datasets_unlocked()
+            if edata_id in datasets:
+                rec = DatasetRecord(**datasets[edata_id])
+                del datasets[edata_id]
+                self._write_json(self._datasets_path, datasets)
+                cache = Path(rec.cache_path)
+                if cache.is_file():
+                    try:
+                        cache.unlink()
+                    except OSError:
+                        pass
+
+    def purge(self, older_than_days: int | None = None) -> int:
+        """Purge stale and orphaned records. Return number of records purged."""
+        if older_than_days is None:
+            ttl_env = os.environ.get("EHRAPY_MCP_CACHE_TTL_DAYS", "").strip()
+            if ttl_env:
+                try:
+                    older_than_days = int(ttl_env)
+                except ValueError:
+                    older_than_days = None
+
+        purged_count = 0
+        cutoff = time.time() - (older_than_days * 86400) if older_than_days is not None else None
+
+        with self._locked_registry():
+            datasets = self._load_datasets_unlocked()
+            to_delete: list[str] = []
+            for edata_id, raw_record in datasets.items():
+                record = DatasetRecord(**raw_record)
+                cache_file = Path(record.cache_path)
+                if not cache_file.is_file():
+                    to_delete.append(edata_id)
+                    continue
+                if cutoff is not None and record.ingested_at < cutoff:
+                    to_delete.append(edata_id)
+                    try:
+                        cache_file.unlink()
+                    except OSError:
+                        pass
+
+            for edata_id in to_delete:
+                del datasets[edata_id]
+                purged_count += 1
+
+            if to_delete:
+                self._write_json(self._datasets_path, datasets)
+
+        return purged_count
+
+    def _load_datasets(self) -> dict[str, dict]:
+        with self._locked_registry():
+            return self._load_datasets_unlocked()
+
+    def _load_datasets_unlocked(self) -> dict[str, dict]:
+        if not self._datasets_path.is_file():
+            return {}
+        try:
+            return json.loads(self._datasets_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return {}
+
+    @contextmanager
+    def _locked_registry(self):
+        with self._process_lock:
+            self._ensure_cache_dir()
+            with self._lock_path.open("a+", encoding="utf-8") as handle:
+                self._acquire_file_lock(handle)
+                try:
+                    yield
+                finally:
+                    self._release_file_lock(handle)
+
+    @staticmethod
+    def _acquire_file_lock(handle) -> None:
+        try:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        except ImportError:
+            pass
+
+    @staticmethod
+    def _release_file_lock(handle) -> None:
+        try:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        except ImportError:
+            pass
+
+    @staticmethod
+    def _write_json(path: Path, payload: dict) -> None:
+        tmp = path.with_name(path.name + ".tmp")
+        tmp.write_text(json.dumps(payload, separators=(",", ":")), encoding="utf-8")
+        tmp.replace(path)
+
+
+registry = MCPRegistry()

--- a/ehrapy/mcp/registry.py
+++ b/ehrapy/mcp/registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 import threading
 import time
 from contextlib import contextmanager
@@ -13,11 +14,47 @@ from pathlib import Path
 import platformdirs
 
 
+def _probe_writable(path: Path) -> bool:
+    """Return True if path can be created and written to."""
+    try:
+        path.mkdir(mode=0o700, parents=True, exist_ok=True)
+        probe = path / f".probe_{os.getpid()}_{time.time_ns()}"
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink()
+        return True
+    except OSError:
+        return False
+
+
 def _get_default_cache_dir() -> Path:
     env_dir = os.environ.get("EHRAPY_MCP_CACHE_DIR")
     if env_dir:
-        return Path(env_dir).expanduser().resolve()
-    return Path(platformdirs.user_cache_dir("ehrapy-mcp")).resolve()
+        cand = Path(env_dir).expanduser().resolve()
+        if _probe_writable(cand):
+            return cand
+    user_cache = Path(platformdirs.user_cache_dir("ehrapy-mcp")).resolve()
+    if _probe_writable(user_cache):
+        return user_cache
+    temp_cache = Path(tempfile.gettempdir()) / "ehrapy-mcp"
+    if _probe_writable(temp_cache):
+        return temp_cache
+    return Path(tempfile.mkdtemp(prefix="ehrapy_mcp_"))
+
+
+def _get_default_demo_data_dir(cache_dir: Path) -> Path:
+    for env_var in ("EHRAPY_MCP_DEMO_DATA_DIR", "EHRAPY_DEMO_DATA_DIR", "EHRAPY_DATA_DIR"):
+        val = os.environ.get(env_var)
+        if val:
+            cand = Path(val).expanduser().resolve()
+            if _probe_writable(cand):
+                return cand
+    cand = cache_dir / "demo_data"
+    if _probe_writable(cand):
+        return cand
+    temp_demo = Path(tempfile.gettempdir()) / "ehrapy_data"
+    if _probe_writable(temp_demo):
+        return temp_demo
+    return Path(tempfile.mkdtemp(prefix="ehrapy_demo_data_"))
 
 
 @dataclass
@@ -42,8 +79,33 @@ class MCPRegistry:
 
     def __init__(self, cache_dir: Path | None = None) -> None:
         self._cache_dir_path = cache_dir or _get_default_cache_dir()
+        self._demo_data_dir_path = _get_default_demo_data_dir(self._cache_dir_path)
         self._ensure_cache_dir()
         self._process_lock = threading.RLock()
+        self._configure_ehrapy_demo_paths()
+
+    def _configure_ehrapy_demo_paths(self) -> None:
+        """Point ehrdata/ehrapy/scanpy demo data loaders to the writable demo directory."""
+        try:
+            import ehrdata.core.constants as ed_const
+            import ehrdata.dt.datasets as ed_datasets
+
+            ed_const.DEFAULT_DATA_PATH = self._demo_data_dir_path
+            ed_datasets.DEFAULT_DATA_PATH = self._demo_data_dir_path
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            import ehrapy as ep
+
+            ep.settings.datasetdir = self._demo_data_dir_path
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            import scanpy as sc
+
+            sc.settings.datasetdir = self._demo_data_dir_path
+        except Exception:  # noqa: BLE001
+            pass
 
     @property
     def _datasets_path(self) -> Path:
@@ -54,15 +116,17 @@ class MCPRegistry:
         return self._cache_dir_path / ".registry.lock"
 
     def _ensure_cache_dir(self) -> None:
+        if not _probe_writable(self._cache_dir_path):
+            self._cache_dir_path = _get_default_cache_dir()
         self._cache_dir_path.mkdir(mode=0o700, parents=True, exist_ok=True)
         try:
             self._cache_dir_path.chmod(0o700)
         except OSError:
             pass
-        for sub in ("edata", "plots"):
+        for sub in ("edata", "plots", "demo_data"):
             sub_path = self._cache_dir_path / sub
-            sub_path.mkdir(mode=0o700, parents=True, exist_ok=True)
             try:
+                sub_path.mkdir(mode=0o700, parents=True, exist_ok=True)
                 sub_path.chmod(0o700)
             except OSError:
                 pass
@@ -74,6 +138,21 @@ class MCPRegistry:
     def plots_dir(self) -> Path:
         """Return the plot artifact directory."""
         return self._cache_dir_path / "plots"
+
+    def demo_data_dir(self) -> Path:
+        """Return the writable demo data directory."""
+        return self._demo_data_dir_path
+
+    def is_cache_writable(self) -> bool:
+        """Return True if cache and demo directories are confirmed writable."""
+        return _probe_writable(self._cache_dir_path) and _probe_writable(self._demo_data_dir_path)
+
+    def ensure_demo_data_dir(self) -> Path:
+        """Ensure demo data directory is configured and writable, falling back if needed."""
+        if not _probe_writable(self._demo_data_dir_path):
+            self._demo_data_dir_path = _get_default_demo_data_dir(self._cache_dir_path)
+        self._configure_ehrapy_demo_paths()
+        return self._demo_data_dir_path
 
     def store_record(self, record: DatasetRecord) -> DatasetRecord:
         """Insert or update a dataset record."""
@@ -148,8 +227,7 @@ class MCPRegistry:
         return purged_count
 
     def _load_datasets(self) -> dict[str, dict]:
-        with self._locked_registry():
-            return self._load_datasets_unlocked()
+        return self._load_datasets_unlocked()
 
     def _load_datasets_unlocked(self) -> dict[str, dict]:
         if not self._datasets_path.is_file():
@@ -163,12 +241,15 @@ class MCPRegistry:
     def _locked_registry(self):
         with self._process_lock:
             self._ensure_cache_dir()
-            with self._lock_path.open("a+", encoding="utf-8") as handle:
-                self._acquire_file_lock(handle)
-                try:
-                    yield
-                finally:
-                    self._release_file_lock(handle)
+            try:
+                with self._lock_path.open("a+", encoding="utf-8") as handle:
+                    self._acquire_file_lock(handle)
+                    try:
+                        yield
+                    finally:
+                        self._release_file_lock(handle)
+            except OSError:
+                yield
 
     @staticmethod
     def _acquire_file_lock(handle) -> None:

--- a/ehrapy/mcp/serialization.py
+++ b/ehrapy/mcp/serialization.py
@@ -207,6 +207,30 @@ def _profile_dataframe(
     return full_md, meta
 
 
+def _find_strat_col(df: pd.DataFrame, relevant_cols: set[str]) -> str | None:
+    """Find a relevant, non-numeric column to stratify the middle sample by."""
+    for col in relevant_cols:
+        if col in df.columns and (not pd.api.types.is_numeric_dtype(df[col]) or pd.api.types.is_bool_dtype(df[col])):
+            return col
+    return None
+
+
+def _middle_sample_positions(mid_df: pd.DataFrame, strat_col: str | None, middle_n: int) -> list[int]:
+    """Pick ``middle_n`` row positions (relative to ``mid_df``), stratified when useful."""
+    pos_series = pd.Series(range(len(mid_df)))
+    if strat_col is None or mid_df[strat_col].nunique() <= 1:
+        return list(pos_series.sample(min(middle_n, len(pos_series)), random_state=42))
+    try:
+        strat_labels = pd.Series(mid_df[strat_col].to_numpy())
+        grouped = pos_series.groupby(strat_labels, group_keys=False)
+        sampled_rel = grouped.apply(
+            lambda g: g.sample(max(1, int(len(g) / len(pos_series) * middle_n)), random_state=42)
+        )
+        return list(sampled_rel.iloc[:middle_n])
+    except Exception:  # noqa: BLE001
+        return list(pos_series.sample(min(middle_n, len(pos_series)), random_state=42))
+
+
 def _sample_rows(
     df: pd.DataFrame,
     relevant_cols: set[str],
@@ -224,48 +248,88 @@ def _sample_rows(
     tail_n = min(5, n_rows - head_n)
     middle_n = max(0, row_budget - head_n - tail_n)
 
-    head_idx = list(df.index[:head_n])
-    tail_idx = list(df.index[-tail_n:]) if tail_n > 0 else []
-    remaining_idx = [i for i in df.index if i not in head_idx and i not in tail_idx]
+    head_pos = list(range(head_n))
+    tail_pos = list(range(n_rows - tail_n, n_rows)) if tail_n > 0 else []
+    mid_pos_range = list(range(head_n, n_rows - tail_n))
 
-    sample_idx: list[Any] = []
-    if middle_n > 0 and remaining_idx:
-        mid_df = df.loc[remaining_idx]
-        strat_col = None
-        for col in relevant_cols:
-            if col in df.columns and (
-                not pd.api.types.is_numeric_dtype(df[col]) or pd.api.types.is_bool_dtype(df[col])
-            ):
-                strat_col = col
-                break
-        if strat_col is not None and mid_df[strat_col].nunique() > 1:
-            try:
-                sampled = mid_df.groupby(strat_col, group_keys=False).apply(
-                    lambda g: g.sample(max(1, int(len(g) / len(mid_df) * middle_n)), random_state=42)
-                )
-                sample_idx = list(sampled.index[:middle_n])
-            except Exception:  # noqa: BLE001
-                sample_idx = list(mid_df.sample(min(middle_n, len(mid_df)), random_state=42).index)
-        else:
-            sample_idx = list(mid_df.sample(min(middle_n, len(mid_df)), random_state=42).index)
+    sample_pos: list[int] = []
+    if middle_n > 0 and mid_pos_range:
+        mid_df = df.iloc[mid_pos_range]
+        strat_col = _find_strat_col(df, relevant_cols)
+        chosen_rel = _middle_sample_positions(mid_df, strat_col, middle_n)
+        sample_pos = [mid_pos_range[p] for p in chosen_rel]
 
-    rows = []
-    for idx in head_idx:
-        r = df.loc[idx].to_dict()
-        r["sample"] = "head"
-        rows.append(r)
-    for idx in sample_idx:
-        r = df.loc[idx].to_dict()
-        r["sample"] = "sample"
-        rows.append(r)
-    for idx in tail_idx:
-        r = df.loc[idx].to_dict()
-        r["sample"] = "tail"
-        rows.append(r)
+    all_positions = head_pos + sample_pos + tail_pos
+    sample_tags = ["head"] * len(head_pos) + ["sample"] * len(sample_pos) + ["tail"] * len(tail_pos)
 
-    sampled_df = pd.DataFrame(rows)
-    cols = ["sample"] + [c for c in sampled_df.columns if c != "sample"]
-    return sampled_df[cols]
+    sampled_df = df.iloc[all_positions].copy()
+    sampled_df.insert(0, "sample", sample_tags)
+    return sampled_df
+
+
+def _serialize_empty_dataframe(
+    df: pd.DataFrame, params: dict[str, Any], function: str, edata: EHRData | None
+) -> tuple[dict[str, Any], str]:
+    """Serialize a DataFrame with no rows or no columns, steering toward a `keys` param if applicable."""
+    if not params.get("keys") and function in ("obs_df", "var_df", "rank_features_groups_df"):
+        avail_cols: list[str] = []
+        if edata is not None:
+            if function == "obs_df":
+                avail_cols = list(edata.obs.columns[:30])
+            elif function == "var_df":
+                avail_cols = list(edata.var.columns[:30])
+        avail_str = f" Available columns: {', '.join(avail_cols)}" if avail_cols else ""
+        meta = {
+            "status": "ok_empty",
+            "shape": list(df.shape),
+            "agent_action": f"No columns requested. Specify columns using `params={{'keys': [...]}}`.{avail_str}",
+        }
+        md = f"# Result: ok_empty\n\nReturned table shape is `{list(df.shape)}`.\n\n**Action:** {meta['agent_action']}"
+        return meta, md
+    meta = {"type": "dataframe", "shape": list(df.shape)}
+    return meta, f"Empty DataFrame (shape: {list(df.shape)})."
+
+
+def _tier3_sampled_view(
+    df: pd.DataFrame,
+    relevant_cols: set[str],
+    response_format: Literal["concise", "detailed"],
+    params: dict[str, Any],
+) -> tuple[dict[str, Any], str] | None:
+    """Return a Tier-3 sampled-row view when rows were explicitly requested, else None."""
+    if response_format != "detailed" and "rows" not in params:
+        return None
+    sampled = _sample_rows(df, relevant_cols)
+    table_md = _df_to_markdown_table(sampled)
+    meta: dict[str, Any] = {"type": "dataframe", "shape": list(df.shape), "tier": 3, "sampled_rows": len(sampled)}
+    md = f"### DataFrame ({df.shape[0]} rows × {df.shape[1]} columns — sampled view)\n\n" + table_md
+    return meta, md
+
+
+def _tier1_full_table(df: pd.DataFrame) -> tuple[dict[str, Any], str] | None:
+    """Return the whole table rendered as Markdown if it fits the Tier-1 budget, else None."""
+    # Bound the work first -- rendering a 100k-row frame to Markdown just to discover it is
+    # too big is the exact overflow this tier is meant to prevent.
+    cells = df.shape[0] * max(1, df.shape[1])
+    if cells > _TIER1_MAX_CHARS:
+        return None
+    full_table_md = _df_to_markdown_table(df)
+    if len(full_table_md) > _TIER1_MAX_CHARS:
+        return None
+    meta: dict[str, Any] = {"type": "dataframe", "shape": list(df.shape), "tier": 1}
+    md = f"### DataFrame ({df.shape[0]} rows × {df.shape[1]} columns)\n\n" + full_table_md
+    return meta, md
+
+
+def _tier2_profile(df: pd.DataFrame, relevant_cols: set[str], is_whole_table: bool) -> tuple[dict[str, Any], str]:
+    """Render the Tier-2 column-profile view (default for large or whole-table results)."""
+    profile_md, profile_meta = _profile_dataframe(df, relevant_cols)
+    profile_meta["tier"] = 2
+    header = f"### Column Profile ({df.shape[0]} rows × {df.shape[1]} columns)\n\n"
+    steering = ""
+    if is_whole_table:
+        steering = "\n\n*Full table not returned — use `export_edata` to write it to disk, or `run_get` with `keys=[...]` for specific columns.*"
+    return profile_meta, header + profile_md + steering
 
 
 def _serialize_dataframe(
@@ -280,70 +344,20 @@ def _serialize_dataframe(
     params = params or {}
     relevant_cols = _extract_relevant_columns(params)
 
-    # Empty result guard
     if df.shape[0] == 0 or df.shape[1] == 0:
-        if not params.get("keys") and function in (
-            "obs_df",
-            "var_df",
-            "rank_features_groups_df",
-        ):
-            avail_cols: list[str] = []
-            if edata is not None:
-                if function == "obs_df":
-                    avail_cols = list(edata.obs.columns[:30])
-                elif function == "var_df":
-                    avail_cols = list(edata.var.columns[:30])
-            avail_str = f" Available columns: {', '.join(avail_cols)}" if avail_cols else ""
-            meta = {
-                "status": "ok_empty",
-                "shape": list(df.shape),
-                "agent_action": f"No columns requested. Specify columns using `params={{'keys': [...]}}`.{avail_str}",
-            }
-            md = f"# Result: ok_empty\n\nReturned table shape is `{list(df.shape)}`.\n\n**Action:** {meta['agent_action']}"
-            return meta, md
-        # Plain empty dataframe
-        meta = {"type": "dataframe", "shape": list(df.shape)}
-        return meta, f"Empty DataFrame (shape: {list(df.shape)})."
+        return _serialize_empty_dataframe(df, params, function, edata)
 
-    # Whole table return guard (e.g. to_pandas)
     is_whole_table = function == "to_pandas"
 
     if not is_whole_table:
-        # Tier 3: rows explicitly requested
-        if response_format == "detailed" or "rows" in params:
-            sampled = _sample_rows(df, relevant_cols)
-            table_md = _df_to_markdown_table(sampled)
-            meta_tier3: dict[str, Any] = {
-                "type": "dataframe",
-                "shape": list(df.shape),
-                "tier": 3,
-                "sampled_rows": len(sampled),
-            }
-            md = f"### DataFrame ({df.shape[0]} rows × {df.shape[1]} columns — sampled view)\n\n" + table_md
-            return meta_tier3, md
+        tier3 = _tier3_sampled_view(df, relevant_cols, response_format, params)
+        if tier3 is not None:
+            return tier3
+        tier1 = _tier1_full_table(df)
+        if tier1 is not None:
+            return tier1
 
-        # Tier 1: Pass-through if it fits the Tier 1 budget. Bound the work first --
-        # rendering a 100k-row frame to Markdown just to discover it is too big is the
-        # exact overflow this tier is meant to prevent.
-        cells = df.shape[0] * max(1, df.shape[1])
-        if cells <= _TIER1_MAX_CHARS:
-            full_table_md = _df_to_markdown_table(df)
-        else:
-            full_table_md = None
-        if full_table_md is not None and len(full_table_md) <= _TIER1_MAX_CHARS:
-            meta_tier1: dict[str, Any] = {"type": "dataframe", "shape": list(df.shape), "tier": 1}
-            md = f"### DataFrame ({df.shape[0]} rows × {df.shape[1]} columns)\n\n" + full_table_md
-            return meta_tier1, md
-
-    # Tier 2: Profile-first (default for large DataFrames or whole-table returns)
-    profile_md, profile_meta = _profile_dataframe(df, relevant_cols)
-    profile_meta["tier"] = 2
-    header = f"### Column Profile ({df.shape[0]} rows × {df.shape[1]} columns)\n\n"
-    steering = ""
-    if is_whole_table:
-        steering = "\n\n*Full table not returned — use `export_edata` to write it to disk, or `run_get` with `keys=[...]` for specific columns.*"
-
-    return profile_meta, header + profile_md + steering
+    return _tier2_profile(df, relevant_cols, is_whole_table)
 
 
 def _unique_plot_path(plots_dir: Path, stem: str) -> Path:
@@ -442,6 +456,36 @@ _JSON_SAFE_SCALARS = (str, bool, int, float)
 _MAX_INLINE_SEQUENCE = 32
 
 
+def _json_safe_ndarray(value: np.ndarray, depth: int) -> Any:
+    if value.ndim == 1 and value.size <= _MAX_INLINE_SEQUENCE:
+        return [_json_safe(v, depth) for v in value.tolist()]
+    return {"type": "ndarray", "shape": list(value.shape), "dtype": str(value.dtype)}
+
+
+def _json_safe_sequence(seq_like: list[Any] | tuple[Any, ...] | set[Any], depth: int) -> list[Any]:
+    seq = list(seq_like)
+    out = [_json_safe(v, depth) for v in seq[:_MAX_INLINE_SEQUENCE]]
+    if len(seq) > _MAX_INLINE_SEQUENCE:
+        out.append(f"... ({len(seq) - _MAX_INLINE_SEQUENCE} more)")
+    return out
+
+
+def _json_safe_scalar(value: Any) -> Any:
+    """Coerce a scalar to JSON-safe, mapping non-finite floats (NaN/inf) to None."""
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    return value
+
+
+def _json_safe_pandas(value: Any) -> dict[str, Any] | None:
+    """Summarize a pandas Series/DataFrame, or None if ``value`` is neither."""
+    if isinstance(value, pd.Series):
+        return {"type": "series", "length": int(len(value)), "dtype": str(value.dtype)}
+    if isinstance(value, pd.DataFrame):
+        return {"type": "dataframe", "shape": list(value.shape)}
+    return None
+
+
 def _json_safe(value: Any, _depth: int = 0) -> Any:
     """Coerce a value into something FastMCP can place in ``structured_content``.
 
@@ -450,28 +494,189 @@ def _json_safe(value: Any, _depth: int = 0) -> Any:
     ``CausalEstimate`` carry ndarrays inside nested ``params`` dicts, so this recurses.
     """
     if value is None or isinstance(value, _JSON_SAFE_SCALARS):
-        return None if isinstance(value, float) and not math.isfinite(value) else value
+        return _json_safe_scalar(value)
     if _depth >= 4:
         return f"<{type(value).__name__}>"
     if isinstance(value, (np.integer, np.floating, np.bool_)):
         return _json_safe(value.item(), _depth + 1)
     if isinstance(value, np.ndarray):
-        if value.ndim == 1 and value.size <= _MAX_INLINE_SEQUENCE:
-            return [_json_safe(v, _depth + 1) for v in value.tolist()]
-        return {"type": "ndarray", "shape": list(value.shape), "dtype": str(value.dtype)}
-    if isinstance(value, pd.Series):
-        return {"type": "series", "length": int(len(value)), "dtype": str(value.dtype)}
-    if isinstance(value, pd.DataFrame):
-        return {"type": "dataframe", "shape": list(value.shape)}
+        return _json_safe_ndarray(value, _depth + 1)
+    pandas_meta = _json_safe_pandas(value)
+    if pandas_meta is not None:
+        return pandas_meta
     if isinstance(value, dict):
         return {str(k): _json_safe(v, _depth + 1) for k, v in value.items()}
     if isinstance(value, (list, tuple, set)):
-        seq = list(value)
-        out = [_json_safe(v, _depth + 1) for v in seq[:_MAX_INLINE_SEQUENCE]]
-        if len(seq) > _MAX_INLINE_SEQUENCE:
-            out.append(f"... ({len(seq) - _MAX_INLINE_SEQUENCE} more)")
-        return out
+        return _json_safe_sequence(value, _depth + 1)
     return str(value)[:200]
+
+
+def _truncate_markdown(md: str, max_chars: int, suffix: str) -> str:
+    """Truncate markdown at a line boundary near max_chars, appending an explanatory suffix."""
+    if len(md) <= max_chars:
+        return md
+    cutoff = md[:max_chars].rfind("\n")
+    cutoff = cutoff if cutoff > 0 else max_chars
+    return md[:cutoff] + suffix
+
+
+def _serialize_visual(result: Any, plots_dir: Path | None) -> tuple[dict[str, Any], list[Any]] | None:
+    """Serialize a visual/plot result to a saved PNG, or None if ``result`` is not visual."""
+    visual_saved = _try_save_visual(result, plots_dir)
+    if visual_saved is None:
+        return None
+    meta, path = visual_saved
+    md = f"Plot rendered successfully and saved to `{path}`."
+    return meta, [md, Image(path=str(path))]
+
+
+def _serialize_ehrdata(result: EHRData) -> tuple[dict[str, Any], str]:
+    meta = {"type": "EHRData", "n_obs": result.n_obs, "n_vars": result.n_vars}
+    md = f"**EHRData dataset:** {result.n_obs} observations × {result.n_vars} variables"
+    return meta, md
+
+
+def _serialize_single_dataframe(
+    result: pd.DataFrame,
+    *,
+    response_format: Literal["concise", "detailed"],
+    params: dict[str, Any],
+    function: str,
+    edata: EHRData | None,
+    max_chars: int,
+) -> tuple[dict[str, Any], str]:
+    meta, md = _serialize_dataframe(
+        result, response_format=response_format, params=params, function=function, edata=edata
+    )
+    md = _truncate_markdown(
+        md, max_chars, f"\n\n*... [Output truncated at {max_chars} characters. Narrow your query with parameters.]*"
+    )
+    return meta, md
+
+
+def _is_dataframe_collection(result: Any) -> bool:
+    """True if ``result`` is a tuple/list containing at least one DataFrame."""
+    return isinstance(result, (tuple, list)) and any(isinstance(x, pd.DataFrame) for x in result)
+
+
+def _table_label_and_missing_note(idx: int, item: pd.DataFrame) -> tuple[str, str]:
+    """Determine a section label for one table in a collection, and any missingness callout."""
+    label = "Observations" if idx == 0 and "missing_values_abs" in item.columns else f"Table {idx + 1}"
+    note = ""
+    if "missing_values_pct" in item.columns and "missing_values_abs" in item.columns and item.shape[0] < 1000:
+        label = "Variables Quality Metrics"
+        top_m = item.sort_values("missing_values_pct", ascending=False).head(5)
+        parts = [
+            f"{idx_name} ({row['missing_values_pct']:.1f}%)"
+            for idx_name, row in top_m.iterrows()
+            if row["missing_values_pct"] > 0
+        ]
+        if parts:
+            note = f"\n\n**Highest-missingness variables:** {', '.join(parts)}"
+    return label, note
+
+
+def _serialize_dataframe_collection(
+    result: tuple[Any, ...] | list[Any],
+    *,
+    response_format: Literal["concise", "detailed"],
+    params: dict[str, Any],
+    function: str,
+    edata: EHRData | None,
+    max_chars: int,
+) -> tuple[dict[str, Any], str]:
+    """Serialize a tuple/list containing one or more DataFrames (e.g. qc_metrics)."""
+    table_sections: list[str] = []
+    table_metas: list[dict[str, Any]] = []
+    top_missing_note = ""
+
+    for idx, item in enumerate(result):
+        if not isinstance(item, pd.DataFrame):
+            table_sections.append(f"### Item {idx + 1}\n\n`{repr(item)[:500]}`")
+            continue
+        t_meta, t_md = _serialize_dataframe(
+            item, response_format=response_format, params=params, function=function, edata=edata
+        )
+        label, note = _table_label_and_missing_note(idx, item)
+        if note:
+            top_missing_note = note
+        table_sections.append(f"### {label}\n\n{t_md}")
+        table_metas.append(t_meta)
+
+    full_md = "\n\n---\n\n".join(table_sections) + top_missing_note
+    full_md = _truncate_markdown(full_md, max_chars, f"\n\n*... [Output truncated at {max_chars} characters.]*")
+
+    return {"type": "table_collection", "tables": table_metas}, full_md
+
+
+def _serialize_series(result: pd.Series) -> tuple[dict[str, Any], str]:
+    if len(result) <= 20:
+        df_s = result.reset_index()
+        md = f"### Series `{result.name or 'result'}`\n\n" + _df_to_markdown_table(df_s)
+    else:
+        df_s = pd.DataFrame({"index": list(result.index), "value": list(result.values)})
+        prof_md, _ = _profile_dataframe(df_s, set())
+        md = f"### Series `{result.name or 'result'}` (Profile)\n\n" + prof_md
+    meta = {"type": "series", "name": result.name, "length": len(result)}
+    return meta, md
+
+
+def _serialize_ndarray(result: np.ndarray) -> tuple[dict[str, Any], str]:
+    meta = {"type": "ndarray", "shape": list(result.shape), "dtype": str(result.dtype)}
+    md = f"**Array result:** shape `{list(result.shape)}`, dtype `{result.dtype}`"
+    return meta, md
+
+
+def _serialize_array_like(result: Any) -> tuple[dict[str, Any], str] | None:
+    """Serialize a pandas Series or numpy ndarray, or None if ``result`` is neither."""
+    if isinstance(result, pd.Series):
+        return _serialize_series(result)
+    if isinstance(result, np.ndarray):
+        return _serialize_ndarray(result)
+    return None
+
+
+def _serialize_dataclass(result: Any) -> tuple[dict[str, Any], str]:
+    d = asdict(result)
+    meta = {"type": type(result).__name__, **d}
+    md = f"### {type(result).__name__}\n\n" + "\n".join(f"- **{k}:** `{v}`" for k, v in d.items())
+    return meta, md
+
+
+def _serialize_dict_result(result: dict[str, Any]) -> tuple[dict[str, Any], str]:
+    meta = {str(k): (v if isinstance(v, (int, float, str, bool)) else str(type(v).__name__)) for k, v in result.items()}
+    md = "### Result\n\n" + "\n".join(f"- **{k}:** `{v}`" for k, v in result.items())
+    return meta, md
+
+
+def _serialize_structured(result: Any) -> tuple[dict[str, Any], str] | None:
+    """Serialize a dataclass instance or a plain dict, or None if ``result`` is neither."""
+    if is_dataclass(result) and not isinstance(result, type):
+        return _serialize_dataclass(result)
+    if isinstance(result, dict):
+        return _serialize_dict_result(result)
+    return None
+
+
+def _serialize_with_summary(result: Any) -> tuple[dict[str, Any], str] | None:
+    """Serialize via a summary() method (e.g. statsmodels/lifelines results), or None if unavailable."""
+    summary_fn = getattr(result, "summary", None)
+    if not callable(summary_fn):
+        return None
+    try:
+        summ_text = str(summary_fn())[:_MAX_REPR_CHARS]
+    except Exception:  # noqa: BLE001
+        return None
+    meta = {"type": type(result).__name__}
+    md = f"### {type(result).__name__} Summary\n\n```\n{summ_text}\n```"
+    return meta, md
+
+
+def _serialize_fallback_repr(result: Any) -> tuple[dict[str, Any], str]:
+    repr_str = repr(result)[:_MAX_REPR_CHARS]
+    meta = {"type": type(result).__name__}
+    md = f"```\n{repr_str}\n```"
+    return meta, md
 
 
 def _serialize_result_inner(
@@ -487,141 +692,49 @@ def _serialize_result_inner(
     params = params or {}
     max_chars = _get_max_result_chars()
 
-    # None
     if result is None:
         return {}, "Operation completed successfully."
 
-    # Visual / Plot object
-    visual_saved = _try_save_visual(result, plots_dir)
-    if visual_saved is not None:
-        meta, path = visual_saved
-        md = f"Plot rendered successfully and saved to `{path}`."
-        img = Image(path=str(path))
-        return meta, [md, img]
+    visual = _serialize_visual(result, plots_dir)
+    if visual is not None:
+        return visual
 
-    # EHRData
     if isinstance(result, EHRData):
-        meta = {"type": "EHRData", "n_obs": result.n_obs, "n_vars": result.n_vars}
-        md = f"**EHRData dataset:** {result.n_obs} observations × {result.n_vars} variables"
-        return meta, md
+        return _serialize_ehrdata(result)
 
-    # Single DataFrame
     if isinstance(result, pd.DataFrame):
-        meta, md = _serialize_dataframe(
+        return _serialize_single_dataframe(
             result,
             response_format=response_format,
             params=params,
             function=function,
             edata=edata,
+            max_chars=max_chars,
         )
-        if len(md) > max_chars:
-            cutoff = md[:max_chars].rfind("\n")
-            cutoff = cutoff if cutoff > 0 else max_chars
-            md = (
-                md[:cutoff]
-                + f"\n\n*... [Output truncated at {max_chars} characters. Narrow your query with parameters.]*"
-            )
-        return meta, md
 
-    # Tuple / list of DataFrames (e.g. qc_metrics)
-    if isinstance(result, (tuple, list)) and any(isinstance(x, pd.DataFrame) for x in result):
-        table_sections: list[str] = []
-        table_metas: list[dict[str, Any]] = []
-        top_missing_note = ""
+    if _is_dataframe_collection(result):
+        return _serialize_dataframe_collection(
+            result,
+            response_format=response_format,
+            params=params,
+            function=function,
+            edata=edata,
+            max_chars=max_chars,
+        )
 
-        for idx, item in enumerate(result):
-            if isinstance(item, pd.DataFrame):
-                t_meta, t_md = _serialize_dataframe(
-                    item,
-                    response_format=response_format,
-                    params=params,
-                    function=function,
-                    edata=edata,
-                )
-                label = "Observations" if idx == 0 and "missing_values_abs" in item.columns else f"Table {idx + 1}"
-                if (
-                    "missing_values_pct" in item.columns
-                    and "missing_values_abs" in item.columns
-                    and item.shape[0] < 1000
-                ):
-                    label = "Variables Quality Metrics"
-                    # Extract top missing
-                    top_m = item.sort_values("missing_values_pct", ascending=False).head(5)
-                    parts = [
-                        f"{idx_name} ({row['missing_values_pct']:.1f}%)"
-                        for idx_name, row in top_m.iterrows()
-                        if row["missing_values_pct"] > 0
-                    ]
-                    if parts:
-                        top_missing_note = f"\n\n**Highest-missingness variables:** {', '.join(parts)}"
+    array_like = _serialize_array_like(result)
+    if array_like is not None:
+        return array_like
 
-                table_sections.append(f"### {label}\n\n{t_md}")
-                table_metas.append(t_meta)
-            else:
-                table_sections.append(f"### Item {idx + 1}\n\n`{repr(item)[:500]}`")
+    structured = _serialize_structured(result)
+    if structured is not None:
+        return structured
 
-        full_md = "\n\n---\n\n".join(table_sections) + top_missing_note
-        if len(full_md) > max_chars:
-            cutoff = full_md[:max_chars].rfind("\n")
-            cutoff = cutoff if cutoff > 0 else max_chars
-            full_md = full_md[:cutoff] + f"\n\n*... [Output truncated at {max_chars} characters.]*"
+    summary_result = _serialize_with_summary(result)
+    if summary_result is not None:
+        return summary_result
 
-        meta = {"type": "table_collection", "tables": table_metas}
-        return meta, full_md
-
-    # Series
-    if isinstance(result, pd.Series):
-        if len(result) <= 20:
-            df_s = result.reset_index()
-            md = f"### Series `{result.name or 'result'}`\n\n" + _df_to_markdown_table(df_s)
-        else:
-            df_s = pd.DataFrame({"index": list(result.index), "value": list(result.values)})
-            prof_md, _ = _profile_dataframe(df_s, set())
-            md = f"### Series `{result.name or 'result'}` (Profile)\n\n" + prof_md
-        meta = {"type": "series", "name": result.name, "length": len(result)}
-        return meta, md
-
-    # NumPy ndarray
-    if isinstance(result, np.ndarray):
-        meta = {
-            "type": "ndarray",
-            "shape": list(result.shape),
-            "dtype": str(result.dtype),
-        }
-        md = f"**Array result:** shape `{list(result.shape)}`, dtype `{result.dtype}`"
-        return meta, md
-
-    # Dataclass
-    if is_dataclass(result) and not isinstance(result, type):
-        d = asdict(result)
-        meta = {"type": type(result).__name__, **d}
-        md = f"### {type(result).__name__}\n\n" + "\n".join(f"- **{k}:** `{v}`" for k, v in d.items())
-        return meta, md
-
-    # Dict
-    if isinstance(result, dict):
-        meta = {
-            str(k): (v if isinstance(v, (int, float, str, bool)) else str(type(v).__name__)) for k, v in result.items()
-        }
-        md = "### Result\n\n" + "\n".join(f"- **{k}:** `{v}`" for k, v in result.items())
-        return meta, md
-
-    # Objects with summary() method (e.g. statsmodels / lifelines)
-    summary_fn = getattr(result, "summary", None)
-    if callable(summary_fn):
-        try:
-            summ_text = str(summary_fn())[:_MAX_REPR_CHARS]
-            meta = {"type": type(result).__name__}
-            md = f"### {type(result).__name__} Summary\n\n```\n{summ_text}\n```"
-            return meta, md
-        except Exception:  # noqa: BLE001
-            pass
-
-    # Fallback repr
-    repr_str = repr(result)[:_MAX_REPR_CHARS]
-    meta = {"type": type(result).__name__}
-    md = f"```\n{repr_str}\n```"
-    return meta, md
+    return _serialize_fallback_repr(result)
 
 
 def serialize_result(

--- a/ehrapy/mcp/serialization.py
+++ b/ehrapy/mcp/serialization.py
@@ -1,0 +1,645 @@
+"""SOTA 3-tier serialization for ehrapy return values.
+
+Markdown-first for human/agent reasoning, compact typed JSON metadata for structuredContent.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import asdict, is_dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+import numpy as np
+import pandas as pd
+from ehrdata import EHRData
+from fastmcp.utilities.types import Image
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    pass
+
+# Budget constants
+_DEFAULT_MAX_CHARS = 10_000
+_TIER1_MAX_CHARS = 2_500
+_TIER3_DEFAULT_ROWS = 20
+_MAX_REPR_CHARS = 1_000
+
+# Information ranking weights
+W_RELEVANCE = 2.0
+W_MISSING = 1.0
+W_DISPERSION = 1.0
+
+
+def _get_max_result_chars() -> int:
+    env_val = os.environ.get("EHRAPY_MCP_MAX_RESULT_CHARS", "").strip()
+    if env_val:
+        try:
+            return max(500, int(env_val))
+        except ValueError:
+            pass
+    return _DEFAULT_MAX_CHARS
+
+
+def _format_cell(val: Any) -> str:
+    if val is None:
+        return "NaN"
+    if isinstance(val, (list, tuple, set, dict, np.ndarray)):
+        # pd.isna on a sequence returns an array, whose truth value is ambiguous.
+        return str(val)[:40]
+    if isinstance(val, float) and math.isnan(val):
+        return "NaN"
+    try:
+        if pd.isna(val):
+            return "NaN"
+    except (TypeError, ValueError):
+        pass
+    if isinstance(val, (float, np.floating)):
+        return f"{val:.4g}"
+    s = str(val).replace("\n", " ").replace("|", "\\|")
+    return s if len(s) <= 40 else s[:37] + "..."
+
+
+def _df_to_markdown_table(df: pd.DataFrame) -> str:
+    """Render a DataFrame as a Markdown pipe table."""
+    headers = [str(col) for col in df.columns]
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join(["---"] * len(headers)) + " |",
+    ]
+    for _, row in df.iterrows():
+        row_str = "| " + " | ".join(_format_cell(val) for val in row) + " |"
+        lines.append(row_str)
+    return "\n".join(lines)
+
+
+def _compute_entropy(series: pd.Series) -> float:
+    """Compute normalized Shannon entropy in [0, 1]."""
+    counts = series.dropna().value_counts(normalize=True)
+    k = len(counts)
+    if k <= 1:
+        return 0.0
+    h = -sum(p * math.log(p) for p in counts if p > 0)
+    max_h = math.log(k)
+    return (h / max_h) if max_h > 0 else 0.0
+
+
+def _compute_dispersion(series: pd.Series) -> float:
+    """Compute normalized dispersion metric in [0, 1]."""
+    valid = series.dropna()
+    if len(valid) <= 1:
+        return 0.0
+    if pd.api.types.is_numeric_dtype(series) and not pd.api.types.is_bool_dtype(series):
+        v_min = valid.min()
+        v_max = valid.max()
+        rng = v_max - v_min
+        if rng == 0:
+            return 0.0
+        scaled = (valid - v_min) / rng
+        return float(min(1.0, scaled.std()))
+    return _compute_entropy(series)
+
+
+def _extract_relevant_columns(params: dict[str, Any] | None) -> set[str]:
+    """Extract column names mentioned in call parameters."""
+    if not params:
+        return set()
+    relevant: set[str] = set()
+    for key in (
+        "keys",
+        "groupby",
+        "duration_col",
+        "event_col",
+        "target",
+        "covariates",
+        "qc_vars",
+        "color",
+        "layer",
+    ):
+        val = params.get(key)
+        if isinstance(val, str):
+            relevant.add(val)
+        elif isinstance(val, (list, tuple, set)):
+            relevant.update(str(x) for x in val)
+    return relevant
+
+
+def _rank_columns(df: pd.DataFrame, relevant_cols: set[str]) -> list[tuple[str, float]]:
+    """Rank columns by information score: w_m*missing + w_v*dispersion + w_r*relevance."""
+    scored: list[tuple[str, float]] = []
+    for col in df.columns:
+        col_str = str(col)
+        missing_frac = float(df[col].isna().mean())
+        disp = _compute_dispersion(df[col])
+        rel = 1.0 if col_str in relevant_cols else 0.0
+        score = (W_MISSING * missing_frac) + (W_DISPERSION * disp) + (W_RELEVANCE * rel)
+        scored.append((col_str, score))
+    # Deterministic tie-break by column name
+    scored.sort(key=lambda item: (-item[1], str(item[0])))
+    return scored
+
+
+def _summarize_column(series: pd.Series) -> str:
+    """Produce summary string for a single column profile."""
+    valid = series.dropna()
+    if len(valid) == 0:
+        return "all missing"
+
+    if pd.api.types.is_numeric_dtype(series) and not pd.api.types.is_bool_dtype(series):
+        mean_val = valid.mean()
+        std_val = valid.std() if len(valid) > 1 else 0.0
+        min_val = valid.min()
+        max_val = valid.max()
+        return f"{mean_val:.2f} ± {std_val:.2f} [{min_val:.2f}, {max_val:.2f}]"
+
+    if pd.api.types.is_datetime64_any_dtype(series):
+        return f"{valid.min()} → {valid.max()}"
+
+    top_counts = valid.value_counts().head(3)
+    parts = [f"{k}: {v}" for k, v in top_counts.items()]
+    return ", ".join(parts)
+
+
+def _profile_dataframe(
+    df: pd.DataFrame,
+    relevant_cols: set[str],
+    *,
+    max_profile_cols: int = 40,
+) -> tuple[str, dict[str, Any]]:
+    """Render Tier 2 column profile table."""
+    total_cols = df.shape[1]
+    ranked = _rank_columns(df, relevant_cols)
+
+    selected_cols = [c for c, _ in ranked[:max_profile_cols]]
+    dropped_count = total_cols - len(selected_cols)
+
+    headers = ["column", "dtype", "non-null %", "unique", "summary"]
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join(["---"] * len(headers)) + " |",
+    ]
+
+    for col_name in selected_cols:
+        s = df[col_name]
+        dtype_str = str(s.dtype)
+        non_null_pct = f"{s.notna().mean() * 100:.1f}%"
+        nunique_str = str(s.nunique())
+        summ = _summarize_column(s).replace("|", "\\|")
+        row = f"| `{col_name}` | {dtype_str} | {non_null_pct} | {nunique_str} | {summ} |"
+        lines.append(row)
+
+    md = "\n".join(lines)
+    steering_notes = []
+    if dropped_count > 0:
+        steering_notes.append(
+            f"\n\n*Showing profile for {len(selected_cols)} of {total_cols} columns (ranked by missingness and variance). {dropped_count} columns omitted.*"
+        )
+
+    full_md = md + "".join(steering_notes)
+    meta = {
+        "type": "dataframe_profile",
+        "shape": list(df.shape),
+        "total_columns": total_cols,
+        "profiled_columns": len(selected_cols),
+        "dropped_columns": dropped_count,
+    }
+    return full_md, meta
+
+
+def _sample_rows(
+    df: pd.DataFrame,
+    relevant_cols: set[str],
+    *,
+    row_budget: int = _TIER3_DEFAULT_ROWS,
+) -> pd.DataFrame:
+    """Sample head 5 + tail 5 + stratified/uniform sample to row_budget with fixed seed 42."""
+    n_rows = len(df)
+    if n_rows <= row_budget:
+        result = df.copy()
+        result.insert(0, "sample", "all")
+        return result
+
+    head_n = min(5, n_rows)
+    tail_n = min(5, n_rows - head_n)
+    middle_n = max(0, row_budget - head_n - tail_n)
+
+    head_idx = list(df.index[:head_n])
+    tail_idx = list(df.index[-tail_n:]) if tail_n > 0 else []
+    remaining_idx = [i for i in df.index if i not in head_idx and i not in tail_idx]
+
+    sample_idx: list[Any] = []
+    if middle_n > 0 and remaining_idx:
+        mid_df = df.loc[remaining_idx]
+        strat_col = None
+        for col in relevant_cols:
+            if col in df.columns and (
+                not pd.api.types.is_numeric_dtype(df[col]) or pd.api.types.is_bool_dtype(df[col])
+            ):
+                strat_col = col
+                break
+        if strat_col is not None and mid_df[strat_col].nunique() > 1:
+            try:
+                sampled = mid_df.groupby(strat_col, group_keys=False).apply(
+                    lambda g: g.sample(max(1, int(len(g) / len(mid_df) * middle_n)), random_state=42)
+                )
+                sample_idx = list(sampled.index[:middle_n])
+            except Exception:  # noqa: BLE001
+                sample_idx = list(mid_df.sample(min(middle_n, len(mid_df)), random_state=42).index)
+        else:
+            sample_idx = list(mid_df.sample(min(middle_n, len(mid_df)), random_state=42).index)
+
+    rows = []
+    for idx in head_idx:
+        r = df.loc[idx].to_dict()
+        r["sample"] = "head"
+        rows.append(r)
+    for idx in sample_idx:
+        r = df.loc[idx].to_dict()
+        r["sample"] = "sample"
+        rows.append(r)
+    for idx in tail_idx:
+        r = df.loc[idx].to_dict()
+        r["sample"] = "tail"
+        rows.append(r)
+
+    sampled_df = pd.DataFrame(rows)
+    cols = ["sample"] + [c for c in sampled_df.columns if c != "sample"]
+    return sampled_df[cols]
+
+
+def _serialize_dataframe(
+    df: pd.DataFrame,
+    *,
+    response_format: Literal["concise", "detailed"] = "concise",
+    params: dict[str, Any] | None = None,
+    function: str = "",
+    edata: EHRData | None = None,
+) -> tuple[dict[str, Any], str]:
+    """Serialize DataFrame according to Tier 1, 2, or 3 rules."""
+    params = params or {}
+    relevant_cols = _extract_relevant_columns(params)
+
+    # Empty result guard
+    if df.shape[0] == 0 or df.shape[1] == 0:
+        if not params.get("keys") and function in (
+            "obs_df",
+            "var_df",
+            "rank_features_groups_df",
+        ):
+            avail_cols: list[str] = []
+            if edata is not None:
+                if function == "obs_df":
+                    avail_cols = list(edata.obs.columns[:30])
+                elif function == "var_df":
+                    avail_cols = list(edata.var.columns[:30])
+            avail_str = f" Available columns: {', '.join(avail_cols)}" if avail_cols else ""
+            meta = {
+                "status": "ok_empty",
+                "shape": list(df.shape),
+                "agent_action": f"No columns requested. Specify columns using `params={{'keys': [...]}}`.{avail_str}",
+            }
+            md = f"# Result: ok_empty\n\nReturned table shape is `{list(df.shape)}`.\n\n**Action:** {meta['agent_action']}"
+            return meta, md
+        # Plain empty dataframe
+        meta = {"type": "dataframe", "shape": list(df.shape)}
+        return meta, f"Empty DataFrame (shape: {list(df.shape)})."
+
+    # Whole table return guard (e.g. to_pandas)
+    is_whole_table = function == "to_pandas"
+
+    if not is_whole_table:
+        # Tier 3: rows explicitly requested
+        if response_format == "detailed" or "rows" in params:
+            sampled = _sample_rows(df, relevant_cols)
+            table_md = _df_to_markdown_table(sampled)
+            meta_tier3: dict[str, Any] = {
+                "type": "dataframe",
+                "shape": list(df.shape),
+                "tier": 3,
+                "sampled_rows": len(sampled),
+            }
+            md = f"### DataFrame ({df.shape[0]} rows × {df.shape[1]} columns — sampled view)\n\n" + table_md
+            return meta_tier3, md
+
+        # Tier 1: Pass-through if it fits the Tier 1 budget. Bound the work first --
+        # rendering a 100k-row frame to Markdown just to discover it is too big is the
+        # exact overflow this tier is meant to prevent.
+        cells = df.shape[0] * max(1, df.shape[1])
+        if cells <= _TIER1_MAX_CHARS:
+            full_table_md = _df_to_markdown_table(df)
+        else:
+            full_table_md = None
+        if full_table_md is not None and len(full_table_md) <= _TIER1_MAX_CHARS:
+            meta_tier1: dict[str, Any] = {"type": "dataframe", "shape": list(df.shape), "tier": 1}
+            md = f"### DataFrame ({df.shape[0]} rows × {df.shape[1]} columns)\n\n" + full_table_md
+            return meta_tier1, md
+
+    # Tier 2: Profile-first (default for large DataFrames or whole-table returns)
+    profile_md, profile_meta = _profile_dataframe(df, relevant_cols)
+    profile_meta["tier"] = 2
+    header = f"### Column Profile ({df.shape[0]} rows × {df.shape[1]} columns)\n\n"
+    steering = ""
+    if is_whole_table:
+        steering = "\n\n*Full table not returned — use `export_edata` to write it to disk, or `run_get` with `keys=[...]` for specific columns.*"
+
+    return profile_meta, header + profile_md + steering
+
+
+def _unique_plot_path(plots_dir: Path, stem: str) -> Path:
+    plots_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    path = plots_dir / f"{stem}.png"
+    counter = 0
+    while path.exists():
+        counter += 1
+        path = plots_dir / f"{stem}_{counter}.png"
+    return path
+
+
+_MAX_PLOT_BYTES = 800 * 1024
+_DPI_LADDER = (100, 72, 56, 40)
+
+
+def _save_figure(fig: Any, plots_dir: Path, stem: str) -> tuple[dict[str, Any], Path]:
+    """Save a figure, stepping the DPI down until it fits the image budget."""
+    path = _unique_plot_path(plots_dir, stem)
+    size = 0
+    dpi = _DPI_LADDER[0]
+    for dpi in _DPI_LADDER:
+        fig.savefig(path, bbox_inches="tight", dpi=dpi)
+        size = path.stat().st_size
+        if size <= _MAX_PLOT_BYTES:
+            break
+    meta: dict[str, Any] = {
+        "type": "figure",
+        "plot_path": str(path),
+        "media_type": "image/png",
+        "dpi": dpi,
+        "size_bytes": size,
+    }
+    if size > _MAX_PLOT_BYTES:
+        # Report rather than silently returning an oversized payload.
+        meta["oversized"] = True
+    return meta, path
+
+
+# Tried in order for holoviews PNG export. The backend is named per-call rather than set
+# via hv.extension(), which would mutate global state for every other plot in the process.
+# bokeh is the holoviews default but its PNG export needs selenium and a headless browser.
+_HOLOVIEWS_BACKENDS = ("matplotlib", "bokeh")
+
+
+def _try_save_holoviews(obj: Any, plots_dir: Path) -> tuple[dict[str, Any], Path] | None:
+    """Render a holoviews object (e.g. ep.pl.kaplan_meier's Overlay) to PNG."""
+    try:
+        import holoviews as hv
+    except ImportError:
+        return None
+
+    if not isinstance(obj, hv.core.dimension.Dimensioned):
+        return None
+
+    path = _unique_plot_path(plots_dir, "holoviews")
+    failures: list[str] = []
+    for backend in _HOLOVIEWS_BACKENDS:
+        if backend not in hv.Store.renderers:
+            continue
+        try:
+            hv.save(obj, str(path), fmt="png", backend=backend)
+        except Exception as exc:  # noqa: BLE001
+            failures.append(f"{backend}: {type(exc).__name__}: {str(exc)[:120]}")
+            continue
+        return {
+            "type": "figure",
+            "plot_path": str(path),
+            "media_type": "image/png",
+            "render_backend": backend,
+        }, path
+
+    # Every backend failed. Report it rather than returning a success with no image.
+    if path.exists():
+        path.unlink(missing_ok=True)
+    raise ValueError(
+        "Could not export this figure to PNG with any available holoviews backend. "
+        + " | ".join(failures)
+        + ". Install the 'selenium' package to enable bokeh image export, or request a "
+        "different plot for this result."
+    )
+
+
+def _try_save_visual(obj: Any, plots_dir: Path | None) -> tuple[dict[str, Any], Path] | None:
+    if plots_dir is None:
+        return None
+    fig = getattr(obj, "figure", None)
+    if fig is not None:
+        return _save_figure(fig, plots_dir, stem=type(obj).__name__)
+    if type(obj).__module__.startswith("matplotlib"):
+        return _save_figure(obj, plots_dir, stem="matplotlib")
+    return _try_save_holoviews(obj, plots_dir)
+
+
+_JSON_SAFE_SCALARS = (str, bool, int, float)
+_MAX_INLINE_SEQUENCE = 32
+
+
+def _json_safe(value: Any, _depth: int = 0) -> Any:
+    """Coerce a value into something FastMCP can place in ``structured_content``.
+
+    structured_content is JSON-serialized by the MCP layer, so any ndarray, Series, or
+    exotic object that reaches it aborts the whole tool call. Analysis results such as
+    ``CausalEstimate`` carry ndarrays inside nested ``params`` dicts, so this recurses.
+    """
+    if value is None or isinstance(value, _JSON_SAFE_SCALARS):
+        return None if isinstance(value, float) and not math.isfinite(value) else value
+    if _depth >= 4:
+        return f"<{type(value).__name__}>"
+    if isinstance(value, (np.integer, np.floating, np.bool_)):
+        return _json_safe(value.item(), _depth + 1)
+    if isinstance(value, np.ndarray):
+        if value.ndim == 1 and value.size <= _MAX_INLINE_SEQUENCE:
+            return [_json_safe(v, _depth + 1) for v in value.tolist()]
+        return {"type": "ndarray", "shape": list(value.shape), "dtype": str(value.dtype)}
+    if isinstance(value, pd.Series):
+        return {"type": "series", "length": int(len(value)), "dtype": str(value.dtype)}
+    if isinstance(value, pd.DataFrame):
+        return {"type": "dataframe", "shape": list(value.shape)}
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v, _depth + 1) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        seq = list(value)
+        out = [_json_safe(v, _depth + 1) for v in seq[:_MAX_INLINE_SEQUENCE]]
+        if len(seq) > _MAX_INLINE_SEQUENCE:
+            out.append(f"... ({len(seq) - _MAX_INLINE_SEQUENCE} more)")
+        return out
+    return str(value)[:200]
+
+
+def _serialize_result_inner(
+    result: Any,
+    *,
+    plots_dir: Path | None = None,
+    response_format: Literal["concise", "detailed"] = "concise",
+    params: dict[str, Any] | None = None,
+    function: str = "",
+    edata: EHRData | None = None,
+) -> tuple[dict[str, Any], list[Any] | str]:
+    """Convert an ehrapy return value into dual-channel structured_content and Markdown/image content."""
+    params = params or {}
+    max_chars = _get_max_result_chars()
+
+    # None
+    if result is None:
+        return {}, "Operation completed successfully."
+
+    # Visual / Plot object
+    visual_saved = _try_save_visual(result, plots_dir)
+    if visual_saved is not None:
+        meta, path = visual_saved
+        md = f"Plot rendered successfully and saved to `{path}`."
+        img = Image(path=str(path))
+        return meta, [md, img]
+
+    # EHRData
+    if isinstance(result, EHRData):
+        meta = {"type": "EHRData", "n_obs": result.n_obs, "n_vars": result.n_vars}
+        md = f"**EHRData dataset:** {result.n_obs} observations × {result.n_vars} variables"
+        return meta, md
+
+    # Single DataFrame
+    if isinstance(result, pd.DataFrame):
+        meta, md = _serialize_dataframe(
+            result,
+            response_format=response_format,
+            params=params,
+            function=function,
+            edata=edata,
+        )
+        if len(md) > max_chars:
+            cutoff = md[:max_chars].rfind("\n")
+            cutoff = cutoff if cutoff > 0 else max_chars
+            md = (
+                md[:cutoff]
+                + f"\n\n*... [Output truncated at {max_chars} characters. Narrow your query with parameters.]*"
+            )
+        return meta, md
+
+    # Tuple / list of DataFrames (e.g. qc_metrics)
+    if isinstance(result, (tuple, list)) and any(isinstance(x, pd.DataFrame) for x in result):
+        table_sections: list[str] = []
+        table_metas: list[dict[str, Any]] = []
+        top_missing_note = ""
+
+        for idx, item in enumerate(result):
+            if isinstance(item, pd.DataFrame):
+                t_meta, t_md = _serialize_dataframe(
+                    item,
+                    response_format=response_format,
+                    params=params,
+                    function=function,
+                    edata=edata,
+                )
+                label = "Observations" if idx == 0 and "missing_values_abs" in item.columns else f"Table {idx + 1}"
+                if (
+                    "missing_values_pct" in item.columns
+                    and "missing_values_abs" in item.columns
+                    and item.shape[0] < 1000
+                ):
+                    label = "Variables Quality Metrics"
+                    # Extract top missing
+                    top_m = item.sort_values("missing_values_pct", ascending=False).head(5)
+                    parts = [
+                        f"{idx_name} ({row['missing_values_pct']:.1f}%)"
+                        for idx_name, row in top_m.iterrows()
+                        if row["missing_values_pct"] > 0
+                    ]
+                    if parts:
+                        top_missing_note = f"\n\n**Highest-missingness variables:** {', '.join(parts)}"
+
+                table_sections.append(f"### {label}\n\n{t_md}")
+                table_metas.append(t_meta)
+            else:
+                table_sections.append(f"### Item {idx + 1}\n\n`{repr(item)[:500]}`")
+
+        full_md = "\n\n---\n\n".join(table_sections) + top_missing_note
+        if len(full_md) > max_chars:
+            cutoff = full_md[:max_chars].rfind("\n")
+            cutoff = cutoff if cutoff > 0 else max_chars
+            full_md = full_md[:cutoff] + f"\n\n*... [Output truncated at {max_chars} characters.]*"
+
+        meta = {"type": "table_collection", "tables": table_metas}
+        return meta, full_md
+
+    # Series
+    if isinstance(result, pd.Series):
+        if len(result) <= 20:
+            df_s = result.reset_index()
+            md = f"### Series `{result.name or 'result'}`\n\n" + _df_to_markdown_table(df_s)
+        else:
+            df_s = pd.DataFrame({"index": list(result.index), "value": list(result.values)})
+            prof_md, _ = _profile_dataframe(df_s, set())
+            md = f"### Series `{result.name or 'result'}` (Profile)\n\n" + prof_md
+        meta = {"type": "series", "name": result.name, "length": len(result)}
+        return meta, md
+
+    # NumPy ndarray
+    if isinstance(result, np.ndarray):
+        meta = {
+            "type": "ndarray",
+            "shape": list(result.shape),
+            "dtype": str(result.dtype),
+        }
+        md = f"**Array result:** shape `{list(result.shape)}`, dtype `{result.dtype}`"
+        return meta, md
+
+    # Dataclass
+    if is_dataclass(result) and not isinstance(result, type):
+        d = asdict(result)
+        meta = {"type": type(result).__name__, **d}
+        md = f"### {type(result).__name__}\n\n" + "\n".join(f"- **{k}:** `{v}`" for k, v in d.items())
+        return meta, md
+
+    # Dict
+    if isinstance(result, dict):
+        meta = {
+            str(k): (v if isinstance(v, (int, float, str, bool)) else str(type(v).__name__)) for k, v in result.items()
+        }
+        md = "### Result\n\n" + "\n".join(f"- **{k}:** `{v}`" for k, v in result.items())
+        return meta, md
+
+    # Objects with summary() method (e.g. statsmodels / lifelines)
+    summary_fn = getattr(result, "summary", None)
+    if callable(summary_fn):
+        try:
+            summ_text = str(summary_fn())[:_MAX_REPR_CHARS]
+            meta = {"type": type(result).__name__}
+            md = f"### {type(result).__name__} Summary\n\n```\n{summ_text}\n```"
+            return meta, md
+        except Exception:  # noqa: BLE001
+            pass
+
+    # Fallback repr
+    repr_str = repr(result)[:_MAX_REPR_CHARS]
+    meta = {"type": type(result).__name__}
+    md = f"```\n{repr_str}\n```"
+    return meta, md
+
+
+def serialize_result(
+    result: Any,
+    *,
+    plots_dir: Path | None = None,
+    response_format: Literal["concise", "detailed"] = "concise",
+    params: dict[str, Any] | None = None,
+    function: str = "",
+    edata: EHRData | None = None,
+) -> tuple[dict[str, Any], list[Any] | str]:
+    """Serialize an ehrapy return value, guaranteeing a JSON-safe metadata channel."""
+    meta, content = _serialize_result_inner(
+        result,
+        plots_dir=plots_dir,
+        response_format=response_format,
+        params=params,
+        function=function,
+        edata=edata,
+    )
+    return _json_safe(meta), content

--- a/ehrapy/mcp/server.py
+++ b/ehrapy/mcp/server.py
@@ -1,0 +1,206 @@
+"""FastMCP server definition, tool registration, middleware, and prompts for ehrapy."""
+
+from __future__ import annotations
+
+import argparse
+from typing import TYPE_CHECKING, Any
+
+import mcp.types as mt
+from fastmcp import FastMCP
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+
+from ehrapy.mcp.errors import unknown_argument_error
+from ehrapy.mcp.prompts import SERVER_INSTRUCTIONS
+from ehrapy.mcp.registry import registry
+from ehrapy.mcp.tools import ALL_TOOLS_LIST
+
+if TYPE_CHECKING:
+    from fastmcp.tools.tool import ToolResult
+
+    pass
+
+_TOOL_ANNOTATIONS: dict[str, dict[str, Any]] = {
+    "load_demo_dataset": {"readOnlyHint": False, "destructiveHint": False, "idempotentHint": True},
+    "ingest_dataset": {"readOnlyHint": False, "destructiveHint": False, "idempotentHint": True},
+    "fork_edata_handle": {"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False},
+    "export_edata": {"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False},
+    "get_edata_snapshot": {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
+    "get_workflow_guide": {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
+    "get_runtime_context": {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
+    "list_ehrapy_functions": {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
+    "get_function_help": {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
+    "run_preprocessing": {"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False},
+    "run_analysis": {"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False},
+    "run_get": {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
+    "run_plot": {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
+    "run_io": {"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False},
+}
+
+
+# Client-side orchestration keys that are not part of any tool schema and are silently dropped.
+_ORCHESTRATION_KEYS = frozenset({"wait_for_previous"})
+
+
+def _append_note(result: ToolResult, note: str, folded: list[str]) -> ToolResult:
+    """Append a steering note to a tool result on both channels."""
+    from fastmcp.tools.tool import ToolResult as _ToolResult
+
+    try:
+        blocks = list(result.content or [])
+        blocks.append(mt.TextContent(type="text", text=f"\n\n_{note}_"))
+        struct = result.structured_content
+        if isinstance(struct, dict):
+            struct = {**struct, "folded_arguments": folded}
+        return _ToolResult(content=blocks, structured_content=struct, is_error=bool(getattr(result, "is_error", False)))
+    except Exception:  # noqa: BLE001
+        # Never let the advisory note break an otherwise successful call.
+        return result
+
+
+class ArgumentValidationMiddleware(Middleware):
+    """Reconcile client-supplied arguments with the tool schema before execution.
+
+    Agents routinely pass an ehrapy function's own kwargs at the top level
+    (``run_preprocessing(function='qc_metrics', groupby='service_unit')``) instead of
+    nesting them under ``params``. For tools that take a ``params`` dict, those keys are
+    folded in and the fold is reported back so the agent learns the correct shape
+    (origin fix #3). For tools with no ``params`` -- or keys that survive folding -- the
+    call is rejected with ``UNKNOWN_ARGUMENT`` rather than silently dropped, so a
+    hallucinated argument never passes unnoticed.
+    """
+
+    def __init__(self, server: FastMCP) -> None:
+        self.server = server
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        """Fold or reject unknown arguments, and strip client orchestration keys."""
+        message = context.message
+        name = message.name
+        arguments = dict(message.arguments or {})
+
+        tool = await self.server.get_tool(name)
+        if tool is None:
+            return await call_next(context)
+
+        # Orchestration keys are stripped unconditionally -- including for zero-argument
+        # tools, whose empty schema would otherwise reject them during validation.
+        stripped = _ORCHESTRATION_KEYS & set(arguments)
+        for key in stripped:
+            del arguments[key]
+
+        has_schema = isinstance(getattr(tool, "parameters", None), dict)
+        if not has_schema:
+            if stripped:
+                context = context.copy(message=mt.CallToolRequestParams(name=name, arguments=arguments))
+            return await call_next(context)
+
+        valid_keys = set(tool.parameters.get("properties", {}).keys())
+
+        unknown = set(arguments) - valid_keys
+        folded: list[str] = []
+        if unknown and "params" in valid_keys:
+            existing = arguments.get("params")
+            existing = dict(existing) if isinstance(existing, dict) else {}
+            # An explicit params entry wins over a folded top-level kwarg of the same name.
+            merged = {k: arguments.pop(k) for k in sorted(unknown)}
+            folded = sorted(merged)
+            arguments["params"] = {**merged, **existing}
+            unknown = set()
+
+        if unknown:
+            return unknown_argument_error(name, unknown, valid_keys)
+
+        if folded or stripped:
+            context = context.copy(message=mt.CallToolRequestParams(name=name, arguments=arguments))
+
+        result = await call_next(context)
+
+        if folded:
+            note = (
+                f"Folded top-level argument(s) {', '.join(f'`{k}`' for k in folded)} into `params`. "
+                f"Pass function keyword arguments inside `params` to avoid relying on this."
+            )
+            result = _append_note(result, note, folded)
+        return result
+
+
+def create_server() -> FastMCP:
+    """Create and configure the FastMCP server instance."""
+    # Startup cache purge
+    try:
+        registry.purge()
+    except Exception:  # noqa: BLE001
+        pass
+
+    server = FastMCP("ehrapy", instructions=SERVER_INSTRUCTIONS)
+    server.add_middleware(ArgumentValidationMiddleware(server))
+
+    # Register tools with annotations
+    for tool_fn in ALL_TOOLS_LIST:
+        name = tool_fn.__name__
+        annotations = _TOOL_ANNOTATIONS.get(name)
+        if annotations:
+            server.tool(annotations=annotations)(tool_fn)
+        else:
+            server.tool()(tool_fn)
+
+    # Register MCP Prompts
+    @server.prompt("ehrapy-explore")
+    def prompt_ehrapy_explore(dataset: str = "mimic_2") -> str:
+        """Prompt template for exploratory data analysis of a clinical cohort."""
+        return (
+            f"Please perform an exploratory analysis on dataset '{dataset}':\n"
+            f"1. Load the dataset using load_demo_dataset(dataset='{dataset}') or get_edata_snapshot() if already loaded.\n"
+            f"2. Calculate quality control metrics using run_preprocessing(function='qc_metrics').\n"
+            f"3. Visualize missingness using run_plot(function='missing_values_matrix').\n"
+            f"4. Summarize key cohort characteristics and data quality issues."
+        )
+
+    @server.prompt("ehrapy-clustering")
+    def prompt_ehrapy_clustering(dataset: str = "mimic_2", resolution: float = 1.0) -> str:
+        """Prompt template for unsupervised subtyping and clustering of clinical cohorts."""
+        return (
+            f"Please perform patient sub-phenotyping and clustering on dataset '{dataset}':\n"
+            f"1. Encode categorical features with run_preprocessing(function='encode', params={{'autodetect': True}}).\n"
+            f"2. Impute missing values with run_preprocessing(function='knn_impute').\n"
+            f"3. Compute PCA with run_preprocessing(function='pca') and neighbor graph with run_preprocessing(function='neighbors').\n"
+            f"4. Perform Leiden clustering with run_analysis(function='leiden', params={{'resolution': {resolution}}}).\n"
+            f"5. Visualize clusters with run_plot(function='umap', params={{'color': 'leiden'}}).\n"
+            f"6. Extract top differentiating features with run_analysis(function='rank_features_groups', params={{'groupby': 'leiden'}}) and run_get(function='rank_features_groups_df')."
+        )
+
+    @server.prompt("ehrapy-survival")
+    def prompt_ehrapy_survival(
+        dataset: str = "mimic_2",
+        duration_col: str = "mort_day_censored",
+        event_col: str = "censor_flg",
+    ) -> str:
+        """Prompt template for clinical survival analysis."""
+        return (
+            f"Please perform survival analysis on dataset '{dataset}':\n"
+            f"1. Fit Kaplan-Meier survival curves using run_analysis(function='kaplan_meier', params={{'duration_col': '{duration_col}', 'event_col': '{event_col}'}}).\n"
+            f"2. Plot survival curves using run_plot(function='kaplan_meier').\n"
+            f"3. Fit a Cox proportional hazards model using run_analysis(function='cox_ph', params={{'duration_col': '{duration_col}', 'event_col': '{event_col}'}}).\n"
+            f"4. Render the forest plot of hazard ratios using run_plot(function='cox_ph_forestplot')."
+        )
+
+    return server
+
+
+mcp = create_server()
+
+
+def main() -> None:
+    """Entry point for running the MCP server."""
+    parser = argparse.ArgumentParser(description="ehrapy MCP server")
+    parser.add_argument("--transport", default="stdio", choices=["stdio", "sse", "http"], help="MCP transport protocol")
+    args = parser.parse_args()
+    mcp.run(transport=args.transport)
+
+
+if __name__ == "__main__":
+    main()

--- a/ehrapy/mcp/server.py
+++ b/ehrapy/mcp/server.py
@@ -128,13 +128,13 @@ class ArgumentValidationMiddleware(Middleware):
         return result
 
 
-def create_server() -> FastMCP:
+def create_server(*, purge_cache: bool = False) -> FastMCP:
     """Create and configure the FastMCP server instance."""
-    # Startup cache purge
-    try:
-        registry.purge()
-    except Exception:  # noqa: BLE001
-        pass
+    if purge_cache:
+        try:
+            registry.purge()
+        except Exception:  # noqa: BLE001
+            pass
 
     server = FastMCP("ehrapy", instructions=SERVER_INSTRUCTIONS)
     server.add_middleware(ArgumentValidationMiddleware(server))
@@ -198,7 +198,13 @@ def main() -> None:
     """Entry point for running the MCP server."""
     parser = argparse.ArgumentParser(description="ehrapy MCP server")
     parser.add_argument("--transport", default="stdio", choices=["stdio", "sse", "http"], help="MCP transport protocol")
+    parser.add_argument("--no-purge", action="store_true", help="Do not purge cache on startup")
     args = parser.parse_args()
+    if not args.no_purge:
+        try:
+            registry.purge()
+        except Exception:  # noqa: BLE001
+            pass
     mcp.run(transport=args.transport)
 
 

--- a/ehrapy/mcp/session.py
+++ b/ehrapy/mcp/session.py
@@ -1,0 +1,72 @@
+"""Per-client MCP session state."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+_SESSIONS_LOCK = threading.RLock()
+
+
+class _EHRapySession:
+    """Thread-safe per-client container for the active EHRData handle."""
+
+    def __init__(self, edata_id: str | None = None) -> None:
+        self._edata_id = edata_id
+        self._lock = threading.RLock()
+
+    @property
+    def edata_id(self) -> str | None:
+        """Return the active edata_id for this session."""
+        with self._lock:
+            return self._edata_id
+
+    @edata_id.setter
+    def edata_id(self, value: str | None) -> None:
+        with self._lock:
+            self._edata_id = value
+
+    def get_latest_edata_id(self) -> str | None:
+        """Return the active edata_id for this session."""
+        return self.edata_id
+
+    def set_latest_edata_id(self, edata_id: str | None) -> None:
+        """Set the active edata_id for this session."""
+        self.edata_id = edata_id
+
+
+_SESSIONS: dict[str, _EHRapySession] = {}
+
+
+def _session_key(ctx: Any) -> str:
+    """Derive a stable per-client key from a FastMCP Context.
+
+    Each attribute is probed defensively: FastMCP raises when these are touched
+    outside an active request context, and a server-wide fallback to "default" is
+    preferable to propagating that error into every tool call.
+    """
+    if ctx is None:
+        return "default"
+    for attr in ("client_id", "session_id", "request_id"):
+        try:
+            value = getattr(ctx, attr, None)
+        except (RuntimeError, AttributeError):
+            continue
+        if value:
+            return str(value)
+    return "default"
+
+
+def get_session(ctx: Any = None) -> _EHRapySession:
+    """Return the per-client session, creating one if needed."""
+    key = _session_key(ctx)
+    with _SESSIONS_LOCK:
+        if key not in _SESSIONS:
+            _SESSIONS[key] = _EHRapySession()
+        return _SESSIONS[key]
+
+
+def reset_sessions() -> None:
+    """Reset all session states (useful for testing)."""
+    with _SESSIONS_LOCK:
+        _SESSIONS.clear()

--- a/ehrapy/mcp/steering.py
+++ b/ehrapy/mcp/steering.py
@@ -1,0 +1,120 @@
+"""Workflow steering and next-step suggestions for ehrapy MCP."""
+
+from __future__ import annotations
+
+# Static workflow transitions: (canonical_namespace, function) -> list of (call_string, description)
+_WORKFLOW_GRAPH: dict[tuple[str, str], list[tuple[str, str]]] = {
+    ("demo", "mimic_2"): [
+        ("get_edata_snapshot()", "Inspect observations, variables, and data structure"),
+        ("run_preprocessing(function='qc_metrics')", "Calculate missingness and quality metrics"),
+    ],
+    ("demo", "physionet2012"): [
+        ("get_edata_snapshot()", "Inspect observations, variables, and data structure"),
+        ("run_preprocessing(function='qc_metrics')", "Calculate missingness and quality metrics"),
+    ],
+    ("io", "read_csv"): [
+        ("get_edata_snapshot()", "Inspect observations, variables, and data structure"),
+        ("run_preprocessing(function='qc_metrics')", "Calculate missingness and quality metrics"),
+    ],
+    ("io", "read_h5ed"): [
+        ("get_edata_snapshot()", "Inspect observations, variables, and data structure"),
+    ],
+    ("preprocessing", "qc_metrics"): [
+        (
+            "run_preprocessing(function='encode', params={'autodetect': True})",
+            "Encode categorical columns into numerical representations",
+        ),
+        ("run_plot(function='missing_values_matrix')", "Visualize missing data distribution patterns"),
+    ],
+    ("preprocessing", "encode"): [
+        ("run_preprocessing(function='knn_impute')", "Impute missing values (or use miss_forest_impute/simple_impute)"),
+        ("run_preprocessing(function='pca')", "Perform Principal Component Analysis for dimensionality reduction"),
+    ],
+    ("preprocessing", "knn_impute"): [
+        ("run_preprocessing(function='pca')", "Perform Principal Component Analysis for dimensionality reduction"),
+    ],
+    ("preprocessing", "miss_forest_impute"): [
+        ("run_preprocessing(function='pca')", "Perform Principal Component Analysis for dimensionality reduction"),
+    ],
+    ("preprocessing", "simple_impute"): [
+        ("run_preprocessing(function='pca')", "Perform Principal Component Analysis for dimensionality reduction"),
+    ],
+    ("preprocessing", "highly_variable_features"): [
+        ("run_preprocessing(function='pca')", "Perform PCA on highly variable features"),
+    ],
+    ("preprocessing", "pca"): [
+        ("run_preprocessing(function='neighbors')", "Compute neighborhood graph from PCA embeddings"),
+    ],
+    ("preprocessing", "neighbors"): [
+        ("run_analysis(function='umap')", "Generate UMAP embedding from neighbor graph"),
+        ("run_analysis(function='leiden')", "Cluster observations into sub-cohorts via Leiden algorithm"),
+    ],
+    ("analysis", "umap"): [
+        ("run_plot(function='umap')", "Plot UMAP embeddings colored by clinical variables"),
+    ],
+    ("analysis", "tsne"): [
+        ("run_plot(function='tsne')", "Plot t-SNE embeddings colored by clinical variables"),
+    ],
+    ("analysis", "leiden"): [
+        (
+            "run_analysis(function='rank_features_groups', params={'groupby': 'leiden'})",
+            "Identify top differentiating clinical features per cluster",
+        ),
+        ("run_plot(function='umap', params={'color': 'leiden'})", "Visualize clusters on UMAP coordinates"),
+    ],
+    ("analysis", "rank_features_groups"): [
+        ("run_get(function='rank_features_groups_df')", "Extract tabular ranking of differential features"),
+        ("run_plot(function='rank_features_groups')", "Plot ranked features per cluster"),
+    ],
+    ("analysis", "kaplan_meier"): [
+        ("run_plot(function='kaplan_meier')", "Render Kaplan-Meier survival curves"),
+        (
+            "run_analysis(function='cox_ph', params={'duration_col': ..., 'event_col': ..., 'covariates': [...]})",
+            "Fit Cox proportional hazards regression model (pass explicit covariates; the full "
+            "encoded matrix is collinear and fails with a singularity error)",
+        ),
+    ],
+    ("analysis", "cox_ph"): [
+        ("run_plot(function='cox_ph_forestplot')", "Render forest plot of hazard ratios and confidence intervals"),
+    ],
+    ("analysis", "iptw"): [
+        (
+            "run_analysis(function='covariate_balance', params={'treatment': ..., 'covariates': [...]})",
+            "Check post-weighting covariate balance (`treatment` and `covariates` are required)",
+        ),
+        (
+            "run_plot(function='love_plot')",
+            "Render Love plot comparing unadjusted vs adjusted balance (PNG export needs the optional `selenium` package)",
+        ),
+    ],
+    ("analysis", "aipw"): [
+        (
+            "run_analysis(function='covariate_balance', params={'treatment': ..., 'covariates': [...]})",
+            "Check post-weighting covariate balance (`treatment` and `covariates` are required)",
+        ),
+        (
+            "run_plot(function='love_plot')",
+            "Render Love plot comparing balance (PNG export needs the optional `selenium` package)",
+        ),
+    ],
+    ("analysis", "g_computation"): [
+        (
+            "run_analysis(function='covariate_balance', params={'treatment': ..., 'covariates': [...]})",
+            "Assess causal treatment effect and covariate balance (`treatment` and `covariates` are required)",
+        ),
+    ],
+}
+
+_NAMESPACE_ALIASES = {
+    "tools": "analysis",
+    "dt": "demo",
+}
+
+
+def get_suggested_next(namespace: str, function: str) -> list[dict[str, str]] | None:
+    """Return suggested next tool calls for a (namespace, function) pair, or None if unknown."""
+    canonical_ns = _NAMESPACE_ALIASES.get(namespace, namespace)
+    suggestions = _WORKFLOW_GRAPH.get((canonical_ns, function))
+    if not suggestions:
+        return None
+    return [{"call": call, "reason": reason} for call, reason in suggestions[:3]]

--- a/ehrapy/mcp/tools/__init__.py
+++ b/ehrapy/mcp/tools/__init__.py
@@ -1,0 +1,38 @@
+"""Tool list and registration for ehrapy MCP."""
+
+from __future__ import annotations
+
+from ehrapy.mcp.tools.dispatch_tools import (
+    fork_edata_handle,
+    get_edata_snapshot,
+    get_function_help,
+    list_ehrapy_functions,
+    load_demo_dataset,
+    run_analysis,
+    run_get,
+    run_io,
+    run_plot,
+    run_preprocessing,
+)
+from ehrapy.mcp.tools.ingestion import export_edata, ingest_dataset
+from ehrapy.mcp.tools.meta import get_runtime_context, get_workflow_guide
+
+ALL_TOOLS_LIST = [
+    # Reference & Discovery
+    get_workflow_guide,
+    get_runtime_context,
+    list_ehrapy_functions,
+    get_function_help,
+    # Cohort Management
+    ingest_dataset,
+    load_demo_dataset,
+    fork_edata_handle,
+    export_edata,
+    get_edata_snapshot,
+    # Execution
+    run_preprocessing,
+    run_analysis,
+    run_get,
+    run_plot,
+    run_io,
+]

--- a/ehrapy/mcp/tools/dispatch_tools.py
+++ b/ehrapy/mcp/tools/dispatch_tools.py
@@ -78,6 +78,55 @@ def fork_edata_handle(edata_id: str | None = None, name: str | None = None, ctx:
         return mcp_error("fork_edata_handle", f"Failed to fork handle '{handle}': {exc}", error_code="FORK_ERROR")
 
 
+def _non_none_str_list(items: Any) -> list[str]:
+    return [str(x) for x in items if x is not None]
+
+
+def _truncated_list_str(items: list[str], limit: int = 25) -> str:
+    suffix = "..." if len(items) > limit else ""
+    return f"{', '.join(items[:limit])}{suffix}"
+
+
+def _snapshot_struct(edata: Any, handle: str, cols: dict[str, list[str]], *, used_latest: bool) -> dict[str, Any]:
+    struct = {
+        "status": "ok",
+        "edata_id": handle,
+        "n_obs": edata.n_obs,
+        "n_vars": edata.n_vars,
+        "obs_columns": cols["obs"],
+        "var_columns": cols["var"],
+        "layers": cols["layers"],
+        "uns_keys": cols["uns"],
+    }
+    if used_latest:
+        struct["used_latest"] = True
+    return struct
+
+
+def _snapshot_markdown(edata: Any, handle: str, cols: dict[str, list[str]]) -> str:
+    md_lines = [
+        f"### Snapshot for EHRData `{handle}`",
+        f"- **Dimensions:** {edata.n_obs} observations × {edata.n_vars} variables",
+        f"- **Observation columns ({len(cols['obs'])}):** {_truncated_list_str(cols['obs'])}",
+        f"- **Variable columns ({len(cols['var'])}):** {_truncated_list_str(cols['var'])}",
+        f"- **Layers ({len(cols['layers'])}):** {', '.join(cols['layers']) if cols['layers'] else 'None'}",
+        f"- **Annotations (uns keys):** {', '.join(cols['uns']) if cols['uns'] else 'None'}",
+    ]
+    return "\n".join(md_lines)
+
+
+def _edata_snapshot_payload(edata: Any, handle: str, *, used_latest: bool) -> tuple[dict[str, Any], str]:
+    """Build the (structured_content, markdown) pair describing an EHRData handle's shape."""
+    cols = {
+        "obs": _non_none_str_list(edata.obs.columns),
+        "var": _non_none_str_list(edata.var.columns),
+        "layers": _non_none_str_list(edata.layers.keys()),
+        "uns": _non_none_str_list(edata.uns.keys()),
+    }
+    struct = _snapshot_struct(edata, handle, cols, used_latest=used_latest)
+    return struct, _snapshot_markdown(edata, handle, cols)
+
+
 def get_edata_snapshot(edata_id: str | None = None, ctx: Context = None) -> ToolResult:
     """Return structural metadata for an EHRData handle including observation count, variable count, layers, obs columns, and uns keys.
 
@@ -95,33 +144,8 @@ def get_edata_snapshot(edata_id: str | None = None, ctx: Context = None) -> Tool
 
     try:
         edata = load_edata(handle)
-        obs_cols = [str(c) for c in edata.obs.columns if c is not None]
-        var_cols = [str(c) for c in edata.var.columns if c is not None]
-        layers = [str(k) for k in edata.layers.keys() if k is not None]
-        uns_keys = [str(k) for k in edata.uns.keys() if k is not None]
-
-        struct = {
-            "status": "ok",
-            "edata_id": handle,
-            "n_obs": edata.n_obs,
-            "n_vars": edata.n_vars,
-            "obs_columns": obs_cols,
-            "var_columns": var_cols,
-            "layers": layers,
-            "uns_keys": uns_keys,
-        }
-        if edata_id is None:
-            struct["used_latest"] = True
-
-        md_lines = [
-            f"### Snapshot for EHRData `{handle}`",
-            f"- **Dimensions:** {edata.n_obs} observations × {edata.n_vars} variables",
-            f"- **Observation columns ({len(obs_cols)}):** {', '.join(obs_cols[:25])}{'...' if len(obs_cols) > 25 else ''}",
-            f"- **Variable columns ({len(var_cols)}):** {', '.join(var_cols[:25])}{'...' if len(var_cols) > 25 else ''}",
-            f"- **Layers ({len(layers)}):** {', '.join(layers) if layers else 'None'}",
-            f"- **Annotations (uns keys):** {', '.join(uns_keys) if uns_keys else 'None'}",
-        ]
-        return ToolResult(structured_content=struct, content="\n".join(md_lines))
+        struct, md = _edata_snapshot_payload(edata, handle, used_latest=edata_id is None)
+        return ToolResult(structured_content=struct, content=md)
     except (KeyError, FileNotFoundError):
         return unknown_handle_error("get_edata_snapshot", "edata_id", handle)
     except Exception as exc:  # noqa: BLE001

--- a/ehrapy/mcp/tools/dispatch_tools.py
+++ b/ehrapy/mcp/tools/dispatch_tools.py
@@ -1,0 +1,285 @@
+"""Dispatch, inspection, demo, and help tools for ehrapy MCP."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+from fastmcp import Context  # noqa: TC002
+from fastmcp.tools.tool import ToolResult
+
+from ehrapy.mcp.catalog import (
+    function_help,
+    function_help_markdown,
+    list_functions,
+    list_namespaces,
+)
+from ehrapy.mcp.dispatch import run_dispatch
+from ehrapy.mcp.edata_store import fork_edata, load_edata
+from ehrapy.mcp.errors import mcp_error, unknown_handle_error
+from ehrapy.mcp.session import get_session
+from ehrapy.mcp.steering import get_suggested_next
+
+
+async def load_demo_dataset(dataset: str, ctx: Context = None) -> ToolResult:
+    """Load a built-in demonstration cohort into the MCP session.
+
+    Use 'mimic_2' for ICU mortality and survival workflows, or 'physionet2012' for in-hospital mortality benchmarking.
+    Returns a dataset handle (edata_id) for subsequent tool calls.
+    """
+    return await run_dispatch("demo", dataset, ctx=ctx)
+
+
+def fork_edata_handle(edata_id: str | None = None, name: str | None = None, ctx: Context = None) -> ToolResult:
+    """Create an independent copy of an existing EHRData dataset handle.
+
+    Use this to branch analysis pipelines or preserve intermediate states before destructive transformations.
+    """
+    session = get_session(ctx)
+    used_latest = False
+    handle = edata_id
+    if handle is None:
+        handle = session.get_latest_edata_id()
+        used_latest = True
+
+    if handle is None:
+        return mcp_error(
+            "fork_edata_handle",
+            "No dataset handle provided and no active dataset in session.",
+            error_code="NO_ACTIVE_DATASET",
+            agent_action="Load a dataset with load_demo_dataset(dataset='mimic_2') first.",
+        )
+
+    try:
+        record = fork_edata(handle, name=name)
+        session.set_latest_edata_id(record.edata_id)
+        struct: dict[str, Any] = {
+            "status": "ok",
+            "edata_id": record.edata_id,
+            "parent_id": record.parent_id,
+            "name": record.name,
+            "n_obs": record.n_obs,
+            "n_vars": record.n_vars,
+        }
+        if used_latest:
+            struct["used_latest"] = True
+
+        md = (
+            f"### Forked EHRData handle\n"
+            f"- **New handle (edata_id):** `{record.edata_id}`\n"
+            f"- **Parent handle:** `{record.parent_id}`\n"
+            f"- **Name:** `{record.name}`\n"
+            f"- **Observations:** {record.n_obs}\n"
+            f"- **Variables:** {record.n_vars}"
+        )
+        return ToolResult(structured_content=struct, content=md)
+    except (KeyError, FileNotFoundError):
+        return unknown_handle_error("fork_edata_handle", "edata_id", handle)
+    except Exception as exc:  # noqa: BLE001
+        return mcp_error("fork_edata_handle", f"Failed to fork handle '{handle}': {exc}", error_code="FORK_ERROR")
+
+
+def get_edata_snapshot(edata_id: str | None = None, ctx: Context = None) -> ToolResult:
+    """Return structural metadata for an EHRData handle including observation count, variable count, layers, obs columns, and uns keys.
+
+    Read-only summary of dataset dimensions.
+    """
+    session = get_session(ctx)
+    handle = edata_id or session.get_latest_edata_id()
+    if handle is None:
+        return mcp_error(
+            "get_edata_snapshot",
+            "No dataset handle provided and no active dataset in session.",
+            error_code="NO_ACTIVE_DATASET",
+            agent_action="Load a dataset with load_demo_dataset(dataset='mimic_2') or ingest_dataset(file_path=...).",
+        )
+
+    try:
+        edata = load_edata(handle)
+        obs_cols = [str(c) for c in edata.obs.columns if c is not None]
+        var_cols = [str(c) for c in edata.var.columns if c is not None]
+        layers = [str(k) for k in edata.layers.keys() if k is not None]
+        uns_keys = [str(k) for k in edata.uns.keys() if k is not None]
+
+        struct = {
+            "status": "ok",
+            "edata_id": handle,
+            "n_obs": edata.n_obs,
+            "n_vars": edata.n_vars,
+            "obs_columns": obs_cols,
+            "var_columns": var_cols,
+            "layers": layers,
+            "uns_keys": uns_keys,
+        }
+        if edata_id is None:
+            struct["used_latest"] = True
+
+        md_lines = [
+            f"### Snapshot for EHRData `{handle}`",
+            f"- **Dimensions:** {edata.n_obs} observations × {edata.n_vars} variables",
+            f"- **Observation columns ({len(obs_cols)}):** {', '.join(obs_cols[:25])}{'...' if len(obs_cols) > 25 else ''}",
+            f"- **Variable columns ({len(var_cols)}):** {', '.join(var_cols[:25])}{'...' if len(var_cols) > 25 else ''}",
+            f"- **Layers ({len(layers)}):** {', '.join(layers) if layers else 'None'}",
+            f"- **Annotations (uns keys):** {', '.join(uns_keys) if uns_keys else 'None'}",
+        ]
+        return ToolResult(structured_content=struct, content="\n".join(md_lines))
+    except (KeyError, FileNotFoundError):
+        return unknown_handle_error("get_edata_snapshot", "edata_id", handle)
+    except Exception as exc:  # noqa: BLE001
+        return mcp_error("get_edata_snapshot", f"Snapshot failed: {exc}", error_code="SNAPSHOT_ERROR")
+
+
+def list_ehrapy_functions(namespace: str) -> ToolResult:
+    """List available functions within a specified ehrapy dispatch namespace.
+
+    Use this to discover supported operations in preprocessing, analysis, get, plot, io, or demo namespaces.
+    """
+    try:
+        funcs = list_functions(namespace)
+        struct = {"status": "ok", "namespace": namespace, "count": len(funcs), "functions": funcs}
+        md = f"### Available functions in `{namespace}` ({len(funcs)})\n\n" + ", ".join(f"`{f}`" for f in funcs)
+        return ToolResult(structured_content=struct, content=md)
+    except KeyError:
+        valid = list_namespaces()
+        return mcp_error(
+            "list_ehrapy_functions",
+            f"Unknown namespace '{namespace}'. Valid namespaces: {', '.join(valid)}.",
+            error_code="UNKNOWN_NAMESPACE",
+            agent_action=f"Specify one of the valid namespaces: {', '.join(valid)}.",
+        )
+
+
+def get_function_help(namespace: str, function: str) -> ToolResult:
+    """Retrieve signature, parameter descriptions, accepted values, and an example call for any ehrapy function.
+
+    Use this when unsure which arguments a function accepts before calling run_preprocessing, run_analysis, or run_get.
+    """
+    try:
+        info = function_help(namespace, function)
+        md = function_help_markdown(namespace, function)
+        struct = {
+            "status": "ok",
+            "namespace": info["namespace"],
+            "function": info["function"],
+            "kind": info["kind"],
+            "parameters": info["parameters"],
+            "example_call": info["example_call"],
+        }
+        return ToolResult(structured_content=struct, content=md)
+    except KeyError as exc:
+        return mcp_error(
+            "get_function_help",
+            str(exc),
+            error_code="UNKNOWN_FUNCTION",
+            agent_action=f"Call list_ehrapy_functions(namespace='{namespace}') to see available functions.",
+        )
+    except Exception as exc:  # noqa: BLE001
+        return mcp_error("get_function_help", f"Failed to retrieve help: {exc}", error_code="HELP_ERROR")
+
+
+async def run_preprocessing(
+    function: str,
+    edata_id: str | None = None,
+    params: dict | None = None,
+    response_format: Literal["concise", "detailed"] = "concise",
+    ctx: Context = None,
+) -> ToolResult:
+    """Run an ehrapy preprocessing function (ep.pp.*) on an EHRData object.
+
+    Use this for quality control, encoding, imputation, normalization, filtering, PCA, and neighbor graph computation.
+    Updates the dataset in place and returns a column profile of the result.
+    Set response_format='detailed' only when you explicitly need sample rows.
+    """
+    return await run_dispatch(
+        "preprocessing",
+        function,
+        edata_id=edata_id,
+        params=params,
+        response_format=response_format,
+        ctx=ctx,
+    )
+
+
+async def run_analysis(
+    function: str,
+    edata_id: str | None = None,
+    params: dict | None = None,
+    response_format: Literal["concise", "detailed"] = "concise",
+    ctx: Context = None,
+) -> ToolResult:
+    """Run an ehrapy analysis function (ep.tl.*) on an EHRData object.
+
+    Use this for survival analysis (Kaplan-Meier, Cox PH), causal inference (IPTW, AIPW, G-computation),
+    embeddings (UMAP, t-SNE), clustering (Leiden), and differential feature ranking.
+    Returns concise statistical summaries or column profiles.
+    """
+    return await run_dispatch(
+        "analysis",
+        function,
+        edata_id=edata_id,
+        params=params,
+        response_format=response_format,
+        ctx=ctx,
+    )
+
+
+async def run_get(
+    function: str,
+    edata_id: str | None = None,
+    params: dict | None = None,
+    response_format: Literal["concise", "detailed"] = "concise",
+    ctx: Context = None,
+) -> ToolResult:
+    """Read observation metadata, variable annotations, or ranked feature tables from an EHRData object.
+
+    This is a read-only operation that does not modify the dataset.
+    Always specify keys to narrow returned columns and avoid truncated output.
+    """
+    return await run_dispatch(
+        "get",
+        function,
+        edata_id=edata_id,
+        params=params,
+        response_format=response_format,
+        ctx=ctx,
+    )
+
+
+async def run_plot(
+    function: str,
+    edata_id: str | None = None,
+    params: dict | None = None,
+    ctx: Context = None,
+) -> ToolResult:
+    """Render a visualization for an EHRData object and save it as a PNG artifact.
+
+    Use this for QC plots, survival curves, embedding projections, and causal balance diagnostics.
+    Returns an image payload and file path.
+    """
+    return await run_dispatch(
+        "plot",
+        function,
+        edata_id=edata_id,
+        params=params,
+        ctx=ctx,
+    )
+
+
+async def run_io(
+    function: str,
+    edata_id: str | None = None,
+    params: dict | None = None,
+    response_format: Literal["concise", "detailed"] = "concise",
+    ctx: Context = None,
+) -> ToolResult:
+    """Execute an EHRData I/O function to read from or write to disk.
+
+    Use this for advanced file format conversions and data loading.
+    """
+    return await run_dispatch(
+        "io",
+        function,
+        edata_id=edata_id,
+        params=params,
+        response_format=response_format,
+        ctx=ctx,
+    )

--- a/ehrapy/mcp/tools/ingestion.py
+++ b/ehrapy/mcp/tools/ingestion.py
@@ -26,6 +26,11 @@ def ingest_dataset(
     """Read an external tabular data file (CSV, TSV) and convert it into a managed EHRData handle.
 
     Use this to load clinical cohorts from the host filesystem into the session cache.
+
+    Cache-Bridge pattern for sandboxed clients: If running in a sandboxed agent environment,
+    file paths in the client sandbox are not directly visible to the MCP host. Call
+    get_runtime_context() to inspect cache_dir, copy your data file into cache_dir, and
+    pass that path to file_path.
     """
     try:
         resolved_path = check_path_allowed(file_path, for_write=False)

--- a/ehrapy/mcp/tools/ingestion.py
+++ b/ehrapy/mcp/tools/ingestion.py
@@ -1,0 +1,136 @@
+"""Dataset ingestion and export tools for ehrapy MCP."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+import ehrdata.io as ed_io
+from fastmcp import Context  # noqa: TC002
+from fastmcp.tools.tool import ToolResult
+
+from ehrapy.mcp.edata_store import load_edata, save_edata
+from ehrapy.mcp.errors import mcp_error, path_access_error, unknown_handle_error
+from ehrapy.mcp.policy import PathNotAllowedError, ReadOnlyModeError, check_path_allowed
+from ehrapy.mcp.session import get_session
+from ehrapy.mcp.steering import get_suggested_next
+
+
+def ingest_dataset(
+    file_path: str,
+    dataset_name: str | None = None,
+    sep: str = ",",
+    index_col: str | None = None,
+    ctx: Context = None,
+) -> ToolResult:
+    """Read an external tabular data file (CSV, TSV) and convert it into a managed EHRData handle.
+
+    Use this to load clinical cohorts from the host filesystem into the session cache.
+    """
+    try:
+        resolved_path = check_path_allowed(file_path, for_write=False)
+    except PathNotAllowedError as exc:
+        return mcp_error("ingest_dataset", str(exc), error_code=exc.error_code, agent_action=exc.agent_action)
+    except ReadOnlyModeError as exc:
+        return mcp_error("ingest_dataset", str(exc), error_code=exc.error_code, agent_action=exc.agent_action)
+
+    if not resolved_path.is_file():
+        return path_access_error("ingest_dataset", str(file_path))
+
+    try:
+        read_kwargs: dict[str, Any] = {"sep": sep}
+        if index_col is not None:
+            read_kwargs["index_column"] = index_col
+        edata = ed_io.read_csv(resolved_path, **read_kwargs)
+        name = dataset_name or resolved_path.stem
+        record = save_edata(edata, name=name, source_path=str(resolved_path))
+
+        session = get_session(ctx)
+        session.set_latest_edata_id(record.edata_id)
+
+        suggestions = get_suggested_next("io", "read_csv")
+        struct: dict[str, Any] = {
+            "status": "ok",
+            "edata_id": record.edata_id,
+            "name": record.name,
+            "n_obs": edata.n_obs,
+            "n_vars": edata.n_vars,
+            "source_path": str(resolved_path),
+        }
+        if suggestions:
+            struct["suggested_next"] = [s["call"] for s in suggestions]
+
+        md_lines = [
+            f"### Ingested dataset `{record.name}`",
+            f"- **Handle (edata_id):** `{record.edata_id}`",
+            f"- **Observations:** {edata.n_obs}",
+            f"- **Variables:** {edata.n_vars}",
+            f"- **Source file:** `{resolved_path}`",
+        ]
+        if suggestions:
+            md_lines.extend(["", "**Suggested next:**"])
+            for s in suggestions:
+                md_lines.append(f"- `{s['call']}` — {s['reason']}")
+
+        return ToolResult(structured_content=struct, content="\n".join(md_lines))
+    except Exception as exc:  # noqa: BLE001
+        return mcp_error("ingest_dataset", f"Failed to ingest file '{file_path}': {exc}", error_code="INGEST_ERROR")
+
+
+def export_edata(
+    target_path: str,
+    edata_id: str | None = None,
+    fmt: Literal["h5ad", "zarr", "csv"] = "h5ad",
+    ctx: Context = None,
+) -> ToolResult:
+    """Export an EHRData object to a specified file path.
+
+    Supports writing to h5ad, zarr, or CSV formats.
+    """
+    session = get_session(ctx)
+    used_latest = False
+    handle = edata_id
+    if handle is None:
+        handle = session.get_latest_edata_id()
+        used_latest = True
+
+    if handle is None:
+        return mcp_error(
+            "export_edata",
+            "No dataset handle provided and no active dataset in session.",
+            error_code="NO_ACTIVE_DATASET",
+            agent_action="Load a dataset with load_demo_dataset(dataset='mimic_2') or ingest_dataset(file_path=...).",
+        )
+
+    try:
+        resolved_path = check_path_allowed(target_path, for_write=True, operation="export_edata")
+    except PathNotAllowedError as exc:
+        return mcp_error("export_edata", str(exc), error_code=exc.error_code, agent_action=exc.agent_action)
+    except ReadOnlyModeError as exc:
+        return mcp_error("export_edata", str(exc), error_code=exc.error_code, agent_action=exc.agent_action)
+
+    try:
+        edata = load_edata(handle)
+        if fmt == "h5ad":
+            ed_io.write_h5ad(edata, resolved_path)
+        elif fmt == "zarr":
+            ed_io.write_zarr(edata, resolved_path)
+        elif fmt == "csv":
+            df = ed_io.to_pandas(edata)
+            df.to_csv(resolved_path)
+        else:
+            return mcp_error("export_edata", f"Unsupported export format '{fmt}'", error_code="INVALID_FORMAT")
+
+        struct: dict[str, Any] = {
+            "status": "ok",
+            "edata_id": handle,
+            "target_path": str(resolved_path),
+            "format": fmt,
+        }
+        if used_latest:
+            struct["used_latest"] = True
+
+        md = f"Dataset `{handle}` successfully exported to `{resolved_path}` ({fmt} format)."
+        return ToolResult(structured_content=struct, content=md)
+    except Exception as exc:  # noqa: BLE001
+        return mcp_error("export_edata", f"Export failed: {exc}", error_code="EXPORT_ERROR")

--- a/ehrapy/mcp/tools/meta.py
+++ b/ehrapy/mcp/tools/meta.py
@@ -27,22 +27,27 @@ def get_workflow_guide() -> ToolResult:
 def get_runtime_context(ctx: Context = None) -> ToolResult:
     """Return MCP runtime environment details including ehrapy version, cache directories, and session handle.
 
-    Use this to verify environment state and identify active dataset identifiers.
+    Use this to verify environment state, discover the cache directory for Cache-Bridge ingestion, and identify active dataset identifiers.
     """
     session = get_session(ctx)
     allowed = get_allowed_roots()
     datasets = registry.list_datasets()
+    cache_dir = registry.cache_dir()
+    demo_dir = registry.demo_data_dir()
+    cache_writable = registry.is_cache_writable()
 
     struct: dict[str, Any] = {
         "status": "ok",
         "ehrapy_version": ep.__version__,
         "python_version": sys.version.split()[0],
-        "cache_dir": str(registry.cache_dir()),
+        "cache_dir": str(cache_dir),
+        "demo_data_dir": str(demo_dir),
         "plots_dir": str(registry.plots_dir()),
         "active_edata_id": session.get_latest_edata_id(),
         "read_only_mode": is_read_only_mode(),
         "allowed_roots": [str(r) for r in allowed] if allowed else None,
         "cached_datasets_count": len(datasets),
+        "cache_writable": cache_writable,
     }
 
     md_lines = [
@@ -51,10 +56,15 @@ def get_runtime_context(ctx: Context = None) -> ToolResult:
         f"- **Python version:** `{sys.version.split()[0]}`",
         f"- **Active dataset (edata_id):** `{session.get_latest_edata_id() or 'None'}`",
         f"- **Cached datasets:** {len(datasets)}",
-        f"- **Cache directory:** `{registry.cache_dir()}`",
+        f"- **Cache directory:** `{cache_dir}`",
+        f"- **Demo data directory:** `{demo_dir}`",
         f"- **Plots directory:** `{registry.plots_dir()}`",
         f"- **Read-only mode:** `{is_read_only_mode()}`",
         f"- **Allowed roots:** `{', '.join(str(r) for r in allowed) if allowed else 'Unrestricted'}`",
+        f"- **Cache writable:** `{cache_writable}`",
+        "",
+        "**Cache-Bridge Ingestion:**",
+        f"To ingest files from a sandboxed client, copy them to `{cache_dir}` and pass the resulting path to `ingest_dataset(file_path=...)`.",
     ]
 
     return ToolResult(structured_content=struct, content="\n".join(md_lines))

--- a/ehrapy/mcp/tools/meta.py
+++ b/ehrapy/mcp/tools/meta.py
@@ -1,0 +1,60 @@
+"""Meta, runtime, and workflow guide tools for ehrapy MCP."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+from fastmcp import Context  # noqa: TC002
+from fastmcp.tools.tool import ToolResult
+
+import ehrapy as ep
+from ehrapy.mcp.policy import get_allowed_roots, is_read_only_mode
+from ehrapy.mcp.prompts import WORKFLOW_PROMPT
+from ehrapy.mcp.registry import registry
+from ehrapy.mcp.session import get_session
+
+
+def get_workflow_guide() -> ToolResult:
+    """Return recommended multi-step clinical analysis workflows covering quality control, survival analysis, and causal inference.
+
+    Use this to determine the standard sequence of ehrapy operations before processing a cohort.
+    """
+    struct = {"status": "ok", "guide": "Standard clinical workflow guide"}
+    return ToolResult(structured_content=struct, content=WORKFLOW_PROMPT)
+
+
+def get_runtime_context(ctx: Context = None) -> ToolResult:
+    """Return MCP runtime environment details including ehrapy version, cache directories, and session handle.
+
+    Use this to verify environment state and identify active dataset identifiers.
+    """
+    session = get_session(ctx)
+    allowed = get_allowed_roots()
+    datasets = registry.list_datasets()
+
+    struct: dict[str, Any] = {
+        "status": "ok",
+        "ehrapy_version": ep.__version__,
+        "python_version": sys.version.split()[0],
+        "cache_dir": str(registry.cache_dir()),
+        "plots_dir": str(registry.plots_dir()),
+        "active_edata_id": session.get_latest_edata_id(),
+        "read_only_mode": is_read_only_mode(),
+        "allowed_roots": [str(r) for r in allowed] if allowed else None,
+        "cached_datasets_count": len(datasets),
+    }
+
+    md_lines = [
+        "### ehrapy MCP Runtime Context",
+        f"- **ehrapy version:** `{ep.__version__}`",
+        f"- **Python version:** `{sys.version.split()[0]}`",
+        f"- **Active dataset (edata_id):** `{session.get_latest_edata_id() or 'None'}`",
+        f"- **Cached datasets:** {len(datasets)}",
+        f"- **Cache directory:** `{registry.cache_dir()}`",
+        f"- **Plots directory:** `{registry.plots_dir()}`",
+        f"- **Read-only mode:** `{is_read_only_mode()}`",
+        f"- **Allowed roots:** `{', '.join(str(r) for r in allowed) if allowed else 'Unrestricted'}`",
+    ]
+
+    return ToolResult(structured_content=struct, content="\n".join(md_lines))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["hatchling"]
 
 [project]
 name = "ehrapy"
-version = "0.15.0"
+version = "0.1.0"
 description = "Electronic Health Record Analysis with Python."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"
@@ -24,7 +24,7 @@ maintainers = [
     {name = "Lukas Heumos", email = "lukas.heumos@posteo.net"},
 ]
 urls.Documentation = "https://ehrapy.readthedocs.io"
-urls.Source = "https://github.com/theislab/ehrapy"
+urls.Source = "https://github.com/Krv-Labs/ehrapy"
 urls.Home-page = "https://github.com/theislab/ehrapy"
 
 classifiers = [
@@ -123,9 +123,6 @@ test = [
 
 [project.scripts]
 ehrapy-mcp = "ehrapy.mcp.server:main"
-
-[tool.hatch.version]
-source = "vcs"
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,12 @@ dask = [
     "dask-ml>=2025.1.0",
 ]
 leiden = ["igraph"]  # careful - GPL
+mcp = [
+    "fastmcp>=3.4,<4",
+    "numpydoc",
+    "platformdirs",
+    "igraph",  # careful - GPL; needed because the MCP workflow guide steers agents to leiden
+]
 rapids12 = ["rapids-singlecell[rapids12]"]
 rapids13 = ["rapids-singlecell[rapids13]"]
 dev = [
@@ -104,16 +110,19 @@ doc = [
     "nbsphinx-link",
     "ipykernel",
     "ipython",
-    "ehrapy[dask,leiden]",
+    "ehrapy[dask,leiden,mcp]",
     "scverse-misc"
 ]
 test = [
-    "ehrapy[dask,leiden]",
+    "ehrapy[dask,leiden,mcp]",
     "pytest",
     "pytest-cov",
     "pytest-mock"
 ]
 
+
+[project.scripts]
+ehrapy-mcp = "ehrapy.mcp.server:main"
 
 [tool.hatch.version]
 source = "vcs"
@@ -139,7 +148,7 @@ scripts.clean = "git clean -fdX -- {args:docs}"
 
 # CPU
 [tool.hatch.envs.hatch-test]
-features = [ "dask", "leiden" ]
+features = [ "dask", "leiden", "mcp" ]
 post-install-commands = [
   "uv pip install --reinstall --no-deps -e submodules/ehrdata",
 ]

--- a/scripts/mcp_eval.py
+++ b/scripts/mcp_eval.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Evaluation runner for ehrapy MCP server (T21).
+
+Runs multi-step workflow tasks defined in tests/mcp/eval_tasks.yaml and reports metrics.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from pathlib import Path
+
+import yaml
+from fastmcp import Client
+
+from ehrapy.mcp.server import mcp
+
+
+async def run_eval() -> int:
+    """Run all evaluation tasks defined in eval_tasks.yaml and print results."""
+    tasks_file = Path(__file__).resolve().parent.parent / "tests" / "mcp" / "eval_tasks.yaml"
+    if not tasks_file.exists():
+        print(f"Error: {tasks_file} not found.", file=sys.stderr)
+        return 1
+
+    with tasks_file.open(encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    tasks = data.get("tasks", [])
+    print(f"Loaded {len(tasks)} evaluation tasks from {tasks_file.name}\n")
+    print("=" * 80)
+
+    total_steps = 0
+    passed_steps = 0
+    failed_steps = 0
+    total_time = 0.0
+
+    async with Client(mcp) as client:
+        for task in tasks:
+            task_id = task.get("id")
+            task_name = task.get("name")
+            steps = task.get("steps", [])
+            print(f"\n▶ Running Task: [{task_id}] {task_name} ({len(steps)} steps)")
+
+            task_passed = True
+            for i, step in enumerate(steps, 1):
+                total_steps += 1
+                tool_name = step["tool"]
+                args = step.get("args", {})
+                expected_status = step.get("assert_status", "ok")
+
+                start_t = time.perf_counter()
+                try:
+                    res = await client.call_tool(tool_name, args)
+                    elapsed = time.perf_counter() - start_t
+                    total_time += elapsed
+
+                    struct = res.structured_content or {}
+                    actual_status = struct.get("status", "error" if res.is_error else "ok")
+
+                    content_text = ""
+                    if res.content:
+                        content_text = " ".join(getattr(c, "text", "") for c in res.content)
+
+                    if actual_status != expected_status:
+                        print(
+                            f"  ❌ Step {i} ({tool_name}): expected status '{expected_status}', got '{actual_status}'"
+                        )
+                        print(f"     Reason: {struct.get('reason')}")
+                        task_passed = False
+                        failed_steps += 1
+                        break
+
+                    assert_contains = step.get("assert_contains", [])
+                    missing_keys = [k for k in assert_contains if k not in struct and k not in content_text]
+                    if missing_keys:
+                        print(f"  ❌ Step {i} ({tool_name}): missing expected fields {missing_keys}")
+                        task_passed = False
+                        failed_steps += 1
+                        break
+
+                    expected_code = step.get("assert_error_code")
+                    if expected_code and struct.get("error_code") != expected_code:
+                        print(
+                            f"  ❌ Step {i} ({tool_name}): expected error_code "
+                            f"'{expected_code}', got '{struct.get('error_code')}'"
+                        )
+                        task_passed = False
+                        failed_steps += 1
+                        break
+
+                    # A plot step must actually return an image, not just report success.
+                    if step.get("assert_image"):
+                        kinds = [type(c).__name__ for c in (res.content or [])]
+                        if "ImageContent" not in kinds:
+                            print(f"  ❌ Step {i} ({tool_name}): expected an image, got {kinds}")
+                            task_passed = False
+                            failed_steps += 1
+                            break
+
+                    passed_steps += 1
+                    approx_tokens = int(len(content_text) / 4)
+                    print(f"  ✔ Step {i}: {tool_name} ({elapsed * 1000:.1f}ms, ~{approx_tokens} tokens)")
+
+                except Exception as exc:  # noqa: BLE001
+                    elapsed = time.perf_counter() - start_t
+                    total_time += elapsed
+                    print(f"  ❌ Step {i} ({tool_name}): Exception {exc}")
+                    task_passed = False
+                    failed_steps += 1
+                    break
+
+            if task_passed:
+                print(f"  🏆 Task [{task_id}] PASSED")
+            else:
+                print(f"  💥 Task [{task_id}] FAILED")
+
+    print("\n" + "=" * 80)
+    print(f"Eval Summary: {passed_steps}/{total_steps} steps passed. Total time: {total_time:.2f}s")
+    return 0 if failed_steps == 0 else 1
+
+
+def main() -> None:
+    """Run CLI entrypoint for evaluation harness."""
+    sys.exit(asyncio.run(run_eval()))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/try_ehrapy_mcp.py
+++ b/scripts/try_ehrapy_mcp.py
@@ -1,0 +1,67 @@
+"""Quick local smoke test for ehrapy-mcp over stdio."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import tempfile
+from pathlib import Path
+
+from fastmcp import Client
+from fastmcp.client.transports import StdioTransport
+
+
+async def main() -> None:
+    """Exercise the packaged ehrapy-mcp server over stdio: list tools, load, ingest, query."""
+    transport = StdioTransport(command=sys.executable, args=["-m", "ehrapy.mcp.server"])
+    async with Client(transport=transport) as client:
+        tools = await client.list_tools()
+        print(f"tools: {len(tools)}")
+
+        guide = (await client.call_tool("get_workflow_guide", {})).content[0].text
+        assert "run_preprocessing" in guide
+        print("get_workflow_guide: ok")
+
+        demo = (await client.call_tool("load_demo_dataset", {"dataset": "mimic_2"})).structured_content
+        edata_id = demo["edata_id"]
+        print(f"load_demo_dataset: ok ({edata_id})")
+
+        qc = (
+            await client.call_tool(
+                "run_preprocessing",
+                {
+                    "function": "qc_metrics",
+                    "edata_id": edata_id,
+                    "params": {"qc_vars": []},
+                },
+            )
+        ).structured_content
+        assert qc["status"] == "ok"
+        print("run_preprocessing qc_metrics: ok")
+
+        obs = (
+            await client.call_tool(
+                "run_get",
+                {
+                    "function": "obs_df",
+                    "edata_id": edata_id,
+                    "params": {"keys": ["age"]},
+                },
+            )
+        ).structured_content
+        assert obs["status"] == "ok"
+        print("run_get obs_df: ok")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "patients.csv"
+            path.write_text("patient_id,age,sex\np1,45,F\np2,62,M\n", encoding="utf-8")
+            ing = (await client.call_tool("ingest_dataset", {"file_path": str(path)})).structured_content
+            snap = (await client.call_tool("get_edata_snapshot", {"edata_id": ing["edata_id"]})).structured_content
+            assert snap["n_obs"] == 2
+            print("ingest_dataset + snapshot: ok")
+
+    print("ALL_OK")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/mcp/eval_tasks.yaml
+++ b/tests/mcp/eval_tasks.yaml
@@ -1,0 +1,264 @@
+tasks:
+  - id: eda_qc_mimic2
+    name: Exploratory Data Analysis & Quality Control on MIMIC-II
+    steps:
+      - tool: load_demo_dataset
+        args:
+          dataset: mimic_2
+        assert_status: ok
+        assert_contains:
+          - edata_id
+      - tool: get_edata_snapshot
+        args: {}
+        assert_status: ok
+      - tool: run_preprocessing
+        args:
+          function: qc_metrics
+          params:
+            qc_vars: []
+        assert_status: ok
+      - tool: run_get
+        args:
+          function: obs_df
+          params:
+            keys: ["missing_values_abs", "missing_values_pct"]
+        assert_status: ok
+
+  - id: clustering_pipeline
+    name: Unsupervised Clustering & Differential Features
+    steps:
+      - tool: load_demo_dataset
+        args:
+          dataset: mimic_2
+        assert_status: ok
+      - tool: run_preprocessing
+        args:
+          function: simple_impute
+          params:
+            var_names: ["gender_num"]
+            strategy: most_frequent
+        assert_status: ok
+      - tool: run_preprocessing
+        args:
+          function: encode
+          params:
+            autodetect: true
+        assert_status: ok
+      - tool: run_preprocessing
+        args:
+          function: simple_impute
+          params:
+            strategy: mean
+        assert_status: ok
+      - tool: run_preprocessing
+        args:
+          function: pca
+        assert_status: ok
+      - tool: run_preprocessing
+        args:
+          function: neighbors
+        assert_status: ok
+      - tool: run_analysis
+        args:
+          function: leiden
+          params:
+            resolution: 0.5
+        assert_status: ok
+      - tool: run_analysis
+        args:
+          function: rank_features_groups
+          params:
+            groupby: leiden
+        assert_status: ok
+      - tool: run_get
+        args:
+          function: rank_features_groups_df
+          params:
+            group: "0"
+        assert_status: ok
+
+  - id: survival_analysis
+    name: Kaplan-Meier Survival Analysis
+    steps:
+      - tool: load_demo_dataset
+        args:
+          dataset: mimic_2
+        assert_status: ok
+      - tool: run_analysis
+        args:
+          function: kaplan_meier
+          params:
+            duration_col: mort_day_censored
+            event_col: censor_flg
+        assert_status: ok
+
+  - id: fork_branching
+    name: Dataset Handle Forking & Independent State
+    steps:
+      - tool: load_demo_dataset
+        args:
+          dataset: mimic_2
+        assert_status: ok
+      - tool: fork_edata_handle
+        args:
+          name: branched_cohort
+        assert_status: ok
+      - tool: get_edata_snapshot
+        args: {}
+        assert_status: ok
+
+  - id: discovery_and_help
+    name: Function Discovery & Signature Help
+    steps:
+      - tool: list_ehrapy_functions
+        args:
+          namespace: preprocessing
+        assert_status: ok
+      - tool: get_function_help
+        args:
+          namespace: preprocessing
+          function: knn_impute
+        assert_status: ok
+
+  - id: workflow_guide_and_context
+    name: Workflow Guide & Runtime Context
+    steps:
+      - tool: get_workflow_guide
+        args: {}
+        assert_status: ok
+      - tool: get_runtime_context
+        args: {}
+        assert_status: ok
+
+  # Every plot advertised by the steering graph and the registered MCP prompts is a
+  # promise to the agent; each must return an actual image, not merely status ok.
+  - id: plot_surface
+    name: Plot Surface — every advertised plot returns an image
+    steps:
+      - tool: load_demo_dataset
+        args:
+          dataset: mimic_2
+        assert_status: ok
+      - tool: run_plot
+        args:
+          function: missing_values_matrix
+        assert_status: ok
+        assert_image: true
+      - tool: run_analysis
+        args:
+          function: kaplan_meier
+          params:
+            duration_col: mort_day_censored
+            event_col: censor_flg
+        assert_status: ok
+      - tool: run_plot
+        args:
+          function: kaplan_meier
+        assert_status: ok
+        assert_image: true
+      - tool: run_preprocessing
+        args:
+          function: encode
+          params:
+            autodetect: true
+        assert_status: ok
+      - tool: run_preprocessing
+        args:
+          function: simple_impute
+          params:
+            strategy: mean
+        assert_status: ok
+      - tool: run_preprocessing
+        args:
+          function: pca
+        assert_status: ok
+      - tool: run_preprocessing
+        args:
+          function: neighbors
+        assert_status: ok
+      - tool: run_analysis
+        args:
+          function: umap
+        assert_status: ok
+      - tool: run_plot
+        args:
+          function: umap
+        assert_status: ok
+        assert_image: true
+      # A plot whose first argument is a fitted model, not the EHRData (origin #5).
+      - tool: run_analysis
+        args:
+          function: positivity_check
+          params:
+            treatment: aline_flg
+            covariates: ["age", "gender_num"]
+        assert_status: ok
+      - tool: run_plot
+        args:
+          function: propensity_overlap
+        assert_status: ok
+        assert_image: true
+
+  # Negative paths: a failing call must carry a specific error_code, never a generic one.
+  - id: error_contracts
+    name: Error Contracts — failures are specific and actionable
+    steps:
+      - tool: load_demo_dataset
+        args:
+          dataset: mimic_2
+        assert_status: ok
+      - tool: get_edata_snapshot
+        args:
+          edata_id: no-such-handle
+        assert_status: error
+        assert_error_code: EDATA_ID_UNKNOWN
+      - tool: run_preprocessing
+        args:
+          function: not_a_real_function
+        assert_status: error
+        assert_error_code: UNKNOWN_FUNCTION
+      - tool: list_ehrapy_functions
+        args:
+          namespace: not_a_namespace
+        assert_status: error
+        assert_error_code: UNKNOWN_NAMESPACE
+      - tool: get_edata_snapshot
+        args:
+          hallucinated_argument: 1
+        assert_status: error
+        assert_error_code: UNKNOWN_ARGUMENT
+      - tool: ingest_dataset
+        args:
+          file_path: /home/claude/sandbox_only.csv
+        assert_status: error
+        assert_error_code: HOST_PATH_NOT_VISIBLE
+      # A plot whose model was never fitted must steer, not surface an AttributeError.
+      - tool: run_plot
+        args:
+          function: love_plot
+        assert_status: error
+        assert_error_code: INVALID_VALUE
+
+  # Causal inference returns dataclasses holding ndarrays; these must survive the
+  # JSON boundary of structured_content.
+  - id: causal_inference
+    name: Causal Inference — IPTW result crosses the MCP boundary
+    steps:
+      - tool: load_demo_dataset
+        args:
+          dataset: mimic_2
+        assert_status: ok
+      - tool: run_preprocessing
+        args:
+          function: encode
+          params:
+            autodetect: true
+        assert_status: ok
+      - tool: run_analysis
+        args:
+          function: iptw
+          params:
+            treatment: aline_flg
+            outcome: hosp_exp_flg
+            covariates: ["age", "gender_num"]
+        assert_status: ok

--- a/tests/mcp/test_budgets.py
+++ b/tests/mcp/test_budgets.py
@@ -1,0 +1,95 @@
+"""CI token-budget gate for MCP tools, schemas, and outputs (T16)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from fastmcp import Client
+
+from ehrapy.mcp.catalog import list_functions, list_namespaces
+from ehrapy.mcp.server import mcp
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_tools_list_payload_budget() -> None:
+    """Test that tools/list payload is <= 16KB and <= 4000 tokens."""
+
+    async def _test():
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+            assert len(tools) == 14
+
+            tools_dicts = [
+                {
+                    "name": t.name,
+                    "description": t.description,
+                    "inputSchema": t.inputSchema,
+                    "annotations": t.annotations.model_dump() if t.annotations else None,
+                }
+                for t in tools
+            ]
+            serialized = json.dumps(tools_dicts)
+            byte_size = len(serialized.encode("utf-8"))
+            approx_tokens = len(serialized) / 4
+
+            assert byte_size <= 16 * 1024, f"tools/list is {byte_size} bytes (> 16KB)"
+            assert approx_tokens <= 4000, f"tools/list is ~{approx_tokens} tokens (> 4000 tokens)"
+
+            # Check individual tool descriptions
+            for t in tools:
+                desc_bytes = len((t.description or "").encode("utf-8"))
+                assert desc_bytes <= 2048, f"Tool {t.name} description exceeds 2KB: {desc_bytes} bytes"
+                assert desc_bytes <= 600, f"Tool {t.name} description exceeds 600 bytes: {desc_bytes} bytes"
+
+    _run(_test())
+
+
+def test_workflow_guide_budget() -> None:
+    """Test that get_workflow_guide output is <= 2000 tokens."""
+
+    async def _test():
+        async with Client(mcp) as client:
+            res = await client.call_tool("get_workflow_guide", {})
+            content = res.content[0].text
+            approx_tokens = len(content) / 4
+            assert approx_tokens <= 2000, f"Workflow guide is ~{approx_tokens} tokens (> 2000 tokens)"
+
+    _run(_test())
+
+
+def test_function_help_budget_all_namespaces() -> None:
+    """Test that get_function_help is <= 2500 chars for representative functions."""
+
+    async def _test():
+        async with Client(mcp) as client:
+            for ns in list_namespaces():
+                funcs = list_functions(ns)
+                for fn_name in funcs[:5]:  # test first 5 in each namespace
+                    res = await client.call_tool("get_function_help", {"namespace": ns, "function": fn_name})
+                    content = res.content[0].text
+                    assert len(content) <= 2500, f"Help for {ns}.{fn_name} is {len(content)} chars (> 2500 chars)"
+
+    _run(_test())
+
+
+def test_qc_metrics_output_budget() -> None:
+    """Test that qc_metrics response on mimic_2 is <= 1500 tokens."""
+
+    async def _test():
+        async with Client(mcp) as client:
+            demo_res = await client.call_tool("load_demo_dataset", {"dataset": "mimic_2"})
+            edata_id = demo_res.structured_content["edata_id"]
+
+            qc_res = await client.call_tool(
+                "run_preprocessing",
+                {"function": "qc_metrics", "edata_id": edata_id, "params": {"qc_vars": []}},
+            )
+            content = qc_res.content[0].text
+            approx_tokens = len(content) / 4
+            assert approx_tokens <= 1500, f"qc_metrics output is ~{approx_tokens} tokens (> 1500 tokens)"
+
+    _run(_test())

--- a/tests/mcp/test_cache_and_security.py
+++ b/tests/mcp/test_cache_and_security.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 import stat
 import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import ehrdata.dt as dt
@@ -21,9 +22,6 @@ from ehrapy.mcp.policy import (
 )
 from ehrapy.mcp.registry import MCPRegistry, registry
 from ehrapy.mcp.server import mcp
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def _run(coro):
@@ -137,3 +135,62 @@ def test_cache_directory_permissions_and_purge(tmp_path: Path, monkeypatch: pyte
     # Test purge runs without errors
     purged = reg.purge(older_than_days=7)
     assert isinstance(purged, int)
+
+
+def test_create_server_does_not_purge_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure create_server does not purge existing datasets on disk (issue #16)."""
+    custom_cache = tmp_path / "mcp_cache"
+    monkeypatch.setenv("EHRAPY_MCP_CACHE_DIR", str(custom_cache))
+
+    # Save a dataset in the cache
+    edata = dt.mimic_2()
+    rec = save_edata(edata, name="preserved_test")
+    cache_file = Path(rec.cache_path)
+    assert cache_file.exists()
+
+    # Create server instance without purge
+    from ehrapy.mcp.server import create_server
+
+    create_server(purge_cache=False)
+    assert cache_file.exists()
+    assert registry.get_dataset(rec.edata_id) is not None
+
+
+def test_read_only_tools_preserve_in_memory_edata_invariant() -> None:
+    """Assert invariant that read-only tools do not mutate cached in-memory EHRData (issue #13)."""
+
+    async def _test():
+        async with Client(mcp) as client:
+            demo_res = await client.call_tool("load_demo_dataset", {"dataset": "mimic_2"})
+            edata_id = demo_res.structured_content["edata_id"]
+
+            edata_before = load_edata(edata_id)
+            obs_cols_before = list(edata_before.obs.columns)
+            var_cols_before = list(edata_before.var.columns)
+            uns_keys_before = set(edata_before.uns.keys())
+            shape_before = edata_before.shape
+            layers_before = set(edata_before.layers.keys())
+
+            # 1. run_get calls
+            await client.call_tool("run_get", {"function": "obs_df", "edata_id": edata_id, "params": {"keys": ["age"]}})
+            await client.call_tool(
+                "run_get",
+                {"function": "var_df", "edata_id": edata_id, "params": {"keys": list(edata_before.var_names[:2])}},
+            )
+
+            # 2. get_edata_snapshot call
+            await client.call_tool("get_edata_snapshot", {"edata_id": edata_id})
+
+            # 3. run_plot call
+            await client.call_tool("run_plot", {"function": "missing_values_matrix", "edata_id": edata_id})
+
+            # Verify in-memory edata is completely unchanged
+            edata_after = load_edata(edata_id)
+            assert edata_after is edata_before  # same cached instance
+            assert list(edata_after.obs.columns) == obs_cols_before
+            assert list(edata_after.var.columns) == var_cols_before
+            assert set(edata_after.uns.keys()) == uns_keys_before
+            assert edata_after.shape == shape_before
+            assert set(edata_after.layers.keys()) == layers_before
+
+    _run(_test())

--- a/tests/mcp/test_cache_and_security.py
+++ b/tests/mcp/test_cache_and_security.py
@@ -1,0 +1,139 @@
+"""Tests for LRU cache, read-only guarantees, filesystem confinement, and TTL purge (T1, T4, T14, T15)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import stat
+import tempfile
+from typing import TYPE_CHECKING
+
+import ehrdata.dt as dt
+import pytest
+from fastmcp import Client
+
+from ehrapy.mcp.edata_store import _MEMORY_CACHE, load_edata, persist_edata, save_edata
+from ehrapy.mcp.policy import (
+    PathNotAllowedError,
+    ReadOnlyModeError,
+    check_path_allowed,
+    is_read_only_mode,
+)
+from ehrapy.mcp.registry import MCPRegistry, registry
+from ehrapy.mcp.server import mcp
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_read_only_get_does_not_touch_disk() -> None:
+    """Test that run_get and get_edata_snapshot do not modify dataset mtime on disk (T1)."""
+
+    async def _test():
+        async with Client(mcp) as client:
+            demo_res = await client.call_tool("load_demo_dataset", {"dataset": "mimic_2"})
+            edata_id = demo_res.structured_content["edata_id"]
+
+            file_path = registry.cache_dir() / "edata" / f"{edata_id}.h5ed"
+            assert file_path.exists()
+            mtime_before = file_path.stat().st_mtime_ns
+
+            # Call run_get
+            get_res = await client.call_tool(
+                "run_get", {"function": "obs_df", "edata_id": edata_id, "params": {"keys": ["age"]}}
+            )
+            assert get_res.structured_content["status"] == "ok"
+            mtime_after_get = file_path.stat().st_mtime_ns
+            assert mtime_after_get == mtime_before
+
+            # Call get_edata_snapshot
+            snap_res = await client.call_tool("get_edata_snapshot", {"edata_id": edata_id})
+            assert snap_res.structured_content["status"] == "ok"
+            mtime_after_snap = file_path.stat().st_mtime_ns
+            assert mtime_after_snap == mtime_before
+
+    _run(_test())
+
+
+def test_lru_cache_hit_and_eviction() -> None:
+    """Test that LRU cache keeps entries in memory and evicts oldest upon exceeding capacity (T4)."""
+    _MEMORY_CACHE.clear()
+    assert len(_MEMORY_CACHE) == 0
+
+    # Load demo dataset
+    edata1 = dt.mimic_2()
+    rec1 = save_edata(edata1, name="edata1")
+    assert rec1.edata_id in _MEMORY_CACHE
+
+    # Access via load_edata (hit)
+    loaded1 = load_edata(rec1.edata_id)
+    assert loaded1.n_obs == edata1.n_obs
+
+    # Fill cache beyond capacity (capacity = 3)
+    edata2 = dt.mimic_2()
+    save_edata(edata2, name="edata2")
+    edata3 = dt.mimic_2()
+    save_edata(edata3, name="edata3")
+    edata4 = dt.mimic_2()
+    save_edata(edata4, name="edata4")
+
+    # Ensure cache length <= 3
+    assert len(_MEMORY_CACHE) <= 3
+    # rec1 should have been evicted from in-memory cache, but remains on disk
+    assert rec1.edata_id not in _MEMORY_CACHE
+    # Can still reload from disk
+    reloaded1 = load_edata(rec1.edata_id)
+    assert reloaded1.n_obs == edata1.n_obs
+    assert rec1.edata_id in _MEMORY_CACHE
+
+
+def test_filesystem_confinement(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that allowed roots restricts path access (T14)."""
+    allowed_dir = tmp_path / "allowed"
+    allowed_dir.mkdir()
+    forbidden_dir = tmp_path / "forbidden"
+    forbidden_dir.mkdir()
+
+    monkeypatch.setenv("EHRAPY_MCP_ALLOWED_ROOTS", str(allowed_dir))
+
+    # Path inside allowed dir
+    valid_file = allowed_dir / "data.csv"
+    valid_file.write_text("a,b\n1,2\n")
+    checked = check_path_allowed(valid_file, for_write=False)
+    assert checked.resolve() == valid_file.resolve()
+
+    # Path outside allowed dir
+    invalid_file = forbidden_dir / "secret.csv"
+    invalid_file.write_text("a,b\n1,2\n")
+    with pytest.raises(PathNotAllowedError):
+        check_path_allowed(invalid_file, for_write=False)
+
+
+def test_read_only_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that EHRAPY_MCP_READ_ONLY disables write operations (T14)."""
+    monkeypatch.setenv("EHRAPY_MCP_READ_ONLY", "1")
+    assert is_read_only_mode() is True
+
+    target = tmp_path / "out.csv"
+    with pytest.raises(ReadOnlyModeError):
+        check_path_allowed(target, for_write=True)
+
+
+def test_cache_directory_permissions_and_purge(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test cache 0o700 permissions and TTL purge (T15)."""
+    custom_cache = tmp_path / "mcp_cache"
+    monkeypatch.setenv("EHRAPY_MCP_CACHE_DIR", str(custom_cache))
+
+    reg = MCPRegistry()
+    cache_path = reg.cache_dir()
+    assert cache_path.exists()
+    mode = stat.S_IMODE(cache_path.stat().st_mode)
+    assert mode & 0o700 == 0o700
+
+    # Test purge runs without errors
+    purged = reg.purge(older_than_days=7)
+    assert isinstance(purged, int)

--- a/tests/mcp/test_mcp.py
+++ b/tests/mcp/test_mcp.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastmcp import Client
+from fastmcp.client.transports import StdioTransport
+
+from ehrapy.mcp.server import mcp
+from ehrapy.mcp.tools import ALL_TOOLS_LIST
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_registered_tools_count_and_unique_names() -> None:
+    assert len(ALL_TOOLS_LIST) == 14
+    names = [fn.__name__ for fn in ALL_TOOLS_LIST]
+    assert len(names) == len(set(names))
+
+
+def test_get_workflow_guide() -> None:
+    async def _test():
+        async with Client(mcp) as client:
+            res = await client.call_tool("get_workflow_guide", {})
+            assert res.structured_content["status"] == "ok"
+            assert "run_preprocessing" in res.content[0].text
+
+    _run(_test())
+
+
+def test_get_runtime_context() -> None:
+    async def _test():
+        async with Client(mcp) as client:
+            res = await client.call_tool("get_runtime_context", {})
+            assert res.structured_content["status"] == "ok"
+            assert "ehrapy_version" in res.structured_content
+            assert "cache_dir" in res.structured_content
+
+    _run(_test())
+
+
+def test_list_and_help() -> None:
+    async def _test():
+        async with Client(mcp) as client:
+            res = await client.call_tool("list_ehrapy_functions", {"namespace": "preprocessing"})
+            assert res.structured_content["status"] == "ok"
+            assert res.structured_content["count"] >= 30
+
+            help_res = await client.call_tool("get_function_help", {"namespace": "get", "function": "obs_df"})
+            assert help_res.structured_content["status"] == "ok"
+            assert help_res.structured_content["function"] == "obs_df"
+
+    _run(_test())
+
+
+def test_unknown_function_returns_error_envelope() -> None:
+    async def _test():
+        async with Client(mcp) as client:
+            res = await client.call_tool("run_preprocessing", {"function": "not_a_real_function"})
+            assert res.structured_content["status"] == "error"
+            assert res.structured_content["error_code"] == "UNKNOWN_FUNCTION"
+
+    _run(_test())
+
+
+def test_ingest_and_snapshot(tmp_path: Path) -> None:
+    path = tmp_path / "patients.csv"
+    path.write_text("patient_id,age,sex\np1,45,F\np2,62,M\n", encoding="utf-8")
+
+    async def _test():
+        async with Client(mcp) as client:
+            ingest_res = await client.call_tool("ingest_dataset", {"file_path": str(path), "index_col": "patient_id"})
+            assert ingest_res.structured_content["status"] == "ok"
+            edata_id = ingest_res.structured_content["edata_id"]
+
+            snap_res = await client.call_tool("get_edata_snapshot", {"edata_id": edata_id})
+            assert snap_res.structured_content["status"] == "ok"
+            assert snap_res.structured_content["n_obs"] == 2
+            assert snap_res.structured_content["n_vars"] == 2
+
+    _run(_test())
+
+
+def test_demo_preprocessing_and_get() -> None:
+    async def _test():
+        async with Client(mcp) as client:
+            demo_res = await client.call_tool("load_demo_dataset", {"dataset": "mimic_2"})
+            assert demo_res.structured_content["status"] == "ok"
+            edata_id = demo_res.structured_content["edata_id"]
+
+            qc_res = await client.call_tool(
+                "run_preprocessing",
+                {"function": "qc_metrics", "edata_id": edata_id, "params": {"qc_vars": []}},
+            )
+            assert qc_res.structured_content["status"] == "ok"
+
+            get_res = await client.call_tool(
+                "run_get",
+                {"function": "obs_df", "edata_id": edata_id, "params": {"keys": ["age"]}},
+            )
+            assert get_res.structured_content["status"] == "ok"
+            assert get_res.structured_content["edata_id"] == edata_id
+
+    _run(_test())
+
+
+def test_stdio_end_to_end(tmp_path: Path) -> None:
+    csv_path = tmp_path / "patients.csv"
+    csv_path.write_text("patient_id,age,sex\np1,45,F\np2,62,M\n", encoding="utf-8")
+    cache_dir = tmp_path / "mcp-cache"
+    env = {**os.environ, "EHRAPY_MCP_CACHE_DIR": str(cache_dir)}
+    transport = StdioTransport(
+        command=sys.executable,
+        args=["-m", "ehrapy.mcp.server"],
+        env=env,
+        cwd=str(Path(__file__).parents[2]),
+        keep_alive=False,
+    )
+
+    async def _test():
+        async with Client(transport) as client:
+            tools = await client.list_tools()
+            assert {tool.name for tool in tools} >= {"load_demo_dataset", "ingest_dataset", "get_edata_snapshot"}
+
+            guide = await client.call_tool("get_workflow_guide", {})
+            assert guide.structured_content["status"] == "ok"
+
+            demo = await client.call_tool("load_demo_dataset", {"dataset": "mimic_2"})
+            assert demo.structured_content["status"] == "ok"
+            demo_id = demo.structured_content["edata_id"]
+
+            qc = await client.call_tool(
+                "run_preprocessing",
+                {"function": "qc_metrics", "edata_id": demo_id, "params": {"qc_vars": []}},
+            )
+            assert qc.structured_content["status"] == "ok"
+
+            ingested = await client.call_tool(
+                "ingest_dataset",
+                {"file_path": str(csv_path), "index_col": "patient_id"},
+            )
+            assert ingested.structured_content["status"] == "ok"
+            ingested_id = ingested.structured_content["edata_id"]
+
+            snapshot = await client.call_tool("get_edata_snapshot", {"edata_id": ingested_id})
+            assert snapshot.structured_content["status"] == "ok"
+            assert snapshot.structured_content["n_obs"] == 2
+            assert snapshot.structured_content["n_vars"] == 2
+
+    _run(_test())

--- a/tests/mcp/test_merge_ports.py
+++ b/tests/mcp/test_merge_ports.py
@@ -1,0 +1,265 @@
+"""Regression tests for fixes ported from origin/feat/add-mcp-tooling and found by dogfooding.
+
+Each test here corresponds to a defect that was live at merge time. The mapping back to
+origin's issue numbers is in the merge commit message (`git log --grep='port origin fixes'`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import re
+
+import pytest
+from fastmcp import Client
+
+from ehrapy.mcp.catalog import get_callable
+from ehrapy.mcp.errors import classify_exception_error
+from ehrapy.mcp.server import mcp
+from ehrapy.mcp.session import get_session, reset_sessions
+from ehrapy.mcp.steering import _WORKFLOW_GRAPH
+
+_TOOL_TO_NAMESPACE = {
+    "run_preprocessing": "preprocessing",
+    "run_analysis": "analysis",
+    "run_get": "get",
+    "run_plot": "plot",
+    "run_io": "io",
+}
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _steering_suggestions():
+    for key, suggestions in _WORKFLOW_GRAPH.items():
+        for call, _reason in suggestions:
+            match = re.match(r"(\w+)\((.*)\)$", call, re.S)
+            if not match or match.group(1) not in _TOOL_TO_NAMESPACE:
+                continue
+            fn_match = re.search(r"function='([^']+)'", match.group(2))
+            if not fn_match:
+                continue
+            yield key, call, _TOOL_TO_NAMESPACE[match.group(1)], fn_match.group(1), match.group(2)
+
+
+def test_every_steering_target_resolves() -> None:
+    """Every function the steering graph suggests must exist in the catalog."""
+    for _key, _call, namespace, function, _inner in _steering_suggestions():
+        get_callable(namespace, function)  # raises KeyError if the suggestion is stale
+
+
+def test_steering_suggestions_name_their_required_params() -> None:
+    """A suggested call must mention every required parameter of its target.
+
+    Dogfooding found `encode`, `cox_ph`, and `covariate_balance` advertised without the
+    arguments they require, so an agent following the steering hit an immediate error.
+    """
+    offenders = []
+    for key, call, namespace, function, inner in _steering_suggestions():
+        signature = inspect.signature(get_callable(namespace, function))
+        required = [
+            p.name
+            for p in signature.parameters.values()
+            if p.default is inspect.Parameter.empty and p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
+        ][1:]  # skip the edata/adata parameter, which dispatch binds
+        missing = [r for r in required if r not in inner]
+        if missing:
+            offenders.append((key, call, missing))
+    assert not offenders, f"steering suggestions missing required params: {offenders}"
+
+
+def test_sessions_are_isolated_per_client() -> None:
+    """Two clients must not share an active edata_id (found by dogfooding)."""
+    reset_sessions()
+    a = get_session(type("Ctx", (), {"client_id": "client-a"})())
+    b = get_session(type("Ctx", (), {"client_id": "client-b"})())
+    a.set_latest_edata_id("handle-a")
+    assert b.get_latest_edata_id() is None
+    assert a.get_latest_edata_id() == "handle-a"
+
+
+def test_session_key_survives_context_without_request() -> None:
+    """Probing a Context outside a request must not raise (origin #10)."""
+
+    class _Hostile:
+        @property
+        def client_id(self):
+            raise RuntimeError("outside request context")
+
+        @property
+        def session_id(self):
+            raise RuntimeError("outside request context")
+
+        @property
+        def request_id(self):
+            raise RuntimeError("outside request context")
+
+    assert get_session(_Hostile()) is not None
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        (TypeError("bad"), "INVALID_INPUT"),
+        (ValueError("bad"), "INVALID_VALUE"),
+        (FileNotFoundError("bad"), "FILE_NOT_FOUND"),
+        (ImportError("bad"), "DEPENDENCY_MISSING"),
+        (RuntimeError("bad"), "EXECUTION_ERROR"),
+    ],
+)
+def test_exceptions_map_to_specific_error_codes(exc: Exception, expected: str) -> None:
+    """Every failure carries a specific error_code and an agent_action (origin #6)."""
+    result = classify_exception_error("run_plot", exc, namespace="plot", function="umap")
+    assert result.structured_content["error_code"] == expected
+    assert result.structured_content["agent_action"]
+
+
+def test_kaplan_meier_plot_binds_the_fitted_model() -> None:
+    """run_plot('kaplan_meier') must bind the fitter from run_analysis, not the EHRData (origin #5)."""
+
+    async def _test():
+        async with Client(mcp) as client:
+            await client.call_tool("load_demo_dataset", {"dataset": "mimic_2"})
+            fit = await client.call_tool(
+                "run_analysis",
+                {
+                    "function": "kaplan_meier",
+                    "params": {"duration_col": "mort_day_censored", "event_col": "censor_flg"},
+                },
+            )
+            assert fit.structured_content["status"] == "ok"
+            plot = await client.call_tool("run_plot", {"function": "kaplan_meier"})
+            assert plot.structured_content["status"] == "ok", plot.structured_content
+            assert any(type(c).__name__ == "ImageContent" for c in plot.content)
+
+    _run(_test())
+
+
+def test_plot_without_a_fitted_model_explains_what_to_run() -> None:
+    """The unfitted case must steer the agent, not surface an AttributeError."""
+
+    async def _test():
+        async with Client(mcp) as client:
+            await client.call_tool("load_demo_dataset", {"dataset": "mimic_2"})
+            res = await client.call_tool("run_plot", {"function": "love_plot"})
+            struct = res.structured_content
+            assert struct["status"] == "error"
+            assert "covariate_balance" in struct["reason"]
+
+    _run(_test())
+
+
+def test_structured_content_is_always_json_serializable() -> None:
+    """Analysis results carrying ndarrays must not break the MCP boundary.
+
+    ep.tl.iptw returns a CausalEstimate whose nested params hold ndarrays; before the
+    sanitizer these reached structured_content and aborted the whole call.
+    """
+
+    async def _test():
+        async with Client(mcp) as client:
+            await client.call_tool("load_demo_dataset", {"dataset": "mimic_2"})
+            await client.call_tool("run_preprocessing", {"function": "encode", "params": {"autodetect": True}})
+            res = await client.call_tool(
+                "run_analysis",
+                {
+                    "function": "iptw",
+                    "params": {
+                        "treatment": "aline_flg",
+                        "outcome": "hosp_exp_flg",
+                        "covariates": ["age", "gender_num"],
+                    },
+                },
+            )
+            assert res.structured_content["status"] == "ok", res.structured_content
+            json.dumps(res.structured_content)
+
+    _run(_test())
+
+
+def test_fitter_cache_invalidates_when_the_dataset_changes() -> None:
+    """A plot must not bind a model fitted against a since-transformed cohort.
+
+    The fitter is stamped with the handle's cache mtime; a later write-through to the
+    same edata_id must make it stale rather than silently rendering a survival curve
+    for data that no longer exists.
+    """
+
+    async def _test():
+        async with Client(mcp) as client:
+            await client.call_tool("load_demo_dataset", {"dataset": "mimic_2"})
+            await client.call_tool(
+                "run_analysis",
+                {
+                    "function": "kaplan_meier",
+                    "params": {"duration_col": "mort_day_censored", "event_col": "censor_flg"},
+                },
+            )
+            # Fitter is fresh: the plot renders.
+            assert (await client.call_tool("run_plot", {"function": "kaplan_meier"})).structured_content[
+                "status"
+            ] == "ok"
+
+            # Transform the same handle, invalidating the fitter.
+            await client.call_tool("run_preprocessing", {"function": "encode", "params": {"autodetect": True}})
+            res = await client.call_tool("run_plot", {"function": "kaplan_meier"})
+            struct = res.structured_content
+            assert struct["status"] == "error", struct
+            assert "kaplan_meier" in struct["reason"]
+
+    _run(_test())
+
+
+def test_propensity_overlap_binds_its_fitted_result() -> None:
+    """run_plot('propensity_overlap') binds the positivity_check result (origin #5)."""
+
+    async def _test():
+        async with Client(mcp) as client:
+            await client.call_tool("load_demo_dataset", {"dataset": "mimic_2"})
+            await client.call_tool("run_preprocessing", {"function": "encode", "params": {"autodetect": True}})
+            fit = await client.call_tool(
+                "run_analysis",
+                {
+                    "function": "positivity_check",
+                    "params": {"treatment": "aline_flg", "covariates": ["age", "gender_num"]},
+                },
+            )
+            assert fit.structured_content["status"] == "ok", fit.structured_content
+            plot = await client.call_tool("run_plot", {"function": "propensity_overlap"})
+            assert plot.structured_content["status"] == "ok", plot.structured_content
+            assert any(type(c).__name__ == "ImageContent" for c in plot.content)
+
+    _run(_test())
+
+
+def test_unrenderable_figure_reports_instead_of_claiming_success() -> None:
+    """A figure no backend can export must error with a reason, not report a bare ok.
+
+    ep.pl.love_plot builds a holoviews Overlay that the matplotlib backend cannot render
+    (categorical axis) and that bokeh can only export with selenium installed.
+    """
+
+    async def _test():
+        async with Client(mcp) as client:
+            await client.call_tool("load_demo_dataset", {"dataset": "mimic_2"})
+            await client.call_tool("run_preprocessing", {"function": "encode", "params": {"autodetect": True}})
+            await client.call_tool(
+                "run_analysis",
+                {
+                    "function": "covariate_balance",
+                    "params": {"treatment": "aline_flg", "covariates": ["age", "gender_num"]},
+                },
+            )
+            res = await client.call_tool("run_plot", {"function": "love_plot"})
+            struct = res.structured_content
+            if struct["status"] == "ok":
+                # A selenium-equipped environment can render it; then it must be a real image.
+                assert any(type(c).__name__ == "ImageContent" for c in res.content)
+            else:
+                assert "selenium" in struct["reason"] or "backend" in struct["reason"]
+                assert not any(type(c).__name__ == "ImageContent" for c in res.content)
+
+    _run(_test())

--- a/tests/mcp/test_provenance_and_steering.py
+++ b/tests/mcp/test_provenance_and_steering.py
@@ -1,0 +1,136 @@
+"""Tests for unknown argument middleware, steering suggestions, prompts, and provenance (T5, T17, T18, T19)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from fastmcp import Client
+
+from ehrapy.mcp.edata_store import load_edata
+from ehrapy.mcp.server import mcp
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_argument_validation_middleware_rejects_unknown_args() -> None:
+    """A tool without a `params` dict rejects unknown arguments loudly (T5, origin #3)."""
+
+    async def _test():
+        async with Client(mcp) as client:
+            res = await client.call_tool(
+                "get_edata_snapshot",
+                {"unknown_bogus_arg": 123},
+            )
+            assert res.structured_content["status"] == "error"
+            assert res.structured_content["error_code"] == "UNKNOWN_ARGUMENT"
+            assert "unknown_bogus_arg" in res.structured_content["details"]["unknown_arguments"]
+
+    _run(_test())
+
+
+def test_argument_validation_middleware_folds_kwargs_into_params() -> None:
+    """A tool with a `params` dict folds stray top-level kwargs into it (origin #3)."""
+
+    async def _test():
+        async with Client(mcp) as client:
+            await client.call_tool("load_demo_dataset", {"dataset": "mimic_2"})
+            res = await client.call_tool(
+                "run_get",
+                {"function": "obs_df", "keys": ["age"]},
+            )
+            struct = res.structured_content
+            assert struct["status"] == "ok", struct
+            assert struct["folded_arguments"] == ["keys"]
+
+    _run(_test())
+
+
+def test_explicit_params_win_over_folded_kwarg() -> None:
+    """An explicit params entry is not clobbered by a folded top-level kwarg of the same name."""
+
+    async def _test():
+        async with Client(mcp) as client:
+            await client.call_tool("load_demo_dataset", {"dataset": "mimic_2"})
+            res = await client.call_tool(
+                "run_get",
+                {"function": "obs_df", "params": {"keys": ["age"]}, "keys": ["bmi"]},
+            )
+            assert res.structured_content["status"] == "ok"
+            # params={'keys': ['age']} wins, so the rendered table is the age column.
+            text = " ".join(getattr(c, "text", "") for c in res.content)
+            assert "age" in text
+
+    _run(_test())
+
+
+def test_argument_validation_middleware_strips_wait_for_previous() -> None:
+    """Test that middleware strips wait_for_previous without failing (T5)."""
+
+    async def _test():
+        async with Client(mcp) as client:
+            res = await client.call_tool(
+                "get_runtime_context",
+                {"wait_for_previous": True},
+            )
+            assert res.structured_content["status"] == "ok"
+
+    _run(_test())
+
+
+def test_steering_suggested_next() -> None:
+    """Test that steering suggestions are included in structured_content and content (T17)."""
+
+    async def _test():
+        async with Client(mcp) as client:
+            demo_res = await client.call_tool("load_demo_dataset", {"dataset": "mimic_2"})
+            assert "suggested_next" in demo_res.structured_content
+            suggestions = demo_res.structured_content["suggested_next"]
+            assert any("qc_metrics" in s for s in suggestions)
+            assert "Suggested next:" in demo_res.content[0].text
+
+    _run(_test())
+
+
+def test_mcp_prompts() -> None:
+    """Test that MCP prompts are registered and return instructions (T18)."""
+
+    async def _test():
+        async with Client(mcp) as client:
+            prompts = await client.list_prompts()
+            prompt_names = [p.name for p in prompts]
+            assert "ehrapy-explore" in prompt_names
+            assert "ehrapy-clustering" in prompt_names
+            assert "ehrapy-survival" in prompt_names
+
+            res = await client.get_prompt("ehrapy-survival", {"dataset": "mimic_2"})
+            assert "kaplan_meier" in res.messages[0].content.text
+
+    _run(_test())
+
+
+def test_provenance_op_log() -> None:
+    """Test that mutating operations append to edata.uns['ehrapy_mcp_ops'] (T19)."""
+
+    async def _test():
+        async with Client(mcp) as client:
+            demo_res = await client.call_tool("load_demo_dataset", {"dataset": "mimic_2"})
+            edata_id = demo_res.structured_content["edata_id"]
+
+            await client.call_tool(
+                "run_preprocessing",
+                {"function": "qc_metrics", "edata_id": edata_id, "params": {"qc_vars": []}},
+            )
+
+            # Load dataset from store
+            edata = load_edata(edata_id)
+            assert "ehrapy_mcp_ops" in edata.uns
+            ops = [json.loads(op) if isinstance(op, str) else op for op in edata.uns["ehrapy_mcp_ops"]]
+            assert len(ops) >= 1
+            last_op = ops[-1]
+            assert last_op["namespace"] == "preprocessing"
+            assert last_op["function"] == "qc_metrics"
+
+    _run(_test())

--- a/tests/mcp/test_regression_report.py
+++ b/tests/mcp/test_regression_report.py
@@ -1,0 +1,37 @@
+"""Test the exact regression sequence from testing report."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+from fastmcp import Client
+
+from ehrapy.mcp.server import mcp
+
+
+def test_regression_sequence() -> None:
+    async def _test():
+        async with Client(mcp) as client:
+            # 1. get_runtime_context returns quickly (<2s)
+            t0 = time.time()
+            ctx_res = await client.call_tool("get_runtime_context", {})
+            t_ctx = time.time() - t0
+            assert ctx_res.structured_content["status"] == "ok"
+            assert t_ctx < 2.0, f"get_runtime_context took too long: {t_ctx}s"
+
+            # 2. load_demo_dataset succeeds and returns valid handle
+            demo_res = await client.call_tool("load_demo_dataset", {"dataset": "mimic_2"})
+            assert demo_res.structured_content["status"] == "ok"
+            edata_id = demo_res.structured_content["edata_id"]
+            assert edata_id is not None
+
+            # 3. list_ehrapy_functions returns in <2s
+            t0 = time.time()
+            list_res = await client.call_tool("list_ehrapy_functions", {"namespace": "preprocessing"})
+            t_list = time.time() - t0
+            assert list_res.structured_content["status"] == "ok"
+            assert list_res.structured_content["count"] >= 30
+            assert t_list < 2.0, f"list_ehrapy_functions took too long: {t_list}s"
+
+    asyncio.run(_test())

--- a/tests/mcp/test_schema_floor.py
+++ b/tests/mcp/test_schema_floor.py
@@ -1,0 +1,60 @@
+"""Schema portability floor tests (T13).
+
+Ensures all tool inputSchemas comply with strict LLM client schema requirements (no $ref, valid primitive types).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from fastmcp import Client
+
+from ehrapy.mcp.server import mcp
+
+_ALLOWED_TYPES = {"string", "number", "integer", "boolean", "object", "array", "null"}
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _validate_schema_node(node: Any, path: str = "") -> None:
+    if not isinstance(node, dict):
+        return
+
+    # No $ref or definitions
+    assert "$ref" not in node, f"$ref found at {path}"
+    assert "definitions" not in node, f"definitions found at {path}"
+    assert "$defs" not in node, f"$defs found at {path}"
+
+    if "type" in node:
+        t = node["type"]
+        if isinstance(t, str):
+            assert t in _ALLOWED_TYPES, f"Invalid type '{t}' at {path}"
+        elif isinstance(t, list):
+            for sub_t in t:
+                assert sub_t in _ALLOWED_TYPES, f"Invalid type '{sub_t}' in type union at {path}"
+
+    if "properties" in node and isinstance(node["properties"], dict):
+        for prop_name, prop_val in node["properties"].items():
+            _validate_schema_node(prop_val, f"{path}.properties.{prop_name}")
+
+    if "items" in node:
+        _validate_schema_node(node["items"], f"{path}.items")
+
+
+def test_tool_schemas_compliance() -> None:
+    """Validate that every tool's inputSchema satisfies the Gemini-safe floor."""
+
+    async def _test():
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+            assert len(tools) == 14
+            for t in tools:
+                schema = t.inputSchema
+                assert isinstance(schema, dict), f"Tool {t.name} inputSchema is not a dict"
+                assert schema.get("type") == "object", f"Tool {t.name} schema root type is not 'object'"
+                _validate_schema_node(schema, path=t.name)
+
+    _run(_test())

--- a/tests/mcp/test_serialization.py
+++ b/tests/mcp/test_serialization.py
@@ -1,0 +1,79 @@
+"""Tests for 3-tier serialization, column profile ranking, and payload guards (T2, T6, T10)."""
+
+import ehrdata.dt as dt
+import numpy as np
+import pandas as pd
+import pytest
+
+from ehrapy.mcp.serialization import (
+    _rank_columns,
+    _sample_rows,
+    serialize_result,
+)
+
+
+def test_tier1_pass_through_small_dataframe() -> None:
+    df = pd.DataFrame({"patient_id": ["p1", "p2", "p3"], "age": [25, 40, 65], "outcome": [0, 1, 0]})
+    meta, md = serialize_result(df)
+    assert meta["tier"] == 1
+    assert "| patient_id | age | outcome |" in md
+    assert "| p1 | 25 | 0 |" in md
+
+
+def test_tier2_column_profile_large_dataframe() -> None:
+    # 500 rows, 15 columns
+    rng = np.random.default_rng(42)
+    data = {f"feat_{i}": rng.standard_normal(500) for i in range(15)}
+    df = pd.DataFrame(data)
+    meta, md = serialize_result(df)
+    assert meta["tier"] == 2
+    assert meta["type"] == "dataframe_profile"
+    assert "| column | dtype | non-null % | unique | summary |" in md
+
+
+def test_tier2_column_ranking_weights() -> None:
+    rng = np.random.default_rng(42)
+    df = pd.DataFrame(
+        {
+            "all_same": [1.0] * 100,
+            "high_missing": [np.nan] * 50 + [1.0] * 50,
+            "target_col": rng.standard_normal(100),
+        }
+    )
+    relevant = {"target_col"}
+    ranked = _rank_columns(df, relevant)
+    ranked_cols = [col for col, _ in ranked]
+    # target_col (relevance weight 2.0) should rank highest
+    assert ranked_cols[0] == "target_col"
+
+
+def test_tier3_sample_rows_detailed_format() -> None:
+    df = pd.DataFrame({"patient_id": [f"p{i}" for i in range(100)], "value": range(100)})
+    meta, md = serialize_result(df, response_format="detailed")
+    assert meta["tier"] == 3
+    assert "| sample | patient_id | value |" in md
+    assert "head" in md
+    assert "tail" in md
+
+
+def test_empty_dataframe_guard() -> None:
+    edata = dt.mimic_2()
+    empty_df = pd.DataFrame()
+    meta, md = serialize_result(empty_df, function="obs_df", edata=edata)
+    assert meta["status"] == "ok_empty"
+    assert "Specify columns using `params={'keys': [...]}`" in meta["agent_action"]
+
+
+def test_whole_table_to_pandas_guard() -> None:
+    df = pd.DataFrame({"a": range(10), "b": range(10)})
+    meta, md = serialize_result(df, function="to_pandas")
+    assert meta["tier"] == 2
+    assert "Full table not returned — use `export_edata`" in md
+
+
+def test_hard_payload_cap_truncation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EHRAPY_MCP_MAX_RESULT_CHARS", "1000")
+    large_df = pd.DataFrame({f"col_{i}": [f"val_{j}_{i}" for j in range(100)] for i in range(30)})
+    meta, md = serialize_result(large_df)
+    assert len(md) <= 1200
+    assert "Output truncated" in md

--- a/tests/mcp/test_serialization.py
+++ b/tests/mcp/test_serialization.py
@@ -56,6 +56,22 @@ def test_tier3_sample_rows_detailed_format() -> None:
     assert "tail" in md
 
 
+def test_sample_rows_duplicate_indices() -> None:
+    """Ensure _sample_rows handles non-unique index labels positionally without corruption (issue #16)."""
+    # 100 rows with all index labels set to 0 and a categorical stratification column
+    df = pd.DataFrame(
+        {"feat": range(100), "category": ["A", "B"] * 50},
+        index=[0] * 100,
+    )
+    sampled = _sample_rows(df, {"category"}, row_budget=20)
+    assert len(sampled) == 20
+    assert list(sampled.columns) == ["sample", "feat", "category"]
+    assert list(sampled["sample"].iloc[:5]) == ["head"] * 5
+    assert list(sampled["sample"].iloc[-5:]) == ["tail"] * 5
+    assert list(sampled["sample"].iloc[5:15]) == ["sample"] * 10
+    assert not sampled.isna().any().any()
+
+
 def test_empty_dataframe_guard() -> None:
     edata = dt.mimic_2()
     empty_df = pd.DataFrame()

--- a/tests/mcp/test_server_robustness.py
+++ b/tests/mcp/test_server_robustness.py
@@ -1,0 +1,103 @@
+"""Tests for MCP server robustness, timeouts, demo dataset writable fallbacks, and sandbox error UX."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path  # noqa: TC003
+from unittest.mock import patch
+
+import pytest  # noqa: TC002
+from fastmcp import Client
+
+import ehrapy as ep
+from ehrapy.mcp.dispatch import get_tool_timeout
+from ehrapy.mcp.registry import MCPRegistry
+from ehrapy.mcp.server import mcp
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_runtime_context_surfaces_demo_dir_and_writability() -> None:
+    """Test that get_runtime_context reports demo_data_dir and cache_writable (Issue 1)."""
+
+    async def _test():
+        async with Client(mcp) as client:
+            ctx_res = await client.call_tool("get_runtime_context", {})
+            assert ctx_res.structured_content["status"] == "ok"
+            assert "demo_data_dir" in ctx_res.structured_content
+            assert ctx_res.structured_content["cache_writable"] is True
+            assert "Cache-Bridge Ingestion" in ctx_res.content[0].text
+
+    _run(_test())
+
+
+def test_demo_dataset_loads_into_writable_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that load_demo_dataset downloads into configured/writable cache dir (Issue 1)."""
+    custom_demo = tmp_path / "demo_cache"
+    monkeypatch.setenv("EHRAPY_MCP_DEMO_DATA_DIR", str(custom_demo))
+
+    reg = MCPRegistry()
+    assert reg.demo_data_dir() == custom_demo
+
+    async def _test():
+        async with Client(mcp) as client:
+            demo_res = await client.call_tool("load_demo_dataset", {"dataset": "mimic_2"})
+            assert demo_res.structured_content["status"] == "ok"
+            assert demo_res.structured_content["edata_id"] is not None
+
+    _run(_test())
+
+
+def test_tool_timeout_handling(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that slow tool operations fail fast with structured TIMEOUT error (Issue 2)."""
+    monkeypatch.setenv("EHRAPY_MCP_TIMEOUT_SECONDS", "0.3")
+    assert get_tool_timeout() == 0.3
+
+    def _mock_slow_qc(*args, **kwargs):
+        time.sleep(1.0)
+
+    with patch.object(ep.preprocessing, "qc_metrics", side_effect=_mock_slow_qc):
+
+        async def _test():
+            async with Client(mcp) as client:
+                demo_res = await client.call_tool("load_demo_dataset", {"dataset": "mimic_2"})
+                edata_id = demo_res.structured_content["edata_id"]
+
+                qc_res = await client.call_tool(
+                    "run_preprocessing",
+                    {"function": "qc_metrics", "edata_id": edata_id, "params": {"qc_vars": []}},
+                )
+                assert qc_res.structured_content["status"] == "error"
+                assert qc_res.structured_content["error_code"] == "TIMEOUT"
+                assert "timed out after 0.3s" in qc_res.structured_content["reason"]
+
+        _run(_test())
+
+
+def test_sandbox_path_detection_and_cache_bridge_guidance() -> None:
+    """Test that sandboxed client paths return HOST_PATH_NOT_VISIBLE with Cache-Bridge guidance (Issue 3)."""
+
+    async def _test():
+        async with Client(mcp) as client:
+            # 1. Test sandbox prefix (/home/claude)
+            res1 = await client.call_tool("ingest_dataset", {"file_path": "/home/claude/cohort.csv"})
+            assert res1.structured_content["status"] == "error"
+            assert res1.structured_content["error_code"] == "HOST_PATH_NOT_VISIBLE"
+            assert "cache_dir" in res1.structured_content["agent_action"]
+            assert res1.structured_content["details"]["path_context"]["looks_like_sandbox_path"] is True
+
+            # 2. Test sandbox prefix (/workspace/data.csv)
+            res2 = await client.call_tool("ingest_dataset", {"file_path": "/workspace/data.csv"})
+            assert res2.structured_content["status"] == "error"
+            assert res2.structured_content["error_code"] == "HOST_PATH_NOT_VISIBLE"
+
+            # 3. Test non-sandbox missing file
+            res3 = await client.call_tool("ingest_dataset", {"file_path": "/var/data/missing_file_xyz.csv"})
+            assert res3.structured_content["status"] == "error"
+            assert res3.structured_content["error_code"] == "FILE_NOT_FOUND"
+            assert "cache_dir" in res3.structured_content["agent_action"]
+
+    _run(_test())


### PR DESCRIPTION
## Summary
Addresses issues identified during testing:

- **Issue 1 (P0): Writable demo data directory:** Ensured demo datasets download into a verified writable cache directory (probing `EHRAPY_MCP_DEMO_DATA_DIR`, `cache_dir / 'demo_data'`, and `/tmp` fallback) rather than failing on read-only CWD. Removed exclusive file locking on read-only dataset queries.
- **Issue 2 (P0): Core tools hang indefinitely:** Offloaded synchronous CPU/disk/network execution from the asyncio event loop into worker threads (`asyncio.to_thread`) and enforced server-side timeouts (`EHRAPY_MCP_TIMEOUT_SECONDS`, default 120s) returning structured `TIMEOUT` errors.
- **Issue 3 (P1): Sandboxed data ingestion & Cache-Bridge UX:** Expanded sandbox path classification to return `HOST_PATH_NOT_VISIBLE` with actionable Cache-Bridge instructions, surfaced `demo_data_dir` and `cache_writable` in `get_runtime_context`, and documented the Cache-Bridge pattern across tool docstrings and prompts.

## Testing
- Added regression test suite in `tests/mcp/test_server_robustness.py` and `tests/mcp/test_regression_report.py`.
- All 55 MCP tests passing.