### PR TITLE
fix(qc): centre Little's covariance on pairwise means

### DIFF
--- a/ehrapy/preprocessing/_quality_control.py
+++ b/ehrapy/preprocessing/_quality_control.py
@@ -706,6 +706,35 @@ def mcar_test(
     raise ValueError(f"Unknown method {method!r}. Choose from 'little' or 'ttest'.")
 
 
+def _pairwise_deletion_cov(X: np.ndarray) -> np.ndarray:
+    """Covariance matrix of `X` by pairwise deletion.
+
+    Each entry is centred on the means of its own variable pair, computed over
+    the rows where both variables are observed. Centring on the global column
+    means instead biases every entry once missingness is high enough that a
+    pair's observed rows differ appreciably from the column's own observed
+    rows. This matches :meth:`pandas.DataFrame.cov`, the reference Little's
+    test is defined against.
+
+    Args:
+        X: 2D array of observations, missing values encoded as NaN.
+
+    Returns:
+        The pairwise-deletion covariance matrix.
+    """
+    valid = ~np.isnan(X)
+    valid_f = valid.astype(np.float64)
+    filled = np.where(valid, np.nan_to_num(X, nan=0.0), 0.0)
+
+    pair_counts = valid_f.T @ valid_f
+    np.fill_diagonal(pair_counts, np.maximum(pair_counts.diagonal(), 1))
+    sum_products = filled.T @ filled
+    # sum_rows[i, j] is the sum of variable i over the rows where i and j are both observed
+    sum_rows = filled.T @ valid_f
+
+    return (sum_products - sum_rows * sum_rows.T / np.maximum(pair_counts, 1.0)) / np.maximum(pair_counts - 1, 1.0)
+
+
 @singledispatch
 def _little_mcar_test(X) -> float:
     _raise_array_type_not_implemented(_little_mcar_test, type(X))
@@ -726,11 +755,7 @@ def _(X: np.ndarray) -> float:
 
     mu = np.nanmean(X, axis=0)
 
-    centered = X - mu
-    valid = ~mask
-    denom = valid.astype(np.float64).T @ valid.astype(np.float64)
-    np.fill_diagonal(denom, np.maximum(denom.diagonal(), 1))
-    cov_global = np.where(valid, centered, 0.0).T @ np.where(valid, centered, 0.0) / (denom - 1)
+    cov_global = _pairwise_deletion_cov(X)
     np.fill_diagonal(cov_global, np.maximum(cov_global.diagonal(), 1e-12))
 
     patterns, inverse, counts = np.unique(mask, axis=0, return_inverse=True, return_counts=True)

--- a/tests/preprocessing/test_quality_control.py
+++ b/tests/preprocessing/test_quality_control.py
@@ -10,7 +10,12 @@ from scipy import sparse as sp
 
 import ehrapy as ep
 from ehrapy.preprocessing._encoding import encode
-from ehrapy.preprocessing._quality_control import _compute_obs_metrics, _compute_var_metrics, mcar_test
+from ehrapy.preprocessing._quality_control import (
+    _compute_obs_metrics,
+    _compute_var_metrics,
+    _pairwise_deletion_cov,
+    mcar_test,
+)
 from tests.conftest import ARRAY_TYPES_NONNUMERIC, TEST_DATA_PATH, as_dense_dask_array
 
 _TEST_PATH_ENCODE = f"{TEST_DATA_PATH}/encode"
@@ -476,6 +481,24 @@ def test_qc_lab_measurements_defaults_to_all_vars():
 def test_mcar_test_method_output_types(mar_edata, method, expected_output_type):
     output = mcar_test(mar_edata, method=method)
     assert isinstance(output, expected_output_type)
+
+
+@pytest.mark.parametrize("missing_fraction", [0.0, 0.1, 0.3, 0.5, 0.7])
+def test_pairwise_deletion_cov_matches_pandas(missing_fraction):
+    """The covariance behind Little's test must match pandas' pairwise covariance.
+
+    Regression test for #1110: entries were centred on each column's global mean
+    rather than the mean of the pair's own observed rows, which drifts as
+    missingness rises.
+    """
+    rng = np.random.default_rng(7)
+    X = rng.normal(size=(400, 8))
+    X[rng.random(X.shape) < missing_fraction] = np.nan
+
+    expected = pd.DataFrame(X).cov().to_numpy()
+    finite = np.isfinite(expected)
+
+    np.testing.assert_allclose(_pairwise_deletion_cov(X)[finite], expected[finite], atol=1e-10)
 
 
 def test_mar_data_identification(mar_edata):


### PR DESCRIPTION
Addresses the covariance half of #1110. **It does not close the issue** — see the caveat at the bottom.

`_little_mcar_test` divided pairwise cross-products by pairwise counts but centred every entry on the column's *global* mean. Those disagree once missingness is high enough that a pair's jointly observed rows differ from the column's own observed rows.

Max absolute deviation from `pandas.DataFrame.cov()` (what pyampute uses), 400x8 normal data:

| missing | before | after |
|---|---|---|
| 0% | 1.1e-16 | 2.2e-16 |
| 10% | 3.6e-04 | 2.2e-15 |
| 30% | 2.6e-03 | 1.2e-15 |
| 50% | 8.3e-03 | 1.6e-15 |
| 70% | 3.3e-02 | 1.3e-15 |

Extracted the estimator as `_pairwise_deletion_cov` so it can be tested directly rather than only through a p-value, and added a parametrized test against `pandas.DataFrame.cov()`.

### What this does not fix

`test_mcar_test_little_matches_pyampute_reference` still fails for `mcar_small` and `mcar_medium_high_missing`, essentially unchanged:

| scenario | before | after | reference |
|---|---|---|---|
| `mcar_small` | 0.77074 | 0.77065 | 0.81275 |
| `mcar_medium_high_missing` | 0.19634 | 0.20944 | 0.00105 |

So the covariance was not the dominant source of the divergence. On `mcar_medium_high_missing` (900x50 at 50% missing) the statistic comes out at d²=22765 on df=22585 — at that missingness almost every row is its own missingness pattern, so `df = Σ k_j - p` is dominated by single-row patterns. Two things look worth deciding before that test can pass:

1. **Estimator.** Little's test is defined on the ML (EM) estimates of μ and Σ; this implementation uses available-case `np.nanmean` and a pairwise covariance.
2. **Degrees of freedom.** Whether single-observation patterns should contribute to `df` at all.

Both are calls for a maintainer, so I've kept this PR to the piece that is unambiguously wrong on its own terms. Happy to follow up on either if you have a preference.

No regressions: the failing set in `tests/preprocessing/test_quality_control.py` is identical before and after (the pre-existing dask and 3D-fixture failures in my environment), plus the 5 new passing cases.
